### PR TITLE
Added lazy index creation for APIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Added validation for hybrid query structure ([#40](https://github.com/opensearch-project/search-relevance/pull/40))
 - [Enhancement] Add support for importing judgments created externally from SRW.  ([#42](https://github.com/opensearch-project/search-relevance/pull/42)
 - Changing URL for plugin APIs to /_plugin/_search_relevance [backend] ([#62](https://github.com/opensearch-project/search-relevance/pull/62)
+- Added lazy index creation for all APIs ([#65](https://github.com/opensearch-project/search-relevance/pull/65)
 
 ### Removed
 

--- a/src/main/java/org/opensearch/searchrelevance/indices/SearchRelevanceIndices.java
+++ b/src/main/java/org/opensearch/searchrelevance/indices/SearchRelevanceIndices.java
@@ -29,48 +29,53 @@ import java.util.Objects;
 import org.opensearch.core.rest.RestStatus;
 import org.opensearch.searchrelevance.exception.SearchRelevanceException;
 
+import lombok.Getter;
+
+@Getter
 public enum SearchRelevanceIndices {
     /**
      * Query Set Index
      */
-    QUERY_SET(QUERY_SET_INDEX, QUERY_SET_INDEX_MAPPING),
+    QUERY_SET(QUERY_SET_INDEX, QUERY_SET_INDEX_MAPPING, false),
 
     /**
      * Experiment Index
      */
-    EXPERIMENT(EXPERIMENT_INDEX, EXPERIMENT_INDEX_MAPPING),
+    EXPERIMENT(EXPERIMENT_INDEX, EXPERIMENT_INDEX_MAPPING, true),
 
     /**
      * Search Configuration Index
      */
-    SEARCH_CONFIGURATION(SEARCH_CONFIGURATION_INDEX, SEARCH_CONFIGURATION_INDEX_MAPPING),
+    SEARCH_CONFIGURATION(SEARCH_CONFIGURATION_INDEX, SEARCH_CONFIGURATION_INDEX_MAPPING, false),
 
     /**
      * Judgment Index
      */
-    JUDGMENT(JUDGMENT_INDEX, JUDGMENT_INDEX_MAPPING),
+    JUDGMENT(JUDGMENT_INDEX, JUDGMENT_INDEX_MAPPING, false),
 
     /**
      * Evaluation Result Index
      */
-    EVALUATION_RESULT(EVALUATION_RESULT_INDEX, EVALUATION_RESULT_INDEX_MAPPING),
+    EVALUATION_RESULT(EVALUATION_RESULT_INDEX, EVALUATION_RESULT_INDEX_MAPPING, false),
 
     /**
      * Judgment Cache Index
      */
-    JUDGMENT_CACHE(JUDGMENT_CACHE_INDEX, JUDGMENT_CACHE_INDEX_MAPPING),
+    JUDGMENT_CACHE(JUDGMENT_CACHE_INDEX, JUDGMENT_CACHE_INDEX_MAPPING, false),
 
     /**
      * Experiment Variant Index
      */
-    EXPERIMENT_VARIANT(EXPERIMENT_VARIANT_INDEX, EXPERIMENT_VARIANT_INDEX_MAPPING);
+    EXPERIMENT_VARIANT(EXPERIMENT_VARIANT_INDEX, EXPERIMENT_VARIANT_INDEX_MAPPING, false);
 
     private final String indexName;
     private final String mapping;
+    private final boolean isProtected;
 
-    SearchRelevanceIndices(String indexName, String mappingPath) {
+    SearchRelevanceIndices(String indexName, String mappingPath, boolean isProtected) {
         this.indexName = Objects.requireNonNull(indexName, "Index name cannot be null.");
         this.mapping = loadMapping(mappingPath);
+        this.isProtected = isProtected;
     }
 
     private String loadMapping(String mappingPath) {
@@ -80,13 +85,4 @@ public enum SearchRelevanceIndices {
             throw new SearchRelevanceException("Failed to load mapping under path: " + mappingPath, e, RestStatus.INTERNAL_SERVER_ERROR);
         }
     }
-
-    public String getIndexName() {
-        return indexName;
-    }
-
-    public String getMapping() {
-        return mapping;
-    }
-
 }

--- a/src/main/java/org/opensearch/searchrelevance/indices/SearchRelevanceIndicesManager.java
+++ b/src/main/java/org/opensearch/searchrelevance/indices/SearchRelevanceIndicesManager.java
@@ -10,12 +10,10 @@ package org.opensearch.searchrelevance.indices;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.function.BiConsumer;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.opensearch.ResourceAlreadyExistsException;
 import org.opensearch.ResourceNotFoundException;
-import org.opensearch.action.DocWriteRequest;
 import org.opensearch.action.DocWriteRequest.OpType;
 import org.opensearch.action.StepListener;
 import org.opensearch.action.admin.indices.create.CreateIndexRequest;
@@ -38,13 +36,16 @@ import org.opensearch.searchrelevance.exception.SearchRelevanceException;
 import org.opensearch.searchrelevance.shared.StashedThreadContext;
 import org.opensearch.transport.client.Client;
 
+import lombok.Builder;
+import lombok.Getter;
+import lombok.extern.log4j.Log4j2;
 import reactor.util.annotation.NonNull;
 
 /**
  * Manager for common search relevance system indices operations.
  */
+@Log4j2
 public class SearchRelevanceIndicesManager {
-    private static final Logger LOGGER = LogManager.getLogger(SearchRelevanceIndicesManager.class);
 
     private final ClusterService clusterService;
     private final Client client;
@@ -64,7 +65,7 @@ public class SearchRelevanceIndicesManager {
         String mapping = index.getMapping();
 
         if (clusterService.state().metadata().hasIndex(indexName)) {
-            LOGGER.debug("Index [{}] already exists, skipping creation", indexName);
+            log.debug("Index [{}] already exists, skipping creation", indexName);
             stepListener.onResponse(null);
             return;
         }
@@ -72,21 +73,37 @@ public class SearchRelevanceIndicesManager {
         StashedThreadContext.run(client, () -> client.admin().indices().create(createIndexRequest, new ActionListener<>() {
             @Override
             public void onResponse(final CreateIndexResponse createIndexResponse) {
-                LOGGER.info("Successfully created index [{}]", indexName);
+                log.info("Successfully created index [{}]", indexName);
                 stepListener.onResponse(null);
             }
 
             @Override
             public void onFailure(final Exception e) {
                 if (e instanceof ResourceAlreadyExistsException) {
-                    LOGGER.debug("index[{}] already exist", indexName);
+                    log.debug("index[{}] already exist", indexName);
                     stepListener.onResponse(null);
                     return;
                 }
-                LOGGER.error("Failed to create index [{}]", indexName, e);
+                log.error("Failed to create index [{}]", indexName, e);
                 stepListener.onFailure(e);
             }
         }));
+    }
+
+    /**
+     * Create a search relevance index if not exists, using synchronize calls
+     * @param index
+     */
+    private void createIndexIfAbsentSync(final SearchRelevanceIndices index) {
+        String indexName = index.getIndexName();
+        String mapping = index.getMapping();
+
+        if (clusterService.state().metadata().hasIndex(indexName)) {
+            log.debug("Index [{}] already exists, skipping creation", indexName);
+            return;
+        }
+        final CreateIndexRequest createIndexRequest = new CreateIndexRequest(indexName).mapping(mapping);
+        StashedThreadContext.run(client, () -> client.admin().indices().create(createIndexRequest));
     }
 
     /**
@@ -102,18 +119,38 @@ public class SearchRelevanceIndicesManager {
         final SearchRelevanceIndices index,
         final ActionListener listener
     ) {
-        StashedThreadContext.run(client, () -> {
+        SearchOperationContext searchOperationContext = SearchOperationContext.builder()
+            .documentId(docId)
+            .xContentBuilder(xContentBuilder)
+            .index(index)
+            .build();
+        executeWithIndexCreation(searchOperationContext, (context, actionListener) -> StashedThreadContext.run(client, () -> {
             try {
-                client.prepareIndex(index.getIndexName())
-                    .setId(docId)
-                    .setOpType(DocWriteRequest.OpType.CREATE)
+                client.prepareIndex(context.getIndex().getIndexName())
+                    .setId(context.getDocumentId())
+                    .setOpType(OpType.CREATE)
                     .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE)
-                    .setSource(xContentBuilder)
+                    .setSource(context.getXContentBuilder())
                     .execute(listener);
             } catch (Exception e) {
                 throw new SearchRelevanceException("Failed to store doc", e, RestStatus.INTERNAL_SERVER_ERROR);
             }
-        });
+        }), listener);
+    }
+
+    /**
+     * Execute Dao method wrapping it in "create index if absent" function
+     * @param context
+     * @param operation
+     * @param listener
+     */
+    private <T> void executeWithIndexCreation(
+        SearchOperationContext context,
+        BiConsumer<SearchOperationContext, ActionListener<T>> operation,
+        ActionListener<T> listener
+    ) {
+        createIndexIfAbsentSync(context.getIndex());
+        operation.accept(context, listener);
     }
 
     /**
@@ -129,18 +166,27 @@ public class SearchRelevanceIndicesManager {
         final SearchRelevanceIndices index,
         final ActionListener listener
     ) {
-        StashedThreadContext.run(client, () -> {
-            try {
-                client.prepareIndex(index.getIndexName())
-                    .setId(docId)
-                    .setOpType(OpType.INDEX)
-                    .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE)
-                    .setSource(xContentBuilder)
-                    .execute(listener);
-            } catch (Exception e) {
-                throw new SearchRelevanceException("Failed to store doc", e, RestStatus.INTERNAL_SERVER_ERROR);
-            }
-        });
+        SearchOperationContext searchOperationContext = SearchOperationContext.builder()
+            .index(index)
+            .xContentBuilder(xContentBuilder)
+            .documentId(docId)
+            .build();
+        executeWithIndexCreation(
+            searchOperationContext,
+            (searchOperationContext1, actionListener) -> StashedThreadContext.run(client, () -> {
+                try {
+                    client.prepareIndex(searchOperationContext1.getIndex().getIndexName())
+                        .setId(searchOperationContext1.getDocumentId())
+                        .setOpType(OpType.INDEX)
+                        .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE)
+                        .setSource(searchOperationContext1.getXContentBuilder())
+                        .execute((ActionListener) actionListener);
+                } catch (Exception e) {
+                    throw new SearchRelevanceException("Failed to store doc", e, RestStatus.INTERNAL_SERVER_ERROR);
+                }
+            }),
+            listener
+        );
     }
 
     /**
@@ -150,26 +196,32 @@ public class SearchRelevanceIndicesManager {
      * @param listener - action lister for async operation
      */
     public void deleteDocByDocId(final String docId, final SearchRelevanceIndices index, final ActionListener<DeleteResponse> listener) {
-        StashedThreadContext.run(client, () -> {
-            try {
-                client.prepareDelete(index.getIndexName(), docId)
-                    .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE)
-                    .execute(new ActionListener<DeleteResponse>() {
-                        @Override
-                        public void onResponse(DeleteResponse deleteResponse) {
-                            LOGGER.info("Successfully delete doc id [{}]", docId);
-                            listener.onResponse(deleteResponse);
-                        }
+        SearchOperationContext searchOperationContext = SearchOperationContext.builder().index(index).documentId(docId).build();
+        executeWithIndexCreation(
+            searchOperationContext,
+            (searchOperationContextArg, actionListener) -> StashedThreadContext.run(client, () -> {
+                try {
+                    client.prepareDelete(searchOperationContext.getIndex().getIndexName(), searchOperationContext.getDocumentId())
+                        .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE)
+                        .execute(new ActionListener<DeleteResponse>() {  // Specify the generic type
+                            @Override
+                            public void onResponse(DeleteResponse deleteResponse) {  // Properly typed parameter
+                                actionListener.onResponse(deleteResponse);
+                            }
 
-                        @Override
-                        public void onFailure(Exception e) {
-                            listener.onFailure(new SearchRelevanceException("Failed to delete doc", e, RestStatus.INTERNAL_SERVER_ERROR));
-                        }
-                    });
-            } catch (Exception e) {
-                listener.onFailure(new SearchRelevanceException("Failed to delete doc", e, RestStatus.INTERNAL_SERVER_ERROR));
-            }
-        });
+                            @Override
+                            public void onFailure(Exception e) {
+                                actionListener.onFailure(
+                                    new SearchRelevanceException("Failed to delete doc", e, RestStatus.INTERNAL_SERVER_ERROR)
+                                );
+                            }
+                        });
+                } catch (Exception e) {
+                    actionListener.onFailure(new SearchRelevanceException("Failed to delete doc", e, RestStatus.INTERNAL_SERVER_ERROR));
+                }
+            }),
+            listener
+        );
     }
 
     /**
@@ -183,33 +235,45 @@ public class SearchRelevanceIndicesManager {
         final SearchRelevanceIndices index,
         final ActionListener<SearchResponse> listener
     ) {
-        SearchRequest searchRequest = new SearchRequest(index.getIndexName());
-        SearchSourceBuilder sourceBuilder = new SearchSourceBuilder().query(QueryBuilders.termQuery("_id", docId)).size(1);
+        SearchOperationContext searchOperationContext = SearchOperationContext.builder().index(index).documentId(docId).build();
+        executeWithIndexCreation(searchOperationContext, (searchOperationContextArg, actionListener) -> {
+            SearchRequest searchRequest = new SearchRequest(searchOperationContextArg.getIndex().getIndexName());
+            SearchSourceBuilder sourceBuilder = new SearchSourceBuilder().query(
+                QueryBuilders.termQuery("_id", searchOperationContextArg.getDocumentId())
+            ).size(1);
 
-        searchRequest.source(sourceBuilder);
+            searchRequest.source(sourceBuilder);
 
-        StashedThreadContext.run(client, () -> {
-            try {
-                client.search(searchRequest, new ActionListener<SearchResponse>() {
-                    @Override
-                    public void onResponse(SearchResponse response) {
-                        LOGGER.info("Successfully get doc id [{}]", docId);
-                        if (response.getHits().getTotalHits().value() == 0) {
-                            listener.onFailure(new ResourceNotFoundException("Document not found: " + docId, RestStatus.NOT_FOUND));
-                            return;
+            StashedThreadContext.run(client, () -> {
+                try {
+                    client.search(searchRequest, new ActionListener<SearchResponse>() {
+                        @Override
+                        public void onResponse(SearchResponse response) {
+                            log.info("Successfully get doc id [{}]", searchOperationContextArg.getDocumentId());
+                            if (response.getHits().getTotalHits().value() == 0) {
+                                actionListener.onFailure(
+                                    new ResourceNotFoundException(
+                                        "Document not found: " + searchOperationContextArg.getDocumentId(),
+                                        RestStatus.NOT_FOUND
+                                    )
+                                );
+                                return;
+                            }
+                            actionListener.onResponse(response);
                         }
-                        listener.onResponse(response);
-                    }
 
-                    @Override
-                    public void onFailure(Exception e) {
-                        listener.onFailure(new SearchRelevanceException("Failed to get document", e, RestStatus.INTERNAL_SERVER_ERROR));
-                    }
-                });
-            } catch (Exception e) {
-                listener.onFailure(new SearchRelevanceException("Failed to get doc", e, RestStatus.INTERNAL_SERVER_ERROR));
-            }
-        });
+                        @Override
+                        public void onFailure(Exception e) {
+                            actionListener.onFailure(
+                                new SearchRelevanceException("Failed to get document", e, RestStatus.INTERNAL_SERVER_ERROR)
+                            );
+                        }
+                    });
+                } catch (Exception e) {
+                    actionListener.onFailure(new SearchRelevanceException("Failed to get doc", e, RestStatus.INTERNAL_SERVER_ERROR));
+                }
+            });
+        }, listener);
         return null;
     }
 
@@ -224,45 +288,51 @@ public class SearchRelevanceIndicesManager {
         final SearchRelevanceIndices index,
         final ActionListener<SearchResponse> listener
     ) {
-        SearchRequest searchRequest = new SearchRequest(index.getIndexName());
-        searchRequest.source(searchSourceBuilder);
-        StashedThreadContext.run(client, () -> {
-            try {
-                client.search(searchRequest, new ActionListener<SearchResponse>() {
-                    @Override
-                    public void onResponse(SearchResponse response) {
-                        LOGGER.info("Successfully list documents with search request [{}]", searchRequest);
-                        listener.onResponse(response);
-                    }
-
-                    @Override
-                    public void onFailure(Exception e) {
-                        if (e instanceof IndexNotFoundException) {
-                            final InternalSearchResponse internalSearchResponse = InternalSearchResponse.empty();
-                            final SearchResponse emptySearchResponse = new SearchResponse(
-                                internalSearchResponse,
-                                null,
-                                0,
-                                0,
-                                0,
-                                0,
-                                null,
-                                new ShardSearchFailure[] {},
-                                SearchResponse.Clusters.EMPTY,
-                                null
-                            );
-                            listener.onResponse(emptySearchResponse);
-                        } else {
-                            listener.onFailure(
-                                new SearchRelevanceException("Failed to list documents", e, RestStatus.INTERNAL_SERVER_ERROR)
-                            );
+        SearchOperationContext searchOperationContext = SearchOperationContext.builder()
+            .searchSourceBuilder(searchSourceBuilder)
+            .index(index)
+            .build();
+        executeWithIndexCreation(searchOperationContext, (context, actionListener) -> {
+            SearchRequest searchRequest = new SearchRequest(context.getIndex().getIndexName());
+            searchRequest.source(context.getSearchSourceBuilder());
+            StashedThreadContext.run(client, () -> {
+                try {
+                    client.search(searchRequest, new ActionListener<SearchResponse>() {
+                        @Override
+                        public void onResponse(SearchResponse response) {
+                            log.info("Successfully list documents with search request [{}]", searchRequest);
+                            ((ActionListener<SearchResponse>) actionListener).onResponse(response);
                         }
-                    }
-                });
-            } catch (Exception e) {
-                listener.onFailure(new SearchRelevanceException("Failed to list docs", e, RestStatus.INTERNAL_SERVER_ERROR));
-            }
-        });
+
+                        @Override
+                        public void onFailure(Exception e) {
+                            if (e instanceof IndexNotFoundException) {
+                                final InternalSearchResponse internalSearchResponse = InternalSearchResponse.empty();
+                                final SearchResponse emptySearchResponse = new SearchResponse(
+                                    internalSearchResponse,
+                                    null,
+                                    0,
+                                    0,
+                                    0,
+                                    0,
+                                    null,
+                                    new ShardSearchFailure[] {},
+                                    SearchResponse.Clusters.EMPTY,
+                                    null
+                                );
+                                ((ActionListener<SearchResponse>) actionListener).onResponse(emptySearchResponse);
+                            } else {
+                                actionListener.onFailure(
+                                    new SearchRelevanceException("Failed to list documents", e, RestStatus.INTERNAL_SERVER_ERROR)
+                                );
+                            }
+                        }
+                    });
+                } catch (Exception e) {
+                    actionListener.onFailure(new SearchRelevanceException("Failed to list docs", e, RestStatus.INTERNAL_SERVER_ERROR));
+                }
+            });
+        }, listener);
         return null;
     }
 
@@ -289,5 +359,17 @@ public class SearchRelevanceIndicesManager {
             Streams.readAllLines(is, sb::append);
             return sb.toString();
         }
+    }
+
+    /**
+     *  DTO for search operation context
+     */
+    @Builder
+    @Getter
+    static class SearchOperationContext {
+        private final SearchRelevanceIndices index;
+        private final SearchSourceBuilder searchSourceBuilder;
+        private final XContentBuilder xContentBuilder;
+        private final String documentId;
     }
 }

--- a/src/main/java/org/opensearch/searchrelevance/transport/experiment/DeleteExperimentTransportAction.java
+++ b/src/main/java/org/opensearch/searchrelevance/transport/experiment/DeleteExperimentTransportAction.java
@@ -7,9 +7,6 @@
  */
 package org.opensearch.searchrelevance.transport.experiment;
 
-import static org.opensearch.searchrelevance.indices.SearchRelevanceIndices.EXPERIMENT;
-
-import org.opensearch.ResourceNotFoundException;
 import org.opensearch.action.delete.DeleteResponse;
 import org.opensearch.action.support.ActionFilters;
 import org.opensearch.action.support.HandledTransportAction;
@@ -41,12 +38,6 @@ public class DeleteExperimentTransportAction extends HandledTransportAction<Open
 
     @Override
     protected void doExecute(Task task, OpenSearchDocRequest request, ActionListener<DeleteResponse> listener) {
-        // Validate cluster health first
-        if (!clusterService.state().routingTable().hasIndex(EXPERIMENT.getIndexName())) {
-            listener.onFailure(new ResourceNotFoundException("Index [" + EXPERIMENT.getIndexName() + "] not found"));
-            return;
-        }
-
         try {
             String experimentId = request.getId();
             if (experimentId == null || experimentId.trim().isEmpty()) {

--- a/src/main/java/org/opensearch/searchrelevance/transport/experiment/GetExperimentTransportAction.java
+++ b/src/main/java/org/opensearch/searchrelevance/transport/experiment/GetExperimentTransportAction.java
@@ -7,11 +7,8 @@
  */
 package org.opensearch.searchrelevance.transport.experiment;
 
-import static org.opensearch.searchrelevance.indices.SearchRelevanceIndices.EXPERIMENT;
-
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.opensearch.ResourceNotFoundException;
 import org.opensearch.action.search.SearchResponse;
 import org.opensearch.action.support.ActionFilters;
 import org.opensearch.action.support.HandledTransportAction;
@@ -44,12 +41,6 @@ public class GetExperimentTransportAction extends HandledTransportAction<OpenSea
 
     @Override
     protected void doExecute(Task task, OpenSearchDocRequest request, ActionListener<SearchResponse> listener) {
-        // Validate cluster health first
-        if (!clusterService.state().routingTable().hasIndex(EXPERIMENT.getIndexName())) {
-            listener.onFailure(new ResourceNotFoundException("Index [" + EXPERIMENT.getIndexName() + "] not found"));
-            return;
-        }
-
         try {
             if (request.getId() != null) {
                 // Handle single experiment request

--- a/src/main/java/org/opensearch/searchrelevance/transport/judgment/DeleteJudgmentTransportAction.java
+++ b/src/main/java/org/opensearch/searchrelevance/transport/judgment/DeleteJudgmentTransportAction.java
@@ -7,9 +7,6 @@
  */
 package org.opensearch.searchrelevance.transport.judgment;
 
-import static org.opensearch.searchrelevance.indices.SearchRelevanceIndices.JUDGMENT;
-
-import org.opensearch.ResourceNotFoundException;
 import org.opensearch.action.delete.DeleteResponse;
 import org.opensearch.action.support.ActionFilters;
 import org.opensearch.action.support.HandledTransportAction;
@@ -41,12 +38,6 @@ public class DeleteJudgmentTransportAction extends HandledTransportAction<OpenSe
 
     @Override
     protected void doExecute(Task task, OpenSearchDocRequest request, ActionListener<DeleteResponse> listener) {
-        // Validate cluster health first
-        if (!clusterService.state().routingTable().hasIndex(JUDGMENT.getIndexName())) {
-            listener.onFailure(new ResourceNotFoundException("Index [" + JUDGMENT.getIndexName() + "] not found"));
-            return;
-        }
-
         try {
             String judgmentId = request.getId();
             if (judgmentId == null || judgmentId.trim().isEmpty()) {

--- a/src/main/java/org/opensearch/searchrelevance/transport/judgment/GetJudgmentTransportAction.java
+++ b/src/main/java/org/opensearch/searchrelevance/transport/judgment/GetJudgmentTransportAction.java
@@ -7,11 +7,8 @@
  */
 package org.opensearch.searchrelevance.transport.judgment;
 
-import static org.opensearch.searchrelevance.indices.SearchRelevanceIndices.JUDGMENT;
-
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.opensearch.ResourceNotFoundException;
 import org.opensearch.action.search.SearchResponse;
 import org.opensearch.action.support.ActionFilters;
 import org.opensearch.action.support.HandledTransportAction;
@@ -44,12 +41,6 @@ public class GetJudgmentTransportAction extends HandledTransportAction<OpenSearc
 
     @Override
     protected void doExecute(Task task, OpenSearchDocRequest request, ActionListener<SearchResponse> listener) {
-        // Validate cluster health first
-        if (!clusterService.state().routingTable().hasIndex(JUDGMENT.getIndexName())) {
-            listener.onFailure(new ResourceNotFoundException("Index [" + JUDGMENT.getIndexName() + "] not found"));
-            return;
-        }
-
         try {
             if (request.getId() != null) {
                 // Handle single judgment request

--- a/src/main/java/org/opensearch/searchrelevance/transport/queryset/DeleteQuerySetTransportAction.java
+++ b/src/main/java/org/opensearch/searchrelevance/transport/queryset/DeleteQuerySetTransportAction.java
@@ -7,9 +7,6 @@
  */
 package org.opensearch.searchrelevance.transport.queryset;
 
-import static org.opensearch.searchrelevance.indices.SearchRelevanceIndices.QUERY_SET;
-
-import org.opensearch.ResourceNotFoundException;
 import org.opensearch.action.delete.DeleteResponse;
 import org.opensearch.action.support.ActionFilters;
 import org.opensearch.action.support.HandledTransportAction;
@@ -41,12 +38,6 @@ public class DeleteQuerySetTransportAction extends HandledTransportAction<OpenSe
 
     @Override
     protected void doExecute(Task task, OpenSearchDocRequest request, ActionListener<DeleteResponse> listener) {
-        // Validate cluster health first
-        if (!clusterService.state().routingTable().hasIndex(QUERY_SET.getIndexName())) {
-            listener.onFailure(new ResourceNotFoundException("Index [" + QUERY_SET.getIndexName() + "] not found"));
-            return;
-        }
-
         try {
             String querySetId = request.getId();
             if (querySetId == null || querySetId.trim().isEmpty()) {

--- a/src/main/java/org/opensearch/searchrelevance/transport/queryset/GetQuerySetTransportAction.java
+++ b/src/main/java/org/opensearch/searchrelevance/transport/queryset/GetQuerySetTransportAction.java
@@ -7,11 +7,8 @@
  */
 package org.opensearch.searchrelevance.transport.queryset;
 
-import static org.opensearch.searchrelevance.indices.SearchRelevanceIndices.QUERY_SET;
-
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.opensearch.ResourceNotFoundException;
 import org.opensearch.action.search.SearchResponse;
 import org.opensearch.action.support.ActionFilters;
 import org.opensearch.action.support.HandledTransportAction;
@@ -44,12 +41,6 @@ public class GetQuerySetTransportAction extends HandledTransportAction<OpenSearc
 
     @Override
     protected void doExecute(Task task, OpenSearchDocRequest request, ActionListener<SearchResponse> listener) {
-        // Validate cluster health first
-        if (!clusterService.state().routingTable().hasIndex(QUERY_SET.getIndexName())) {
-            listener.onFailure(new ResourceNotFoundException("Index [" + QUERY_SET.getIndexName() + "] not found"));
-            return;
-        }
-
         try {
             if (request.getId() != null) {
                 // Handle single query set request

--- a/src/main/java/org/opensearch/searchrelevance/transport/searchConfiguration/DeleteSearchConfigurationTransportAction.java
+++ b/src/main/java/org/opensearch/searchrelevance/transport/searchConfiguration/DeleteSearchConfigurationTransportAction.java
@@ -7,9 +7,6 @@
  */
 package org.opensearch.searchrelevance.transport.searchConfiguration;
 
-import static org.opensearch.searchrelevance.indices.SearchRelevanceIndices.SEARCH_CONFIGURATION;
-
-import org.opensearch.ResourceNotFoundException;
 import org.opensearch.action.delete.DeleteResponse;
 import org.opensearch.action.support.ActionFilters;
 import org.opensearch.action.support.HandledTransportAction;
@@ -41,12 +38,6 @@ public class DeleteSearchConfigurationTransportAction extends HandledTransportAc
 
     @Override
     protected void doExecute(Task task, OpenSearchDocRequest request, ActionListener<DeleteResponse> listener) {
-        // Validate cluster health first
-        if (!clusterService.state().routingTable().hasIndex(SEARCH_CONFIGURATION.getIndexName())) {
-            listener.onFailure(new ResourceNotFoundException("Index [" + SEARCH_CONFIGURATION.getIndexName() + "] not found"));
-            return;
-        }
-
         try {
             String searchConfigurationId = request.getId();
             if (searchConfigurationId == null || searchConfigurationId.trim().isEmpty()) {

--- a/src/main/java/org/opensearch/searchrelevance/transport/searchConfiguration/GetSearchConfigurationTransportAction.java
+++ b/src/main/java/org/opensearch/searchrelevance/transport/searchConfiguration/GetSearchConfigurationTransportAction.java
@@ -7,11 +7,8 @@
  */
 package org.opensearch.searchrelevance.transport.searchConfiguration;
 
-import static org.opensearch.searchrelevance.indices.SearchRelevanceIndices.SEARCH_CONFIGURATION;
-
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.opensearch.ResourceNotFoundException;
 import org.opensearch.action.search.SearchResponse;
 import org.opensearch.action.support.ActionFilters;
 import org.opensearch.action.support.HandledTransportAction;
@@ -44,12 +41,6 @@ public class GetSearchConfigurationTransportAction extends HandledTransportActio
 
     @Override
     protected void doExecute(Task task, OpenSearchDocRequest request, ActionListener<SearchResponse> listener) {
-        // Validate cluster health first
-        if (!clusterService.state().routingTable().hasIndex(SEARCH_CONFIGURATION.getIndexName())) {
-            listener.onFailure(new ResourceNotFoundException("Index [" + SEARCH_CONFIGURATION.getIndexName() + "] not found"));
-            return;
-        }
-
         try {
             if (request.getId() != null) {
                 // Handle single search configuration request

--- a/src/test/java/org/opensearch/searchrelevance/indices/SearchRelevanceIndicesTests.java
+++ b/src/test/java/org/opensearch/searchrelevance/indices/SearchRelevanceIndicesTests.java
@@ -1,0 +1,48 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+package org.opensearch.searchrelevance.indices;
+
+import java.util.Set;
+
+import org.opensearch.test.OpenSearchTestCase;
+
+public class SearchRelevanceIndicesTests extends OpenSearchTestCase {
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+    }
+
+    public void testPropertiesOfEnumItems() {
+        for (SearchRelevanceIndices index : SearchRelevanceIndices.values()) {
+            assertNotNull(index.getMapping());
+            assertTrue(index.getMapping().contains("\"properties\""));
+            assertNotNull(index.getIndexName());
+            assertFalse(index.getIndexName().isBlank());
+        }
+    }
+
+    public void testProtectedFlag() {
+        Set<SearchRelevanceIndices> protectedIndices = Set.of(SearchRelevanceIndices.EXPERIMENT);
+        for (SearchRelevanceIndices index : protectedIndices) {
+            assertTrue(index.isProtected());
+        }
+
+        Set<SearchRelevanceIndices> notProtectedIndices = Set.of(
+            SearchRelevanceIndices.SEARCH_CONFIGURATION,
+            SearchRelevanceIndices.JUDGMENT,
+            SearchRelevanceIndices.JUDGMENT_CACHE,
+            SearchRelevanceIndices.EVALUATION_RESULT,
+            SearchRelevanceIndices.EXPERIMENT_VARIANT,
+            SearchRelevanceIndices.QUERY_SET
+        );
+        for (SearchRelevanceIndices index : notProtectedIndices) {
+            assertFalse(index.isProtected());
+        }
+    }
+}


### PR DESCRIPTION
### Description
Fixed user facing error for scenario when main plugin entities are not yet created. We're checking if index exists and fail in case it doesn't. With this PR logic changes to create index if not present.

Things I have added/changed:
- is_protected flag for index
- framework for running backend action in sync or async modes
- logic that decides between sync/async modes depending on index is_protected flag
- deleted if_index_absent check from Dao classes, this is taken care of by new framework

Flexible logic is needed for protected (aka system) indexes because of special handling of thread context due to usage of secure plugin of OpenSearch.

Continue work of https://github.com/opensearch-project/search-relevance/pull/54, 

### Issues Resolved
https://github.com/opensearch-project/search-relevance/issues/55

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
