### PR TITLE
build search request with normal parsing and wrapper query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,5 +11,6 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Fixed
 
  - Update demo setup to be include ubi and ecommerce data sets and run in OS 3.1 ([#10](https://github.com/opensearch-project/search-relevance/issues/10))
+ - Build search request with normal parsing and wrapper query ([#22](https://github.com/opensearch-project/search-relevance/pull/22))
 
 ### Security

--- a/src/main/java/org/opensearch/searchrelevance/model/builder/SearchRequestBuilder.java
+++ b/src/main/java/org/opensearch/searchrelevance/model/builder/SearchRequestBuilder.java
@@ -9,30 +9,37 @@ package org.opensearch.searchrelevance.model.builder;
 
 import static org.opensearch.searchrelevance.common.PluginConstants.WILDCARD_QUERY_TEXT;
 
-import org.opensearch.action.search.SearchRequest;
-import org.opensearch.index.query.QueryBuilders;
-import org.opensearch.search.builder.SearchSourceBuilder;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.Map;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import org.opensearch.action.search.SearchRequest;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.common.xcontent.json.JsonXContent;
+import org.opensearch.core.xcontent.DeprecationHandler;
+import org.opensearch.core.xcontent.NamedXContentRegistry;
+import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.core.xcontent.XContentParser;
+import org.opensearch.index.query.QueryBuilders;
+import org.opensearch.search.SearchModule;
+import org.opensearch.search.builder.SearchSourceBuilder;
 
 /**
  * Common Search Request Builder for Search Configuration with placeholder with QueryText filled.
  */
 public class SearchRequestBuilder {
 
-    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+    private static final NamedXContentRegistry NAMED_CONTENT_REGISTRY;
 
-    private static final String SEARCH_PIPELINE_FIELD_NAME = "search_pipeline";
-    private static final String QUERY_BODY_FIELD_NAME = "query";
-    private static final String SOURCE_FIELD_NAME = "_source";
-    private static final String EXCLUDE_FIELD_NAME = "exclude";
+    static {
+        SearchModule searchModule = new SearchModule(Settings.EMPTY, Collections.emptyList());
+        NAMED_CONTENT_REGISTRY = new NamedXContentRegistry(searchModule.getNamedXContents());
+    }
 
     /**
      * Builds a search request with the given parameters.
      * @param index - target index to be searched against
-     * @param query - DSL query that includes queryBody and optional searchPipelineBody and excluding fields from source
+     * @param query - DSL query that includes queryBody and optional extra fields, like pipeline, aggregation, exclude ...
      * @param queryText - queryText need to be replaced with placeholder
      * @param searchPipeline - searchPipeline if it is provided
      * @param size - number of returned hits from the search
@@ -40,62 +47,59 @@ public class SearchRequestBuilder {
      */
     public static SearchRequest buildSearchRequest(String index, String query, String queryText, String searchPipeline, int size) {
         SearchRequest searchRequest = new SearchRequest(index);
-        SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder();
 
-        String processedQueryBody = fetchQueryBody(query).replace(WILDCARD_QUERY_TEXT, queryText);
-        searchSourceBuilder.query(QueryBuilders.wrapperQuery(processedQueryBody));
-        searchSourceBuilder.size(size);
-
-        String[] excludedFields = fetchExcludingFields(query);
-        if (excludedFields != null && excludedFields.length > 0) {
-            searchSourceBuilder.fetchSource(null, excludedFields);
-        }
-
-        // set search pipeline from query if it's provided
-        String pipelineBody = fetchPipelineBody(query);
-        if (pipelineBody != null) {
-            searchSourceBuilder.pipeline(pipelineBody);
-        }
-
-        // set search pipeline if searchPipeline is provided
-        if (searchPipeline != null && !searchPipeline.isEmpty()) {
-            searchRequest.pipeline(searchPipeline);
-        }
-
-        searchRequest.source(searchSourceBuilder);
-        return searchRequest;
-    }
-
-    public static String fetchPipelineBody(String query) {
         try {
-            JsonNode rootNode = OBJECT_MAPPER.readTree(query);
-            JsonNode pipelineNode = rootNode.get(SEARCH_PIPELINE_FIELD_NAME);
-            return pipelineNode != null ? OBJECT_MAPPER.writeValueAsString(pipelineNode) : null;
-        } catch (JsonProcessingException e) {
-            throw new IllegalArgumentException("Failed to parse pipeline body from query", e);
-        }
-    }
+            // Replace placeholder with actual query text
+            String processedQuery = query.replace(WILDCARD_QUERY_TEXT, queryText);
 
-    public static String[] fetchExcludingFields(String query) {
-        try {
-            JsonNode rootNode = OBJECT_MAPPER.readTree(query);
-            JsonNode sourceNode = rootNode.get(SOURCE_FIELD_NAME);
-            if (sourceNode != null && sourceNode.has(EXCLUDE_FIELD_NAME)) {
-                return OBJECT_MAPPER.convertValue(sourceNode.get(EXCLUDE_FIELD_NAME), String[].class);
+            // Parse the full query into a map
+            XContentParser parser = JsonXContent.jsonXContent.createParser(
+                NamedXContentRegistry.EMPTY,
+                DeprecationHandler.IGNORE_DEPRECATIONS,
+                processedQuery
+            );
+            Map<String, Object> fullQueryMap = parser.map();
+
+            // This implementation handles the 'query' field separately from other fields because:
+            // 1. Custom query types (like hybrid, neural) are not registered in the default QueryBuilders
+            // 2. Using WrapperQuery allows passing through any query structure without parsing
+            // 3. All other fields (aggregations, source filtering, etc.) can be parsed normally by SearchSourceBuilder
+            Object queryObject = fullQueryMap.remove("query");
+
+            // Parse everything except query using SearchSourceBuilder.fromXContent
+            XContentBuilder builder = JsonXContent.contentBuilder();
+            builder.map(fullQueryMap);
+
+            parser = JsonXContent.jsonXContent.createParser(
+                NAMED_CONTENT_REGISTRY,
+                DeprecationHandler.IGNORE_DEPRECATIONS,
+                builder.toString()
+            );
+
+            SearchSourceBuilder sourceBuilder = SearchSourceBuilder.fromXContent(parser);
+
+            // Handle query separately using WrapperQuery
+            if (queryObject != null) {
+                builder = JsonXContent.contentBuilder();
+                builder.value(queryObject);
+                String queryBody = builder.toString();
+                sourceBuilder.query(QueryBuilders.wrapperQuery(queryBody));
             }
-            return null;
-        } catch (JsonProcessingException e) {
-            throw new IllegalArgumentException("Failed to parse excluded fields from query", e);
+
+            // Set size
+            sourceBuilder.size(size);
+
+            // Set search pipeline if provided
+            if (searchPipeline != null && !searchPipeline.isEmpty()) {
+                searchRequest.pipeline(searchPipeline);
+            }
+
+            searchRequest.source(sourceBuilder);
+            return searchRequest;
+
+        } catch (IOException ex) {
+            throw new IllegalArgumentException("Failed to build search request", ex);
         }
     }
 
-    public static String fetchQueryBody(String query) {
-        try {
-            JsonNode rootNode = OBJECT_MAPPER.readTree(query);
-            JsonNode queryNode = rootNode.get(QUERY_BODY_FIELD_NAME);
-            return queryNode != null ? OBJECT_MAPPER.writeValueAsString(queryNode) : null;
-        } catch (JsonProcessingException e) {
-            throw new IllegalArgumentException("Failed to parse query body from query", e);
-        }
-    }
 }


### PR DESCRIPTION
### Description
Change search request builder logics to take all possible fields, includes aggregation, includes, .. previous implementation only took query, _source and search_pipeline. 
This implementation handles the 'query' field separately from other fields because:
  1. Custom query types (like hybrid, neural) are not registered in the default QueryBuilders
  2. Using WrapperQuery allows passing through any query structure without parsing
  3. All other fields (aggregations, source filtering, etc.) can be parsed normally by SearchSourceBuilder

**Testing**
- verified the changes with a aggregation query 
```
{
  "size": 20,
  "query": {
    "multi_match": {
      "query": "apple pie",
      "fields": ["name", "description"]
    }
  },
  "aggs": {
    "price_stats": {
      "stats": {
        "field": "price"
      }
    },
    "price_ranges": {
      "range": {
        "field": "price",
        "ranges": [
          { "to": 2.0 },
          { "from": 2.0, "to": 4.0 },
          { "from": 4.0 }
        ]
      }
    },
    "fruit_names": {
      "terms": {
        "field": "name",
        "size": 10
      }
    }
  }
}
```
- verified the changes with a hybrid search query 
```
{
    "_source": {
      "exclude": [
        "passage_embedding"
      ]
    },
    "query": {
        "hybrid": {
            "queries": [
                {
                    "match": {
                        "name": "apple"
                    }
                },
                {
                    "match": {
                        "name": {
                            "query": "apple"
                        }
                    }
                }
            ]
        }
    },
    "search_pipeline" : {
        "description": "Post processor for hybrid search",
        "phase_results_processors": [
            {
                "normalization-processor": {
                    "normalization": {
                        "technique": "min_max"
                    },
                    "combination": {
                        "technique": "arithmetic_mean",
                        "parameters": {
                            "weights": [
                                0.7,
                                0.3
                            ]
                        }
                    }
                }
            }
        ]
    }
}
```

### Issues Resolved
#14 



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
