### PR TITLE
Flipping default feature flag setting to disabled

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -227,6 +227,7 @@ testClusters.integTest {
             debugPort += 1
         }
     }
+    setting 'plugins.search_relevance.workbench_enabled', 'true'
 }
 
 run {

--- a/src/main/java/org/opensearch/searchrelevance/settings/SearchRelevanceSettings.java
+++ b/src/main/java/org/opensearch/searchrelevance/settings/SearchRelevanceSettings.java
@@ -25,7 +25,7 @@ public class SearchRelevanceSettings {
     public static final String SEARCH_RELEVANCE_WORKBENCH_ENABLED_KEY = "plugins.search_relevance.workbench_enabled";
     public static final Setting<Boolean> SEARCH_RELEVANCE_WORKBENCH_ENABLED = Setting.boolSetting(
         SEARCH_RELEVANCE_WORKBENCH_ENABLED_KEY,
-        true,
+        false,
         Setting.Property.NodeScope,
         Setting.Property.Dynamic
     );

--- a/src/test/java/org/opensearch/searchrelevance/plugin/SearchRelevancePluginTests.java
+++ b/src/test/java/org/opensearch/searchrelevance/plugin/SearchRelevancePluginTests.java
@@ -196,6 +196,6 @@ public class SearchRelevancePluginTests extends OpenSearchTestCase {
         Setting<?> setting = settings.get(0);
         assertEquals("plugins.search_relevance.workbench_enabled", setting.getKey());
         assertEquals(1, settings.size());
-        assertEquals(true, setting.get(Settings.EMPTY));
+        assertEquals(false, setting.get(Settings.EMPTY));
     }
 }


### PR DESCRIPTION
### Description
We added a feature flag for SRW in https://github.com/opensearch-project/search-relevance/pull/34, it's enabled by default. We need to flip the default value to false/disabled, main reason being - we not going to meet the 3.1 release time window with application security review. 

Don't merge it yet without corresponding change in UI. 

### Issues Resolved
https://github.com/opensearch-project/search-relevance/issues/33

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
