### PR TITLE
add custom plugin usage to DEVELOPER_GUIDE.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,5 +11,6 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Fixed
 
  - Update demo setup to be include ubi and ecommerce data sets and run in OS 3.1 ([#10](https://github.com/opensearch-project/search-relevance/issues/10))
+ - Add a section on custom plugin usage to `DEVELOPER_GUIDE.md`
 
 ### Security


### PR DESCRIPTION
### Description
This PR adds a section to the dev guide explaining how to add custom plugins that I found necessary when testing judgment calculation that depends on UBI which is not available in the version we're developing against.

### Issues Resolved
n/a

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
