### PR TITLE
Added validation for hybrid query structure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Added new experiment type for hybrid search ([#26](https://github.com/opensearch-project/search-relevance/pull/26))
 - Added feature flag for search relevance workbench ([#34](https://github.com/opensearch-project/search-relevance/pull/34))
 - [Enhancement] Extend data model to adopt different experiment options/parameters ([#29](https://github.com/opensearch-project/search-relevance/issues/29))
+- Added validation for hybrid query structure ([#40](https://github.com/opensearch-project/search-relevance/pull/40))
 
 ### Removed
 

--- a/src/main/java/org/opensearch/searchrelevance/model/builder/SearchRequestBuilder.java
+++ b/src/main/java/org/opensearch/searchrelevance/model/builder/SearchRequestBuilder.java
@@ -8,6 +8,7 @@
 package org.opensearch.searchrelevance.model.builder;
 
 import static org.opensearch.searchrelevance.common.PluginConstants.WILDCARD_QUERY_TEXT;
+import static org.opensearch.searchrelevance.experiment.QuerySourceUtil.validateHybridQuery;
 
 import java.io.IOException;
 import java.util.Collections;
@@ -141,6 +142,8 @@ public class SearchRequestBuilder {
             );
             Map<String, Object> fullQueryMap = parser.map();
 
+            validateHybridQuery(fullQueryMap);
+
             // This implementation handles the 'query' field separately from other fields because:
             // 1. Custom query types (like hybrid, neural) are not registered in the default QueryBuilders
             // 2. Using WrapperQuery allows passing through any query structure without parsing
@@ -200,5 +203,4 @@ public class SearchRequestBuilder {
             throw new IllegalArgumentException("Failed to build search request", ex);
         }
     }
-
 }

--- a/src/test/java/org/opensearch/searchrelevance/experiment/QuerySourceUtilTests.java
+++ b/src/test/java/org/opensearch/searchrelevance/experiment/QuerySourceUtilTests.java
@@ -10,11 +10,16 @@ package org.opensearch.searchrelevance.experiment;
 import static org.opensearch.searchrelevance.experiment.ExperimentOptionsForHybridSearch.EXPERIMENT_OPTION_COMBINATION_TECHNIQUE;
 import static org.opensearch.searchrelevance.experiment.ExperimentOptionsForHybridSearch.EXPERIMENT_OPTION_NORMALIZATION_TECHNIQUE;
 
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
 import org.opensearch.searchrelevance.model.ExperimentVariant;
 import org.opensearch.test.OpenSearchTestCase;
+
+import lombok.SneakyThrows;
 
 public class QuerySourceUtilTests extends OpenSearchTestCase {
 
@@ -50,5 +55,125 @@ public class QuerySourceUtilTests extends OpenSearchTestCase {
     public void testCreateDefinitionOfTemporarySearchPipeline_NullInput_ThrowsNullPointerException() {
         // When & Then
         assertThrows(NullPointerException.class, () -> QuerySourceUtil.createDefinitionOfTemporarySearchPipeline(null));
+    }
+
+    @SneakyThrows
+    public void testValidateHybridQuery_ValidQuery() {
+        Map<String, Object> hybridQueries = new HashMap<>();
+        hybridQueries.put("queries", Arrays.asList(new HashMap<>(), new HashMap<>())); // Two subqueries
+
+        Map<String, Object> hybrid = new HashMap<>();
+        hybrid.put("hybrid", hybridQueries);
+
+        Map<String, Object> fullQuery = new HashMap<>();
+        fullQuery.put("query", hybrid);
+
+        QuerySourceUtil.validateHybridQuery(fullQuery);
+    }
+
+    public void testValidateHybridQuery_MissingQuery() {
+        Map<String, Object> fullQuery = new HashMap<>();
+
+        IllegalArgumentException exception = assertThrows(
+            IllegalArgumentException.class,
+            () -> QuerySourceUtil.validateHybridQuery(fullQuery)
+        );
+        assertEquals("query in search configuration does not have query", exception.getMessage());
+    }
+
+    public void testValidateHybridQuery_InvalidQueryType() {
+        Map<String, Object> fullQuery = new HashMap<>();
+        fullQuery.put("query", "not_a_map");
+
+        IllegalArgumentException exception = assertThrows(
+            IllegalArgumentException.class,
+            () -> QuerySourceUtil.validateHybridQuery(fullQuery)
+        );
+        assertEquals("query in search configuration does not have query", exception.getMessage());
+    }
+
+    public void testValidateHybridQuery_MissingHybrid() {
+        Map<String, Object> query = new HashMap<>();
+        Map<String, Object> fullQuery = new HashMap<>();
+        fullQuery.put("query", query);
+
+        IllegalArgumentException exception = assertThrows(
+            IllegalArgumentException.class,
+            () -> QuerySourceUtil.validateHybridQuery(fullQuery)
+        );
+        assertEquals("query in search configuration does must be of type hybrid", exception.getMessage());
+    }
+
+    public void testValidateHybridQuery_InvalidHybridType() {
+        Map<String, Object> query = new HashMap<>();
+        query.put("hybrid", "not_a_map");
+        Map<String, Object> fullQuery = new HashMap<>();
+        fullQuery.put("query", query);
+
+        IllegalArgumentException exception = assertThrows(
+            IllegalArgumentException.class,
+            () -> QuerySourceUtil.validateHybridQuery(fullQuery)
+        );
+        assertEquals("query in search configuration does must be of type hybrid", exception.getMessage());
+    }
+
+    public void testValidateHybridQuery_MissingQueries() {
+        Map<String, Object> hybridMap = new HashMap<>();
+        Map<String, Object> query = new HashMap<>();
+        query.put("hybrid", hybridMap);
+        Map<String, Object> fullQuery = new HashMap<>();
+        fullQuery.put("query", query);
+
+        IllegalArgumentException exception = assertThrows(
+            IllegalArgumentException.class,
+            () -> QuerySourceUtil.validateHybridQuery(fullQuery)
+        );
+        assertEquals("hybrid query in search configuration does not have queries", exception.getMessage());
+    }
+
+    public void testValidateHybridQuery_InvalidQueriesType() {
+        Map<String, Object> hybridMap = new HashMap<>();
+        hybridMap.put("queries", "not_a_list");
+        Map<String, Object> query = new HashMap<>();
+        query.put("hybrid", hybridMap);
+        Map<String, Object> fullQuery = new HashMap<>();
+        fullQuery.put("query", query);
+
+        IllegalArgumentException exception = assertThrows(
+            IllegalArgumentException.class,
+            () -> QuerySourceUtil.validateHybridQuery(fullQuery)
+        );
+        assertEquals("hybrid query in search configuration does not have queries", exception.getMessage());
+    }
+
+    public void testValidateHybridQuery_whenOneSubquery_thenFail() {
+        Map<String, Object> hybridMap = new HashMap<>();
+        hybridMap.put("queries", Collections.singletonList(new HashMap<>())); // only one query instead of two
+        Map<String, Object> query = new HashMap<>();
+        query.put("hybrid", hybridMap);
+        Map<String, Object> fullQuery = new HashMap<>();
+        fullQuery.put("query", query);
+
+        IllegalArgumentException exception = assertThrows(
+            IllegalArgumentException.class,
+            () -> QuerySourceUtil.validateHybridQuery(fullQuery)
+        );
+        assertEquals("invalid hybrid query: expected exactly [2] sub-queries but found [1]", exception.getMessage());
+    }
+
+    public void testValidateHybridQuery_whenThreeSubqueries_thenFail() {
+        Map<String, Object> hybridMap = new HashMap<>();
+        List<Map<?, ?>> queries = Arrays.asList(Map.of(), Map.of(), Map.of());
+        hybridMap.put("queries", queries);
+        Map<String, Object> query = new HashMap<>();
+        query.put("hybrid", hybridMap);
+        Map<String, Object> fullQuery = new HashMap<>();
+        fullQuery.put("query", query);
+
+        IllegalArgumentException exception = assertThrows(
+            IllegalArgumentException.class,
+            () -> QuerySourceUtil.validateHybridQuery(fullQuery)
+        );
+        assertEquals("invalid hybrid query: expected exactly [2] sub-queries but found [3]", exception.getMessage());
     }
 }

--- a/src/test/java/org/opensearch/searchrelevance/model/builder/SearchRequestBuilderTests.java
+++ b/src/test/java/org/opensearch/searchrelevance/model/builder/SearchRequestBuilderTests.java
@@ -129,4 +129,15 @@ public class SearchRequestBuilderTests extends OpenSearchTestCase {
         );
     }
 
+    public void testHybridQuerySearchConfiguration_whenLessThenTwoSubQueries_thenFail() {
+        String hybridQuery =
+            "{\"_source\":{\"exclude\":[\"passage_embedding\"]},\"query\":{\"hybrid\":{\"queries\":[{\"match\":{\"name\":\""
+                + WILDCARD_QUERY_TEXT
+                + "\"}}]}}}";
+        IllegalArgumentException exception = expectThrows(
+            IllegalArgumentException.class,
+            () -> SearchRequestBuilder.buildRequestForHybridSearch(TEST_INDEX, hybridQuery, Map.of(), TEST_QUERY_TEXT, TEST_SIZE)
+        );
+        assertEquals("invalid hybrid query: expected exactly [2] sub-queries but found [1]", exception.getMessage());
+    }
 }


### PR DESCRIPTION
### Description
Added validation of the query type for Hybrid Search Optimizer. 
Parameters that are validated:
 - query must be of type "hybrid"
 - query must have exactly two sub-queries. this is needed because we did not logic for distributing weights for more then 2 sub-queries, and having one or zero sub-queries does not have a lot of sense (it equivalent of running sub-query as a standalone query).

I'm checking basic things based on general query structure,  more deep checks are limited without direct dependency on hybrid query classes. Adding such dependency is problematic because neural-search repo does not publish jar archives, only zip files that are harder to adopt as runtime dependency.

### Issues Resolved
https://github.com/o19s/search-relevance/issues/115

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
