### PR TITLE
Hybrid optimizer - added experiment options for hybrid search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,12 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ## [Unreleased]
 
 ### Added
+- Added new experiment type for hybrid search ([#10](https://github.com/opensearch-project/search-relevance/pull/26))
 
 ### Removed
 
 ### Fixed
-
- - Update demo setup to be include ubi and ecommerce data sets and run in OS 3.1 ([#10](https://github.com/opensearch-project/search-relevance/issues/10))
- - Build search request with normal parsing and wrapper query ([#22](https://github.com/opensearch-project/search-relevance/pull/22))
+- Update demo setup to be include ubi and ecommerce data sets and run in OS 3.1 ([#10](https://github.com/opensearch-project/search-relevance/issues/10))
+- Build search request with normal parsing and wrapper query ([#22](https://github.com/opensearch-project/search-relevance/pull/22))
 
 ### Security

--- a/src/main/java/org/opensearch/searchrelevance/experiment/EmptyExperimentOptions.java
+++ b/src/main/java/org/opensearch/searchrelevance/experiment/EmptyExperimentOptions.java
@@ -5,11 +5,9 @@
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.
  */
-package org.opensearch.searchrelevance.model;
+package org.opensearch.searchrelevance.experiment;
 
-public enum ExperimentType {
-    PAIRWISE_COMPARISON,
-    LLM_EVALUATION,
-    UBI_EVALUATION,
-    HYBRID_SEARCH
-}
+/**
+ * Empty implementation of ExperimentOptions
+ */
+public class EmptyExperimentOptions implements ExperimentOptions {}

--- a/src/main/java/org/opensearch/searchrelevance/experiment/ExperimentOptions.java
+++ b/src/main/java/org/opensearch/searchrelevance/experiment/ExperimentOptions.java
@@ -5,11 +5,9 @@
  * this file be licensed under the Apache-2.0 license or a
  * compatible open source license.
  */
-package org.opensearch.searchrelevance.model;
+package org.opensearch.searchrelevance.experiment;
 
-public enum ExperimentType {
-    PAIRWISE_COMPARISON,
-    LLM_EVALUATION,
-    UBI_EVALUATION,
-    HYBRID_SEARCH
-}
+/**
+ * Interface for experiment options
+ */
+public interface ExperimentOptions {}

--- a/src/main/java/org/opensearch/searchrelevance/experiment/ExperimentOptionsFactory.java
+++ b/src/main/java/org/opensearch/searchrelevance/experiment/ExperimentOptionsFactory.java
@@ -1,0 +1,93 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+package org.opensearch.searchrelevance.experiment;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Function;
+
+/**
+ * Factory class for creating ExperimentOptions based on the experiment name and parameters
+ */
+public class ExperimentOptionsFactory {
+
+    public static final String EMPTY_EXPERIMENT_OPTIONS = "EMPTY_EXPERIMENT_OPTIONS";
+    public static final String HYBRID_SEARCH_EXPERIMENT_OPTIONS = "HYBRID_SEARCH_EXPERIMENT_OPTIONS";
+
+    private static final Map<String, Function<Map<String, Object>, ExperimentOptions>> OPTIONS_BY_EXPERIMENT_NAME = Map.of(
+        EMPTY_EXPERIMENT_OPTIONS,
+        params -> new EmptyExperimentOptions(),
+        HYBRID_SEARCH_EXPERIMENT_OPTIONS,
+        ExperimentOptionsFactory::getExperimentOptionsForHybridSearch
+    );
+
+    /**
+     * Creates an ExperimentOptions object based on the provided experiment name and parameters.
+     *
+     * @param experimentName The name of the experiment.
+     * @param params The parameters for the experiment.
+     * @return An ExperimentOptions object.
+     * @throws IllegalArgumentException If the provided experiment name is not supported.
+     */
+    public static ExperimentOptions createExperimentOptions(final String experimentName, final Map<String, Object> params) {
+        return Optional.ofNullable(OPTIONS_BY_EXPERIMENT_NAME.get(experimentName))
+            .orElseThrow(() -> new IllegalArgumentException("provided experiment name is not supported"))
+            .apply(params);
+    }
+
+    private static ExperimentOptionsForHybridSearch getExperimentOptionsForHybridSearch(Map<String, Object> params) {
+        ExperimentOptionsForHybridSearch.ExperimentOptionsForHybridSearchBuilder builder = ExperimentOptionsForHybridSearch.builder();
+
+        if (params.containsKey("normalizationTechniques")) {
+            builder.normalizationTechniques((Set<String>) params.get("normalizationTechniques"));
+        }
+
+        if (params.containsKey("combinationTechniques")) {
+            builder.combinationTechniques((Set<String>) params.get("combinationTechniques"));
+        }
+
+        if (params.containsKey("weightsRange")) {
+            Map<String, Object> weightsRangeMap = (Map<String, Object>) params.get("weightsRange");
+            ExperimentOptionsForHybridSearch.WeightsRange.WeightsRangeBuilder weightsRangeBuilder =
+                ExperimentOptionsForHybridSearch.WeightsRange.builder();
+
+            if (weightsRangeMap.containsKey("rangeMin")) {
+                weightsRangeBuilder.rangeMin(((Number) weightsRangeMap.get("rangeMin")).floatValue());
+            }
+
+            if (weightsRangeMap.containsKey("rangeMax")) {
+                weightsRangeBuilder.rangeMax(((Number) weightsRangeMap.get("rangeMax")).floatValue());
+            }
+
+            if (weightsRangeMap.containsKey("increment")) {
+                weightsRangeBuilder.increment(((Number) weightsRangeMap.get("increment")).floatValue());
+            }
+
+            builder.weightsRange(weightsRangeBuilder.build());
+        }
+
+        return builder.build();
+    }
+
+    /**
+     * Creates a default set of experiment parameters for hybrid search.
+     *
+     * @return A map containing the default experiment parameters.
+     */
+    public static Map<String, Object> createDefaultExperimentParametersForHybridSearch() {
+        return Map.of(
+            "normalizationTechniques",
+            Set.of("min_max", "l2"),
+            "combinationTechniques",
+            Set.of("arithmetic_mean", "geometric_mean", "harmonic_mean"),
+            "weightsRange",
+            Map.of("rangeMin", 0.0, "rangeMax", 1.0, "increment", 0.1)
+        );
+    }
+}

--- a/src/main/java/org/opensearch/searchrelevance/experiment/ExperimentOptionsForHybridSearch.java
+++ b/src/main/java/org/opensearch/searchrelevance/experiment/ExperimentOptionsForHybridSearch.java
@@ -7,6 +7,8 @@
  */
 package org.opensearch.searchrelevance.experiment;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Set;
 
 import lombok.Builder;
@@ -28,5 +30,34 @@ public class ExperimentOptionsForHybridSearch implements ExperimentOptions {
         private float rangeMin;
         private float rangeMax;
         private float increment;
+    }
+
+    public List<SubExperimentHybridSearchDao> getParameterCombinations(boolean includeWeights) {
+        List<SubExperimentHybridSearchDao> allPossibleParameterCombinations = new ArrayList<>();
+        for (String normalizationTechnique : normalizationTechniques) {
+            for (String combinationTechnique : combinationTechniques) {
+                if (includeWeights) {
+                    for (float queryWeightForCombination = weightsRange.getRangeMin(); queryWeightForCombination <= weightsRange
+                        .getRangeMax(); queryWeightForCombination += weightsRange.getIncrement()) {
+                        allPossibleParameterCombinations.add(
+                            SubExperimentHybridSearchDao.builder()
+                                .normalizationTechnique(normalizationTechnique)
+                                .combinationTechnique(combinationTechnique)
+                                .queryWeightsForCombination(new float[] { queryWeightForCombination, 1.0f - queryWeightForCombination })
+                                .build()
+                        );
+                    }
+                } else {
+                    allPossibleParameterCombinations.add(
+                        SubExperimentHybridSearchDao.builder()
+                            .normalizationTechnique(normalizationTechnique)
+                            .combinationTechnique(combinationTechnique)
+                            .queryWeightsForCombination(new float[] { 0.5f, 0.5f })
+                            .build()
+                    );
+                }
+            }
+        }
+        return allPossibleParameterCombinations;
     }
 }

--- a/src/main/java/org/opensearch/searchrelevance/experiment/ExperimentOptionsForHybridSearch.java
+++ b/src/main/java/org/opensearch/searchrelevance/experiment/ExperimentOptionsForHybridSearch.java
@@ -1,0 +1,32 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+package org.opensearch.searchrelevance.experiment;
+
+import java.util.Set;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+/**
+ * Experiment options for hybrid search
+ */
+public class ExperimentOptionsForHybridSearch implements ExperimentOptions {
+    private Set<String> normalizationTechniques;
+    private Set<String> combinationTechniques;
+    private WeightsRange weightsRange;
+
+    @Data
+    @Builder
+    static class WeightsRange {
+        private float rangeMin;
+        private float rangeMax;
+        private float increment;
+    }
+}

--- a/src/main/java/org/opensearch/searchrelevance/experiment/QuerySourceUtil.java
+++ b/src/main/java/org/opensearch/searchrelevance/experiment/QuerySourceUtil.java
@@ -1,0 +1,41 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+package org.opensearch.searchrelevance.experiment;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Utility class for a query source
+ */
+public class QuerySourceUtil {
+
+    /**
+     * Creates a definition of a temporary search pipeline for hybrid search.
+     * @param experimentHybridSearchDao
+     * @return
+     */
+    public static Map<String, Object> createDefinitionOfTemporarySearchPipeline(
+        final SubExperimentHybridSearchDao experimentHybridSearchDao
+    ) {
+        Map<String, Object> normalizationTechniqueConfig = new HashMap<>(
+            Map.of("technique", experimentHybridSearchDao.getNormalizationTechnique())
+        );
+        Map<String, Object> combinationTechniqueConfig = new HashMap<>(
+            Map.of("technique", experimentHybridSearchDao.getCombinationTechnique())
+        );
+        Map<String, Object> normalizationProcessorConfig = new HashMap<>(
+            Map.of("normalization", normalizationTechniqueConfig, "combination", combinationTechniqueConfig)
+        );
+        Map<String, Object> phaseProcessorObject = new HashMap<>(Map.of("normalization-processor", normalizationProcessorConfig));
+        Map<String, Object> temporarySearchPipeline = new HashMap<>();
+        temporarySearchPipeline.put("phase_results_processors", List.of(phaseProcessorObject));
+        return temporarySearchPipeline;
+    }
+}

--- a/src/main/java/org/opensearch/searchrelevance/experiment/SubExperimentHybridSearchDao.java
+++ b/src/main/java/org/opensearch/searchrelevance/experiment/SubExperimentHybridSearchDao.java
@@ -1,0 +1,19 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+package org.opensearch.searchrelevance.experiment;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class SubExperimentHybridSearchDao {
+    private final String normalizationTechnique;
+    private final String combinationTechnique;
+    private final float[] queryWeightsForCombination;
+}

--- a/src/test/java/org/opensearch/searchrelevance/experiment/ExperimentOptionsFactoryTests.java
+++ b/src/test/java/org/opensearch/searchrelevance/experiment/ExperimentOptionsFactoryTests.java
@@ -1,0 +1,56 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+package org.opensearch.searchrelevance.experiment;
+
+import java.util.Map;
+import java.util.Set;
+
+import org.opensearch.test.OpenSearchTestCase;
+
+public class ExperimentOptionsFactoryTests extends OpenSearchTestCase {
+
+    private static final float DELTA_FOR_FLOAT_ASSERTION = 0.0001f;
+
+    public void testCreateExperimentOptions_whenValidHybridSearchOptions_thenSuccessful() {
+        // When
+        ExperimentOptions experimentOptions = ExperimentOptionsFactory.createExperimentOptions(
+            ExperimentOptionsFactory.HYBRID_SEARCH_EXPERIMENT_OPTIONS,
+            ExperimentOptionsFactory.createDefaultExperimentParametersForHybridSearch()
+        );
+
+        // Then
+        assertNotNull(experimentOptions);
+        assertTrue(experimentOptions instanceof ExperimentOptionsForHybridSearch);
+        ExperimentOptionsForHybridSearch result = (ExperimentOptionsForHybridSearch) experimentOptions;
+        assertNotNull(result.getWeightsRange());
+        ExperimentOptionsForHybridSearch.WeightsRange resultWeightsRange = result.getWeightsRange();
+        assertEquals(0.0f, resultWeightsRange.getRangeMin(), DELTA_FOR_FLOAT_ASSERTION);
+        assertEquals(1.0f, resultWeightsRange.getRangeMax(), DELTA_FOR_FLOAT_ASSERTION);
+        assertEquals(0.1f, resultWeightsRange.getIncrement(), DELTA_FOR_FLOAT_ASSERTION);
+    }
+
+    public void testCreateExperimentOptions_whenInvalidHybridSearchOptions_thenFail() {
+        // Given
+        Map<String, Object> invalidOptions = Map.of(
+            "normalizationTechniques",
+            Set.of("min_max", "l2"),
+            "combinationTechniques",
+            Set.of("arithmetic_mean", "geometric_mean", "harmonic_mean"),
+            "weightsRange",
+            Map.of("rangeMin", 1.0, "rangeMax", 0.0, "increment", 0.1)
+        );
+
+        // When & Then
+        IllegalArgumentException exception = assertThrows(
+            IllegalArgumentException.class,
+            () -> ExperimentOptionsFactory.createExperimentOptions("random_experiment_name", invalidOptions)
+        );
+
+        assertEquals("provided experiment name is not supported", exception.getMessage());
+    }
+}

--- a/src/test/java/org/opensearch/searchrelevance/experiment/QuerySourceUtilTests.java
+++ b/src/test/java/org/opensearch/searchrelevance/experiment/QuerySourceUtilTests.java
@@ -1,0 +1,49 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+package org.opensearch.searchrelevance.experiment;
+
+import java.util.List;
+import java.util.Map;
+
+import org.opensearch.test.OpenSearchTestCase;
+
+public class QuerySourceUtilTests extends OpenSearchTestCase {
+
+    public void testCreateDefinitionOfTemporarySearchPipeline_ValidInput_ReturnsCorrectStructure() {
+        // Given
+        SubExperimentHybridSearchDao experimentHybridSearchDao = SubExperimentHybridSearchDao.builder()
+            .normalizationTechnique("min_max")
+            .combinationTechnique("arithmetic_mean")
+            .build();
+
+        // When
+        Map<String, Object> result = QuerySourceUtil.createDefinitionOfTemporarySearchPipeline(experimentHybridSearchDao);
+
+        // Then
+        assertNotNull(result);
+        assertTrue(result.containsKey("phase_results_processors"));
+
+        List<?> processors = (List<?>) result.get("phase_results_processors");
+        assertEquals(1, processors.size());
+
+        Map<?, ?> processorObject = (Map<?, ?>) processors.get(0);
+        assertTrue(processorObject.containsKey("normalization-processor"));
+
+        Map<?, ?> normalizationProcessor = (Map<?, ?>) processorObject.get("normalization-processor");
+        Map<?, ?> normalization = (Map<?, ?>) normalizationProcessor.get("normalization");
+        Map<?, ?> combination = (Map<?, ?>) normalizationProcessor.get("combination");
+
+        assertEquals("min_max", normalization.get("technique"));
+        assertEquals("arithmetic_mean", combination.get("technique"));
+    }
+
+    public void testCreateDefinitionOfTemporarySearchPipeline_NullInput_ThrowsNullPointerException() {
+        // When & Then
+        assertThrows(NullPointerException.class, () -> QuerySourceUtil.createDefinitionOfTemporarySearchPipeline(null));
+    }
+}

--- a/src/test/java/org/opensearch/searchrelevance/model/builder/SearchRequestBuilderTests.java
+++ b/src/test/java/org/opensearch/searchrelevance/model/builder/SearchRequestBuilderTests.java
@@ -9,6 +9,9 @@ package org.opensearch.searchrelevance.model.builder;
 
 import static org.opensearch.searchrelevance.common.PluginConstants.WILDCARD_QUERY_TEXT;
 
+import java.util.List;
+import java.util.Map;
+
 import org.opensearch.action.search.SearchRequest;
 import org.opensearch.search.builder.SearchSourceBuilder;
 import org.opensearch.test.OpenSearchTestCase;
@@ -57,6 +60,44 @@ public class SearchRequestBuilderTests extends OpenSearchTestCase {
         SearchSourceBuilder sourceBuilder = searchRequest.source();
         assertNotNull("SearchSourceBuilder should not be null", sourceBuilder);
         assertEquals("Size should match", TEST_SIZE, sourceBuilder.size());
+    }
+
+    public void testHybridQuerySearchConfiguration_whenQuerySourceWithGenericHybridQuery_thenSuccess() {
+        String hybridQuery =
+            "{\"_source\":{\"exclude\":[\"passage_embedding\"]},\"query\":{\"hybrid\":{\"queries\":[{\"match\":{\"name\":\""
+                + WILDCARD_QUERY_TEXT
+                + "\"}},{\"match\":{\"name\":{\"query\":\""
+                + WILDCARD_QUERY_TEXT
+                + "\"}}}]}}}";
+        SearchRequest searchRequest = SearchRequestBuilder.buildSearchRequest(TEST_INDEX, hybridQuery, TEST_QUERY_TEXT, TEST_SIZE);
+        assertNotNull("SearchRequest should not be null", searchRequest);
+        assertEquals("Index should match", TEST_INDEX, searchRequest.indices()[0]);
+
+        SearchSourceBuilder sourceBuilder = searchRequest.source();
+        assertNotNull("SearchSourceBuilder should not be null", sourceBuilder);
+        assertEquals("Size should match", TEST_SIZE, sourceBuilder.size());
+
+        assertNotNull(sourceBuilder.searchPipelineSource());
+        Map<String, Object> searchPipelineSource = sourceBuilder.searchPipelineSource();
+        assertFalse(searchPipelineSource.isEmpty());
+        assertTrue(searchPipelineSource.containsKey("phase_results_processors"));
+        assertEquals(1, ((List<?>) searchPipelineSource.get("phase_results_processors")).size());
+    }
+
+    public void testHybridQuerySearchConfiguration_whenQuerySourceHasTemporaryPipeline_thenFail() {
+        String hybridQuery =
+            "{\"_source\":{\"exclude\":[\"passage_embedding\"]},\"query\":{\"hybrid\":{\"queries\":[{\"match\":{\"name\":\""
+                + WILDCARD_QUERY_TEXT
+                + "\"}},{\"match\":{\"name\":{\"query\":\""
+                + WILDCARD_QUERY_TEXT
+                + "\"}}}]}},\"search_pipeline\":{\"description\":\"Post processor for hybrid search\","
+                + "\"phase_results_processors\":[{\"normalization-processor\":{\"normalization\":{\"technique\":\"min_max\"},\"combination\":"
+                + "{\"technique\":\"arithmetic_mean\",\"parameters\":{\"weights\":[0.7,0.3]}}}}]}}";
+        IllegalArgumentException exception = expectThrows(
+            IllegalArgumentException.class,
+            () -> SearchRequestBuilder.buildSearchRequest(TEST_INDEX, hybridQuery, TEST_QUERY_TEXT, TEST_SIZE)
+        );
+        assertEquals("search pipeline is not allowed in search request", exception.getMessage());
     }
 
     public void testBuildSearchRequestInvalidJson() {


### PR DESCRIPTION
### Description
Adding building blocks for hybrid optimizer: 
- extend Experiments API by allowing different experiment options
- hardcoded experiment options for initial release (3.1 scope)
- validate that query in search configuration does not have temporary pipeline in it
- if experiment is of type hybrid search then we iterate over experiment options, create temp search pipeline for each unique combination of parameters

I'm extending existing Experiment API, this is how request for hybrid search experiment will look like:

```
PUT _plugins/search_relevance/experiments
{
    "querySetId": "70a624f6-53c9-4644-8af8-6b76485379e1",
    "searchConfigurationList": ["7d0dd57f-aa14-4620-ab17-944779581225", "614b0347-8e10-4f10-b632-f0d43a79f572"],
    "size": 2,
    "judgmentList": ["4a01b588-d8f8-476d-8b78-4485767fc7cd"],
    "type": "HYBRID_SEARCH"
}
```

Future work/not supported in this PR:
- store individual metrics for sub-experiment (now it stores multiple evaluation docs, but not the link between experiment and evaluation, need to add sub-experiments)
- parse internals of DSL query and validate aspects of hybrid query, for instance if this is really hybrid query, how many sub-queries in it etc.

### Issues Resolved
https://github.com/o19s/search-relevance/issues/115

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
