### PR TITLE
Create indexes for query sets, search configs, judgment lists if none…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,5 +21,6 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
  - Fix COEC calculation: introduce rank in ClickthroughRate class, fix bucket size for positional aggregation, correct COEC claculation ([#23](https://github.com/opensearch-project/search-relevance/issues/23)).
  - LLM Judgment Processor Improvement ([#27](https://github.com/opensearch-project/search-relevance/pull/27))
  - Deal with experiment processing when no experiment variants exist. ([#45](https://github.com/opensearch-project/search-relevance/pull/45))
+ - Create indexes for query sets, search configs, judgment lists if none of these were created or imported before to prevent errors for missing indexes in frontend. ([#55](https://github.com/opensearch-project/search-relevance/issues/55))
 
 ### Security

--- a/src/main/java/org/opensearch/searchrelevance/experiment/QuerySourceUtil.java
+++ b/src/main/java/org/opensearch/searchrelevance/experiment/QuerySourceUtil.java
@@ -11,8 +11,8 @@ import static org.opensearch.searchrelevance.experiment.ExperimentOptionsForHybr
 import static org.opensearch.searchrelevance.experiment.ExperimentOptionsForHybridSearch.EXPERIMENT_OPTION_NORMALIZATION_TECHNIQUE;
 import static org.opensearch.searchrelevance.experiment.ExperimentOptionsForHybridSearch.EXPERIMENT_OPTION_WEIGHTS_FOR_COMBINATION;
 
-import java.util.ArrayList;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;

--- a/src/main/java/org/opensearch/searchrelevance/transport/judgment/GetJudgmentTransportAction.java
+++ b/src/main/java/org/opensearch/searchrelevance/transport/judgment/GetJudgmentTransportAction.java
@@ -7,11 +7,9 @@
  */
 package org.opensearch.searchrelevance.transport.judgment;
 
-import static org.opensearch.searchrelevance.indices.SearchRelevanceIndices.JUDGMENT;
-
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.opensearch.ResourceNotFoundException;
+import org.opensearch.action.StepListener;
 import org.opensearch.action.search.SearchResponse;
 import org.opensearch.action.support.ActionFilters;
 import org.opensearch.action.support.HandledTransportAction;
@@ -44,11 +42,9 @@ public class GetJudgmentTransportAction extends HandledTransportAction<OpenSearc
 
     @Override
     protected void doExecute(Task task, OpenSearchDocRequest request, ActionListener<SearchResponse> listener) {
-        // Validate cluster health first
-        if (!clusterService.state().routingTable().hasIndex(JUDGMENT.getIndexName())) {
-            listener.onFailure(new ResourceNotFoundException("Index [" + JUDGMENT.getIndexName() + "] not found"));
-            return;
-        }
+        // Create index if not already existing; important when users view judgment list overview before creating, uploading one
+        StepListener<Void> createIndexStep = new StepListener<>();
+        judgmentDao.createIndexIfAbsent(createIndexStep);
 
         try {
             if (request.getId() != null) {

--- a/src/main/java/org/opensearch/searchrelevance/transport/queryset/GetQuerySetTransportAction.java
+++ b/src/main/java/org/opensearch/searchrelevance/transport/queryset/GetQuerySetTransportAction.java
@@ -7,11 +7,9 @@
  */
 package org.opensearch.searchrelevance.transport.queryset;
 
-import static org.opensearch.searchrelevance.indices.SearchRelevanceIndices.QUERY_SET;
-
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.opensearch.ResourceNotFoundException;
+import org.opensearch.action.StepListener;
 import org.opensearch.action.search.SearchResponse;
 import org.opensearch.action.support.ActionFilters;
 import org.opensearch.action.support.HandledTransportAction;
@@ -44,11 +42,9 @@ public class GetQuerySetTransportAction extends HandledTransportAction<OpenSearc
 
     @Override
     protected void doExecute(Task task, OpenSearchDocRequest request, ActionListener<SearchResponse> listener) {
-        // Validate cluster health first
-        if (!clusterService.state().routingTable().hasIndex(QUERY_SET.getIndexName())) {
-            listener.onFailure(new ResourceNotFoundException("Index [" + QUERY_SET.getIndexName() + "] not found"));
-            return;
-        }
+        // Create index if not already existing; important when users view query set overview before creating, uploading one
+        StepListener<Void> createIndexStep = new StepListener<>();
+        querySetDao.createIndexIfAbsent(createIndexStep);
 
         try {
             if (request.getId() != null) {

--- a/src/main/java/org/opensearch/searchrelevance/transport/searchConfiguration/GetSearchConfigurationTransportAction.java
+++ b/src/main/java/org/opensearch/searchrelevance/transport/searchConfiguration/GetSearchConfigurationTransportAction.java
@@ -7,11 +7,9 @@
  */
 package org.opensearch.searchrelevance.transport.searchConfiguration;
 
-import static org.opensearch.searchrelevance.indices.SearchRelevanceIndices.SEARCH_CONFIGURATION;
-
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.opensearch.ResourceNotFoundException;
+import org.opensearch.action.StepListener;
 import org.opensearch.action.search.SearchResponse;
 import org.opensearch.action.support.ActionFilters;
 import org.opensearch.action.support.HandledTransportAction;
@@ -44,11 +42,9 @@ public class GetSearchConfigurationTransportAction extends HandledTransportActio
 
     @Override
     protected void doExecute(Task task, OpenSearchDocRequest request, ActionListener<SearchResponse> listener) {
-        // Validate cluster health first
-        if (!clusterService.state().routingTable().hasIndex(SEARCH_CONFIGURATION.getIndexName())) {
-            listener.onFailure(new ResourceNotFoundException("Index [" + SEARCH_CONFIGURATION.getIndexName() + "] not found"));
-            return;
-        }
+        // Create index if not already existing; important when users view search configuration overview before creating, uploading one
+        StepListener<Void> createIndexStep = new StepListener<>();
+        searchConfigurationDao.createIndexIfAbsent(createIndexStep);
 
         try {
             if (request.getId() != null) {


### PR DESCRIPTION
… of these were created or imported before to prevent errors for missing indexes in frontend.

### Description
When a `GET` is sent to either of the endpoints for the above mentioned the corresponding index is created if not present. That way no errors are shown in the frontend which improves user experience.

### Issues Resolved
#55 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
