### PR TITLE
WIP: Create evaluation result data to enable Dashboards visualization

### DIFF
--- a/src/main/java/org/opensearch/searchrelevance/common/PluginConstants.java
+++ b/src/main/java/org/opensearch/searchrelevance/common/PluginConstants.java
@@ -51,6 +51,8 @@ public class PluginConstants {
     public static final String JUDGMENT_CACHE_INDEX_MAPPING = "mappings/judgment_cache.json";
     public static final String EXPERIMENT_VARIANT_INDEX = "search-relevance-experiment-variant";
     public static final String EXPERIMENT_VARIANT_INDEX_MAPPING = "mappings/experiment_variant.json";
+    public static final String DASHBOARD_EVALUATION_RESULT_INDEX = "srw_metrics_search-relevance-evaluation-result";
+    public static final String DASHBOARD_EVALUATION_RESULT_INDEX_MAPPING = "mappings/dashboard_evaluation_result.json";
 
     /**
      * UBI
@@ -58,6 +60,11 @@ public class PluginConstants {
     public static final String UBI_QUERIES_INDEX = "ubi_queries";
     public static final String USER_QUERY_FIELD = "user_query";
     public static final String UBI_EVENTS_INDEX = "ubi_events";
+
+    /**
+     * Application name for dashboard evaluation results
+     */
+    public static final String DASHBOARD_APPLICATION_NAME = "search-relevance-workbench";
 
     public static final String CLICK_MODEL = "clickModel";
     public static final String NAX_RANK = "maxRank";

--- a/src/main/java/org/opensearch/searchrelevance/dao/DashboardEvaluationResultDao.java
+++ b/src/main/java/org/opensearch/searchrelevance/dao/DashboardEvaluationResultDao.java
@@ -1,0 +1,115 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+package org.opensearch.searchrelevance.dao;
+
+import static org.opensearch.searchrelevance.indices.SearchRelevanceIndices.DASHBOARD_EVALUATION_RESULT;
+
+import java.io.IOException;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.opensearch.action.StepListener;
+import org.opensearch.action.delete.DeleteResponse;
+import org.opensearch.action.search.SearchResponse;
+import org.opensearch.common.xcontent.XContentFactory;
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.core.rest.RestStatus;
+import org.opensearch.core.xcontent.ToXContent;
+import org.opensearch.index.query.QueryBuilders;
+import org.opensearch.search.builder.SearchSourceBuilder;
+import org.opensearch.searchrelevance.exception.SearchRelevanceException;
+import org.opensearch.searchrelevance.indices.SearchRelevanceIndicesManager;
+import org.opensearch.searchrelevance.model.DashboardEvaluationResult;
+
+public class DashboardEvaluationResultDao {
+    private static final Logger LOGGER = LogManager.getLogger(DashboardEvaluationResultDao.class);
+    private final SearchRelevanceIndicesManager searchRelevanceIndicesManager;
+
+    public DashboardEvaluationResultDao(SearchRelevanceIndicesManager searchRelevanceIndicesManager) {
+        this.searchRelevanceIndicesManager = searchRelevanceIndicesManager;
+    }
+
+    /**
+     * Create dashboard evaluation result index if not exists
+     * @param stepListener - step listener for async operation
+     */
+    public void createIndexIfAbsent(final StepListener<Void> stepListener) {
+        searchRelevanceIndicesManager.createIndexIfAbsent(DASHBOARD_EVALUATION_RESULT, stepListener);
+    }
+
+    /**
+     * Stores dashboard evaluation result in the system index
+     * @param dashboardEvaluationResult - DashboardEvaluationResult content to be stored
+     * @param listener - action listener for async operation
+     */
+    public void putDashboardEvaluationResult(final DashboardEvaluationResult dashboardEvaluationResult, final ActionListener listener) {
+        if (dashboardEvaluationResult == null) {
+            listener.onFailure(new SearchRelevanceException("DashboardEvaluationResult cannot be null", RestStatus.BAD_REQUEST));
+            return;
+        }
+        if (dashboardEvaluationResult.id() == null || dashboardEvaluationResult.id().isEmpty()) {
+            listener.onFailure(new SearchRelevanceException("Document ID cannot be null or empty", RestStatus.BAD_REQUEST));
+            return;
+        }
+        try {
+            searchRelevanceIndicesManager.putDoc(
+                dashboardEvaluationResult.id(),
+                dashboardEvaluationResult.toXContent(XContentFactory.jsonBuilder(), ToXContent.EMPTY_PARAMS),
+                DASHBOARD_EVALUATION_RESULT,
+                listener
+            );
+        } catch (IOException e) {
+            throw new SearchRelevanceException("Failed to store dashboardEvaluationResult", e, RestStatus.INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    /**
+     * Delete dashboard evaluation result by document ID
+     * @param id - document ID to be deleted
+     * @param listener - action listener for async operation
+     */
+    public void deleteDashboardEvaluationResult(final String id, final ActionListener<DeleteResponse> listener) {
+        if (id == null || id.isEmpty()) {
+            listener.onFailure(new SearchRelevanceException("Document ID must not be null or empty", RestStatus.BAD_REQUEST));
+            return;
+        }
+        searchRelevanceIndicesManager.deleteDocByDocId(id, DASHBOARD_EVALUATION_RESULT, listener);
+    }
+
+    /**
+     * Get dashboard evaluation result by document ID
+     * @param id - document ID to be retrieved
+     * @param listener - action listener for async operation
+     */
+    public SearchResponse getDashboardEvaluationResult(String id, ActionListener<SearchResponse> listener) {
+        if (id == null || id.isEmpty()) {
+            listener.onFailure(new SearchRelevanceException("Document ID must not be null or empty", RestStatus.BAD_REQUEST));
+            return null;
+        }
+        return searchRelevanceIndicesManager.getDocByDocId(id, DASHBOARD_EVALUATION_RESULT, listener);
+    }
+
+    /**
+     * List dashboard evaluation results by source builder
+     * @param sourceBuilder - source builder to be searched
+     * @param listener - action listener for async operation
+     */
+    public SearchResponse listDashboardEvaluationResults(SearchSourceBuilder sourceBuilder, ActionListener<SearchResponse> listener) {
+        // Apply default values if not set
+        if (sourceBuilder == null) {
+            sourceBuilder = new SearchSourceBuilder();
+        }
+
+        // Ensure we have a query
+        if (sourceBuilder.query() == null) {
+            sourceBuilder.query(QueryBuilders.matchAllQuery());
+        }
+
+        return searchRelevanceIndicesManager.listDocsBySearchRequest(sourceBuilder, DASHBOARD_EVALUATION_RESULT, listener);
+    }
+} 

--- a/src/main/java/org/opensearch/searchrelevance/indices/SearchRelevanceIndices.java
+++ b/src/main/java/org/opensearch/searchrelevance/indices/SearchRelevanceIndices.java
@@ -7,6 +7,8 @@
  */
 package org.opensearch.searchrelevance.indices;
 
+import static org.opensearch.searchrelevance.common.PluginConstants.DASHBOARD_EVALUATION_RESULT_INDEX;
+import static org.opensearch.searchrelevance.common.PluginConstants.DASHBOARD_EVALUATION_RESULT_INDEX_MAPPING;
 import static org.opensearch.searchrelevance.common.PluginConstants.EVALUATION_RESULT_INDEX;
 import static org.opensearch.searchrelevance.common.PluginConstants.EVALUATION_RESULT_INDEX_MAPPING;
 import static org.opensearch.searchrelevance.common.PluginConstants.EXPERIMENT_INDEX;
@@ -66,7 +68,12 @@ public enum SearchRelevanceIndices {
     /**
      * Experiment Variant Index
      */
-    EXPERIMENT_VARIANT(EXPERIMENT_VARIANT_INDEX, EXPERIMENT_VARIANT_INDEX_MAPPING, false);
+    EXPERIMENT_VARIANT(EXPERIMENT_VARIANT_INDEX, EXPERIMENT_VARIANT_INDEX_MAPPING, false),
+
+    /**
+     * Dashboard Evaluation Result Index
+     */
+    DASHBOARD_EVALUATION_RESULT(DASHBOARD_EVALUATION_RESULT_INDEX, DASHBOARD_EVALUATION_RESULT_INDEX_MAPPING, false);
 
     private final String indexName;
     private final String mapping;

--- a/src/main/java/org/opensearch/searchrelevance/indices/SearchRelevanceIndicesManager.java
+++ b/src/main/java/org/opensearch/searchrelevance/indices/SearchRelevanceIndicesManager.java
@@ -96,7 +96,7 @@ public class SearchRelevanceIndicesManager {
      * Create a search relevance index if not exists, using synchronize calls
      * @param index
      */
-    private void createIndexIfAbsentSync(final SearchRelevanceIndices index) {
+    public void createIndexIfAbsentSync(final SearchRelevanceIndices index) {
         String indexName = index.getIndexName();
         String mapping = index.getMapping();
 
@@ -105,7 +105,21 @@ public class SearchRelevanceIndicesManager {
             return;
         }
         final CreateIndexRequest createIndexRequest = new CreateIndexRequest(indexName).mapping(mapping);
-        StashedThreadContext.run(client, () -> client.admin().indices().create(createIndexRequest));
+        StashedThreadContext.run(client, () -> client.admin().indices().create(createIndexRequest, new ActionListener<>() {
+            @Override
+            public void onResponse(final CreateIndexResponse createIndexResponse) {
+                log.info("Successfully created index [{}]", indexName);
+            }
+
+            @Override
+            public void onFailure(final Exception e) {
+                if (e instanceof ResourceAlreadyExistsException) {
+                    log.info("index[{}] already exist", indexName);
+                    return;
+                }
+                log.error("Failed to create index [{}]", indexName, e);
+            }
+        }));
     }
 
     public SearchResponse getDocByDocIdSync(final String docId, final SearchRelevanceIndices index) {

--- a/src/main/java/org/opensearch/searchrelevance/metrics/MetricsHelper.java
+++ b/src/main/java/org/opensearch/searchrelevance/metrics/MetricsHelper.java
@@ -10,6 +10,7 @@ package org.opensearch.searchrelevance.metrics;
 import static org.opensearch.searchrelevance.common.MetricsConstants.METRICS_PAIRWISE_COMPARISON_FIELD_NAME;
 import static org.opensearch.searchrelevance.common.MetricsConstants.PAIRWISE_FIELD_NAME_A;
 import static org.opensearch.searchrelevance.common.MetricsConstants.PAIRWISE_FIELD_NAME_B;
+import static org.opensearch.searchrelevance.common.PluginConstants.DASHBOARD_APPLICATION_NAME;
 import static org.opensearch.searchrelevance.common.MetricsConstants.PAIRWISE_FIELD_NAME_DOC_IDS;
 import static org.opensearch.searchrelevance.common.MetricsConstants.PAIRWISE_FIELD_NAME_SEARCH_CONFIGURATION_ID;
 import static org.opensearch.searchrelevance.common.MetricsConstants.PAIRWISE_FIELD_NAME_SNAPSHOTS;
@@ -45,7 +46,9 @@ import org.opensearch.search.SearchHit;
 import org.opensearch.searchrelevance.dao.EvaluationResultDao;
 import org.opensearch.searchrelevance.dao.ExperimentVariantDao;
 import org.opensearch.searchrelevance.dao.JudgmentDao;
+import org.opensearch.searchrelevance.dao.DashboardEvaluationResultDao;
 import org.opensearch.searchrelevance.model.AsyncStatus;
+import org.opensearch.searchrelevance.model.DashboardEvaluationResult;
 import org.opensearch.searchrelevance.model.EvaluationResult;
 import org.opensearch.searchrelevance.model.ExperimentVariant;
 import org.opensearch.searchrelevance.model.builder.SearchRequestBuilder;
@@ -65,6 +68,7 @@ public class MetricsHelper {
     private final JudgmentDao judgmentDao;
     private final EvaluationResultDao evaluationResultDao;
     private final ExperimentVariantDao experimentVariantDao;
+    private final DashboardEvaluationResultDao dashboardEvaluationResultDao;
 
     @Inject
     public MetricsHelper(
@@ -72,13 +76,15 @@ public class MetricsHelper {
         @NonNull Client client,
         @NonNull JudgmentDao judgmentDao,
         @NonNull EvaluationResultDao evaluationResultDao,
-        @NonNull ExperimentVariantDao experimentVariantDao
+        @NonNull ExperimentVariantDao experimentVariantDao,
+        @NonNull DashboardEvaluationResultDao dashboardEvaluationResultDao
     ) {
         this.clusterService = clusterService;
         this.client = client;
         this.judgmentDao = judgmentDao;
         this.evaluationResultDao = evaluationResultDao;
         this.experimentVariantDao = experimentVariantDao;
+        this.dashboardEvaluationResultDao = dashboardEvaluationResultDao;
     }
 
     /**
@@ -190,9 +196,10 @@ public class MetricsHelper {
         Map<String, List<String>> indexAndQueries,
         int size,
         List<String> judgmentIds,
-        ActionListener<Map<String, Object>> listener
+        ActionListener<Map<String, Object>> listener,
+        String experimentId
     ) {
-        processEvaluationMetrics(queryText, indexAndQueries, size, judgmentIds, listener, List.of());
+        processEvaluationMetrics(queryText, indexAndQueries, size, judgmentIds, listener, Collections.emptyList(), experimentId);
     }
 
     public void processEvaluationMetrics(
@@ -201,7 +208,8 @@ public class MetricsHelper {
         int size,
         List<String> judgmentIds,
         ActionListener<Map<String, Object>> listener,
-        List<ExperimentVariant> experimentVariants
+        List<ExperimentVariant> experimentVariants,
+        String experimentId
     ) {
         if (indexAndQueries.isEmpty() || judgmentIds.isEmpty()) {
             listener.onFailure(new IllegalArgumentException("Missing required parameters"));
@@ -252,7 +260,8 @@ public class MetricsHelper {
                                     docIdToRatings,
                                     configToEvalIds,
                                     listener,
-                                    experimentVariants
+                                    experimentVariants,
+                                    experimentId
                                 );
                             }
                         } catch (Exception e) {
@@ -276,7 +285,8 @@ public class MetricsHelper {
                                     docIdToRatings,
                                     configToEvalIds,
                                     listener,
-                                    experimentVariants
+                                    experimentVariants,
+                                    experimentId
                                 );
                             }
                         }
@@ -297,7 +307,8 @@ public class MetricsHelper {
         Map<String, String> docIdToScores,
         Map<String, Object> configToEvalIds,
         ActionListener<Map<String, Object>> listener,
-        List<ExperimentVariant> experimentVariants
+        List<ExperimentVariant> experimentVariants,
+        String experimentId
     ) {
         AtomicBoolean hasFailure = new AtomicBoolean(false);
         AtomicInteger pendingConfigurations = getNumberOfExperimentRuns(indexAndQueries, experimentVariants);
@@ -314,6 +325,8 @@ public class MetricsHelper {
             String index = indexAndQueries.get(searchConfigurationId).get(0);
             String query = indexAndQueries.get(searchConfigurationId).get(1);
             String searchPipeline = indexAndQueries.get(searchConfigurationId).get(2);
+            String dashboardSearchConfigName = indexAndQueries.get(searchConfigurationId).get(3);
+            String dashboardQuerySetName = indexAndQueries.get(searchConfigurationId).get(4);
 
             if (Objects.isNull(experimentVariants) || experimentVariants.isEmpty()) {
                 processSearchConfigurationWithEmptyExperimentOptions(
@@ -327,8 +340,11 @@ public class MetricsHelper {
                     index,
                     query,
                     searchPipeline,
+                    dashboardSearchConfigName,
+                    dashboardQuerySetName,
                     hasFailure,
-                    pendingConfigurations
+                    pendingConfigurations,
+                    experimentId
                 );
             } else {
                 processSearchConfigurationWithHybridExperimentOptions(
@@ -375,8 +391,11 @@ public class MetricsHelper {
         String index,
         String query,
         String searchPipeline,
+        String dashboardSearchConfigName,
+        String dashboardQuerySetName,
         AtomicBoolean hasFailure,
-        AtomicInteger pendingConfigurations
+        AtomicInteger pendingConfigurations,
+        String experimentId
     ) {
         SearchRequest searchRequest = buildSearchRequest(index, query, queryText, searchPipeline, size);
         final String evaluationId = UUID.randomUUID().toString();
@@ -426,6 +445,36 @@ public class MetricsHelper {
                         hasFailure.set(true);
                         listener.onFailure(error);
                     }));
+
+                    // Create dashboard evaluation results for all metrics
+                    metrics.forEach((metricEntry) -> {
+                        String metricName = metricEntry.get("metric").toString();
+                        double metricValue = (double)metricEntry.get("value");
+                        final String resultId = UUID.randomUUID().toString();
+
+                        // Use experimentId rather than evaluationId
+                        // In the Dashboards, an evaluation refers to an experiment, therefore that is what we use
+                        DashboardEvaluationResult dashboardEvaluationResult = new DashboardEvaluationResult(
+                            resultId,
+                            TimeUtils.getTimestamp(),
+                            dashboardSearchConfigName,
+                            dashboardQuerySetName,
+                            queryText,
+                            metricName,
+                            (float)metricValue,
+                            DASHBOARD_APPLICATION_NAME,
+                            experimentId
+                        );
+
+                        // Store dashboard evaluation result
+                        dashboardEvaluationResultDao.putDashboardEvaluationResult(
+                            dashboardEvaluationResult,
+                            ActionListener.wrap(
+                                success -> log.debug("Successfully stored dashboard evaluation result for evaluation ID: {} and metric: {}", evaluationId, metricName),
+                                error -> log.error("Failed to store dashboard evaluation result for evaluation ID: {} and metric: {}", evaluationId, metricName, error)
+                            )
+                        );
+                    });
                 } catch (Exception e) {
                     hasFailure.set(true);
                     listener.onFailure(e);

--- a/src/main/java/org/opensearch/searchrelevance/metrics/MetricsHelper.java
+++ b/src/main/java/org/opensearch/searchrelevance/metrics/MetricsHelper.java
@@ -359,7 +359,9 @@ public class MetricsHelper {
                     query,
                     hasFailure,
                     pendingConfigurations,
-                    experimentVariants
+                    experimentVariants,
+                    dashboardSearchConfigName,
+                    dashboardQuerySetName
                 );
             }
         }
@@ -463,7 +465,8 @@ public class MetricsHelper {
                             metricName,
                             (float)metricValue,
                             DASHBOARD_APPLICATION_NAME,
-                            experimentId
+                            experimentId,
+                            ""
                         );
 
                         // Store dashboard evaluation result
@@ -501,7 +504,9 @@ public class MetricsHelper {
         String query,
         AtomicBoolean hasFailure,
         AtomicInteger pendingConfigurations,
-        List<ExperimentVariant> experimentVariants
+        List<ExperimentVariant> experimentVariants,
+        String dashboardSearchConfigName,
+        String dashboardQuerySetName
     ) {
         if (Objects.isNull(experimentVariants) || experimentVariants.isEmpty()) {
             throw new IllegalArgumentException("experiment variant for hybrid search cannot be empty");
@@ -547,6 +552,36 @@ public class MetricsHelper {
                         List<String> docIds = Arrays.stream(hits).map(SearchHit::getId).collect(Collectors.toList());
 
                         List<Map<String, Object>> metrics = calculateEvaluationMetrics(docIds, docIdToScores, size);
+                        
+                        // Create dashboard evaluation results for all metrics
+                        metrics.forEach((metricEntry) -> {
+                            String metricName = metricEntry.get("metric").toString();
+                            double metricValue = (double)metricEntry.get("value");
+                            final String resultId = UUID.randomUUID().toString();
+
+                            DashboardEvaluationResult dashboardEvaluationResult = new DashboardEvaluationResult(
+                                resultId,
+                                TimeUtils.getTimestamp(),
+                                dashboardSearchConfigName,
+                                dashboardQuerySetName,
+                                queryText,
+                                metricName,
+                                (float)metricValue,
+                                DASHBOARD_APPLICATION_NAME,
+                                experimentVariant.getExperimentId(),
+                                experimentVariant.getLabel()
+                            );
+
+                            // Store dashboard evaluation result
+                            dashboardEvaluationResultDao.putDashboardEvaluationResult(
+                                dashboardEvaluationResult,
+                                ActionListener.wrap(
+                                    success -> log.debug("Successfully stored dashboard evaluation result for evaluation ID: {} and metric: {}", evaluationId, metricName),
+                                    error -> log.error("Failed to store dashboard evaluation result for evaluation ID: {} and metric: {}", evaluationId, metricName, error)
+                                )
+                            );
+                        });
+                        
                         EvaluationResult evaluationResult = new EvaluationResult(
                             evaluationId,
                             TimeUtils.getTimestamp(),
@@ -565,7 +600,8 @@ public class MetricsHelper {
                                 AsyncStatus.COMPLETED,
                                 experimentVariant.getExperimentId(),
                                 experimentVariant.getParameters(),
-                                Map.of("evaluationResultId", evaluationId)
+                                Map.of("evaluationResultId", evaluationId),
+                                experimentVariant.getLabel()
                             );
                             StepListener<IndexResponse> voidStepListener = new StepListener<>();
                             experimentVariantDao.updateExperimentVariant(experimentVariantResult, voidStepListener);
@@ -615,7 +651,8 @@ public class MetricsHelper {
                         AsyncStatus.ERROR,
                         experimentVariant.getExperimentId(),
                         experimentVariant.getParameters(),
-                        Map.of("evaluationResultId", evaluationId)
+                        Map.of("evaluationResultId", evaluationId),
+                        experimentVariant.getLabel()
                     );
                     experimentVariantDao.updateExperimentVariant(experimentVariantResult, ActionListener.wrap(success -> {}, error -> {
                         hasFailure.set(true);

--- a/src/main/java/org/opensearch/searchrelevance/metrics/MetricsHelper.java
+++ b/src/main/java/org/opensearch/searchrelevance/metrics/MetricsHelper.java
@@ -427,57 +427,52 @@ public class MetricsHelper {
                     List<String> docIds = Arrays.stream(hits).map(SearchHit::getId).collect(Collectors.toList());
 
                     List<Map<String, Object>> metrics = calculateEvaluationMetrics(docIds, docIdToScores, size);
-                    EvaluationResult evaluationResult = new EvaluationResult(
+                    
+                    // Create dashboard evaluation results for all metrics first, then create EvaluationResult
+                    populateDashboardEvaluationResultsSequentially(
+                        metrics,
                         evaluationId,
-                        TimeUtils.getTimestamp(),
-                        searchConfigurationId,
+                        dashboardSearchConfigName,
+                        dashboardQuerySetName,
                         queryText,
-                        judgmentIds,
-                        docIds,
-                        metrics
-                    );
+                        experimentId,
+                        "",
+                        new ActionListener<Void>() {
+                            @Override
+                            public void onResponse(Void response) {
+                                log.debug("Successfully completed dashboard evaluation results population for evaluation ID: {}", evaluationId);
+                                
+                                // Now create the EvaluationResult after dashboard results are populated
+                                EvaluationResult evaluationResult = new EvaluationResult(
+                                    evaluationId,
+                                    TimeUtils.getTimestamp(),
+                                    searchConfigurationId,
+                                    queryText,
+                                    judgmentIds,
+                                    docIds,
+                                    metrics
+                                );
 
-                    evaluationResultDao.putEvaluationResult(evaluationResult, ActionListener.wrap(success -> {
-                        configToEvalIds.put(POINTWISE_FIELD_NAME_SEARCH_CONFIGURATION_ID, searchConfigurationId);
-                        configToEvalIds.put(POINTWISE_FIELD_NAME_EVALUATION_ID, evaluationId);
-                        if (pendingConfigurations.decrementAndGet() == 0) {
-                            listener.onResponse(configToEvalIds);
+                                evaluationResultDao.putEvaluationResult(evaluationResult, ActionListener.wrap(success -> {
+                                    configToEvalIds.put(POINTWISE_FIELD_NAME_SEARCH_CONFIGURATION_ID, searchConfigurationId);
+                                    configToEvalIds.put(POINTWISE_FIELD_NAME_EVALUATION_ID, evaluationId);
+                                    if (pendingConfigurations.decrementAndGet() == 0) {
+                                        listener.onResponse(configToEvalIds);
+                                    }
+                                }, error -> {
+                                    hasFailure.set(true);
+                                    listener.onFailure(error);
+                                }));
+                            }
+
+                            @Override
+                            public void onFailure(Exception e) {
+                                log.error("Failed to populate dashboard evaluation results for evaluation ID: {}", evaluationId, e);
+                                hasFailure.set(true);
+                                listener.onFailure(e);
+                            }
                         }
-                    }, error -> {
-                        hasFailure.set(true);
-                        listener.onFailure(error);
-                    }));
-
-                    // Create dashboard evaluation results for all metrics
-                    metrics.forEach((metricEntry) -> {
-                        String metricName = metricEntry.get("metric").toString();
-                        double metricValue = (double)metricEntry.get("value");
-                        final String resultId = UUID.randomUUID().toString();
-
-                        // Use experimentId rather than evaluationId
-                        // In the Dashboards, an evaluation refers to an experiment, therefore that is what we use
-                        DashboardEvaluationResult dashboardEvaluationResult = new DashboardEvaluationResult(
-                            resultId,
-                            TimeUtils.getTimestamp(),
-                            dashboardSearchConfigName,
-                            dashboardQuerySetName,
-                            queryText,
-                            metricName,
-                            (float)metricValue,
-                            DASHBOARD_APPLICATION_NAME,
-                            experimentId,
-                            ""
-                        );
-
-                        // Store dashboard evaluation result
-                        dashboardEvaluationResultDao.putDashboardEvaluationResult(
-                            dashboardEvaluationResult,
-                            ActionListener.wrap(
-                                success -> log.debug("Successfully stored dashboard evaluation result for evaluation ID: {} and metric: {}", evaluationId, metricName),
-                                error -> log.error("Failed to store dashboard evaluation result for evaluation ID: {} and metric: {}", evaluationId, metricName, error)
-                            )
-                        );
-                    });
+                    );
                 } catch (Exception e) {
                     hasFailure.set(true);
                     listener.onFailure(e);
@@ -553,89 +548,85 @@ public class MetricsHelper {
 
                         List<Map<String, Object>> metrics = calculateEvaluationMetrics(docIds, docIdToScores, size);
                         
-                        // Create dashboard evaluation results for all metrics
-                        metrics.forEach((metricEntry) -> {
-                            String metricName = metricEntry.get("metric").toString();
-                            double metricValue = (double)metricEntry.get("value");
-                            final String resultId = UUID.randomUUID().toString();
-
-                            DashboardEvaluationResult dashboardEvaluationResult = new DashboardEvaluationResult(
-                                resultId,
-                                TimeUtils.getTimestamp(),
-                                dashboardSearchConfigName,
-                                dashboardQuerySetName,
-                                queryText,
-                                metricName,
-                                (float)metricValue,
-                                DASHBOARD_APPLICATION_NAME,
-                                experimentVariant.getExperimentId(),
-                                experimentVariant.getLabel()
-                            );
-
-                            // Store dashboard evaluation result
-                            dashboardEvaluationResultDao.putDashboardEvaluationResult(
-                                dashboardEvaluationResult,
-                                ActionListener.wrap(
-                                    success -> log.debug("Successfully stored dashboard evaluation result for evaluation ID: {} and metric: {}", evaluationId, metricName),
-                                    error -> log.error("Failed to store dashboard evaluation result for evaluation ID: {} and metric: {}", evaluationId, metricName, error)
-                                )
-                            );
-                        });
-                        
-                        EvaluationResult evaluationResult = new EvaluationResult(
+                        // Create dashboard evaluation results for all metrics first, then create EvaluationResult
+                        populateDashboardEvaluationResultsSequentially(
+                            metrics,
                             evaluationId,
-                            TimeUtils.getTimestamp(),
-                            searchConfigurationId,
+                            dashboardSearchConfigName,
+                            dashboardQuerySetName,
                             queryText,
-                            judgmentIds,
-                            docIds,
-                            metrics
+                            experimentVariant.getExperimentId(),
+                            experimentVariant.getLabel(),
+                            new ActionListener<Void>() {
+                                @Override
+                                public void onResponse(Void response) {
+                                    log.debug("Successfully completed dashboard evaluation results population for evaluation ID: {}", evaluationId);
+                                    
+                                    // Now create the EvaluationResult after dashboard results are populated
+                                    EvaluationResult evaluationResult = new EvaluationResult(
+                                        evaluationId,
+                                        TimeUtils.getTimestamp(),
+                                        searchConfigurationId,
+                                        queryText,
+                                        judgmentIds,
+                                        docIds,
+                                        metrics
+                                    );
+
+                                    evaluationResultDao.putEvaluationResult(evaluationResult, ActionListener.wrap(success -> {
+                                        ExperimentVariant experimentVariantResult = new ExperimentVariant(
+                                            experimentVariant.getId(),
+                                            TimeUtils.getTimestamp(),
+                                            experimentVariant.getType(),
+                                            AsyncStatus.COMPLETED,
+                                            experimentVariant.getExperimentId(),
+                                            experimentVariant.getParameters(),
+                                            Map.of("evaluationResultId", evaluationId),
+                                            experimentVariant.getLabel()
+                                        );
+                                        StepListener<IndexResponse> voidStepListener = new StepListener<>();
+                                        experimentVariantDao.updateExperimentVariant(experimentVariantResult, voidStepListener);
+                                        voidStepListener.whenComplete(indexResponse -> {
+                                            synchronized (configToExperimentVariants) {
+                                                Map<String, Object> map = (Map<String, Object>) configToExperimentVariants.get(searchConfigurationId);
+                                                map.put(experimentVariant.getId(), evaluationId);
+                                            }
+                                            if (pendingConfigurations.decrementAndGet() == 0) {
+                                                Map<String, Object> transformedConfigToExperimentVariants = new HashMap<>();
+                                                transformedConfigToExperimentVariants.put(
+                                                    POINTWISE_FIELD_NAME_SEARCH_CONFIGURATION_ID,
+                                                    searchConfigurationId
+                                                );
+
+                                                List<Map<String, Object>> evaluationResults = new ArrayList<>();
+                                                Map<String, Object> configMap = (Map<String, Object>) configToExperimentVariants.get(
+                                                    searchConfigurationId
+                                                );
+                                                configMap.forEach((variantId, evalId) -> {
+                                                    Map<String, Object> result = new HashMap<>();
+                                                    result.put(POINTWISE_FIELD_NAME_EVALUATION_ID, evalId);
+                                                    result.put(POINTWISE_FIELD_NAME_EXPERIMENT_VARIANT_ID, variantId);
+                                                    evaluationResults.add(result);
+                                                });
+                                                transformedConfigToExperimentVariants.put(POINTWISE_FIELD_NAME_EVALUATION_RESULTS, evaluationResults);
+
+                                                listener.onResponse(transformedConfigToExperimentVariants);
+                                            }
+                                        }, listener::onFailure);
+                                    }, error -> {
+                                        hasFailure.set(true);
+                                        listener.onFailure(error);
+                                    }));
+                                }
+
+                                @Override
+                                public void onFailure(Exception e) {
+                                    log.error("Failed to populate dashboard evaluation results for evaluation ID: {}", evaluationId, e);
+                                    hasFailure.set(true);
+                                    listener.onFailure(e);
+                                }
+                            }
                         );
-
-                        evaluationResultDao.putEvaluationResult(evaluationResult, ActionListener.wrap(success -> {
-                            ExperimentVariant experimentVariantResult = new ExperimentVariant(
-                                experimentVariant.getId(),
-                                TimeUtils.getTimestamp(),
-                                experimentVariant.getType(),
-                                AsyncStatus.COMPLETED,
-                                experimentVariant.getExperimentId(),
-                                experimentVariant.getParameters(),
-                                Map.of("evaluationResultId", evaluationId),
-                                experimentVariant.getLabel()
-                            );
-                            StepListener<IndexResponse> voidStepListener = new StepListener<>();
-                            experimentVariantDao.updateExperimentVariant(experimentVariantResult, voidStepListener);
-                            voidStepListener.whenComplete(indexResponse -> {
-                                synchronized (configToExperimentVariants) {
-                                    Map<String, Object> map = (Map<String, Object>) configToExperimentVariants.get(searchConfigurationId);
-                                    map.put(experimentVariant.getId(), evaluationId);
-                                }
-                                if (pendingConfigurations.decrementAndGet() == 0) {
-                                    Map<String, Object> transformedConfigToExperimentVariants = new HashMap<>();
-                                    transformedConfigToExperimentVariants.put(
-                                        POINTWISE_FIELD_NAME_SEARCH_CONFIGURATION_ID,
-                                        searchConfigurationId
-                                    );
-
-                                    List<Map<String, Object>> evaluationResults = new ArrayList<>();
-                                    Map<String, Object> configMap = (Map<String, Object>) configToExperimentVariants.get(
-                                        searchConfigurationId
-                                    );
-                                    configMap.forEach((variantId, evalId) -> {
-                                        Map<String, Object> result = new HashMap<>();
-                                        result.put(POINTWISE_FIELD_NAME_EVALUATION_ID, evalId);
-                                        result.put(POINTWISE_FIELD_NAME_EXPERIMENT_VARIANT_ID, variantId);
-                                        evaluationResults.add(result);
-                                    });
-                                    transformedConfigToExperimentVariants.put(POINTWISE_FIELD_NAME_EVALUATION_RESULTS, evaluationResults);
-
-                                    listener.onResponse(transformedConfigToExperimentVariants);
-                                }
-                            }, listener::onFailure);
-                        }, error -> {
-                            hasFailure.set(true);
-                            listener.onFailure(error);
-                        }));
                     } catch (Exception e) {
                         hasFailure.set(true);
                         listener.onFailure(e);
@@ -664,5 +655,99 @@ public class MetricsHelper {
                 }
             });
         }
+    }
+
+    /**
+     * Helper method to populate dashboard evaluation results sequentially
+     * Only populates the next metric if the previous one was successfully stored
+     */
+    private void populateDashboardEvaluationResultsSequentially(
+        List<Map<String, Object>> metrics,
+        String evaluationId,
+        String dashboardSearchConfigName,
+        String dashboardQuerySetName,
+        String queryText,
+        String experimentId,
+        String experimentVariantLabel,
+        ActionListener<Void> completionListener
+    ) {
+        if (metrics == null || metrics.isEmpty()) {
+            completionListener.onResponse(null);
+            return;
+        }
+
+        populateDashboardEvaluationResultRecursive(
+            metrics,
+            0,
+            evaluationId,
+            dashboardSearchConfigName,
+            dashboardQuerySetName,
+            queryText,
+            experimentId,
+            experimentVariantLabel,
+            completionListener
+        );
+    }
+
+    private void populateDashboardEvaluationResultRecursive(
+        List<Map<String, Object>> metrics,
+        int currentIndex,
+        String evaluationId,
+        String dashboardSearchConfigName,
+        String dashboardQuerySetName,
+        String queryText,
+        String experimentId,
+        String experimentVariantLabel,
+        ActionListener<Void> completionListener
+    ) {
+        if (currentIndex >= metrics.size()) {
+            // All metrics have been processed successfully
+            completionListener.onResponse(null);
+            return;
+        }
+
+        Map<String, Object> metricEntry = metrics.get(currentIndex);
+        String metricName = metricEntry.get("metric").toString();
+        double metricValue = (double) metricEntry.get("value");
+        final String resultId = UUID.randomUUID().toString();
+
+        DashboardEvaluationResult dashboardEvaluationResult = new DashboardEvaluationResult(
+            resultId,
+            TimeUtils.getTimestamp(),
+            dashboardSearchConfigName,
+            dashboardQuerySetName,
+            queryText,
+            metricName,
+            (float) metricValue,
+            DASHBOARD_APPLICATION_NAME,
+            experimentId,
+            experimentVariantLabel
+        );
+
+        // Store dashboard evaluation result
+        dashboardEvaluationResultDao.putDashboardEvaluationResult(
+            dashboardEvaluationResult,
+            ActionListener.wrap(
+                success -> {
+                    log.debug("Successfully stored dashboard evaluation result for evaluation ID: {} and metric: {}", evaluationId, metricName);
+                    // Process the next metric recursively
+                    populateDashboardEvaluationResultRecursive(
+                        metrics,
+                        currentIndex + 1,
+                        evaluationId,
+                        dashboardSearchConfigName,
+                        dashboardQuerySetName,
+                        queryText,
+                        experimentId,
+                        experimentVariantLabel,
+                        completionListener
+                    );
+                },
+                error -> {
+                    log.error("Failed to store dashboard evaluation result for evaluation ID: {} and metric: {}", evaluationId, metricName, error);
+                    completionListener.onFailure(error);
+                }
+            )
+        );
     }
 }

--- a/src/main/java/org/opensearch/searchrelevance/model/DashboardEvaluationResult.java
+++ b/src/main/java/org/opensearch/searchrelevance/model/DashboardEvaluationResult.java
@@ -26,6 +26,7 @@ public class DashboardEvaluationResult implements ToXContentObject {
     public static final String VALUE = "value";
     public static final String APPLICATION = "application";
     public static final String EVALUATION_ID = "evaluation_id";
+    public static final String VARIANT_LABEL = "variant_label";
 
     private final String id;
     private final String timestamp;
@@ -36,6 +37,7 @@ public class DashboardEvaluationResult implements ToXContentObject {
     private final float value;
     private final String application;
     private final String evaluationId;
+    private final String variantLabel;
 
     public DashboardEvaluationResult(
         String id,
@@ -46,7 +48,8 @@ public class DashboardEvaluationResult implements ToXContentObject {
         String metric,
         float value,
         String application,
-        String evaluationId
+        String evaluationId,
+        String variantLabel
     ) {
         this.id = id;
         this.timestamp = timestamp;
@@ -57,6 +60,7 @@ public class DashboardEvaluationResult implements ToXContentObject {
         this.value = value;
         this.application = application;
         this.evaluationId = evaluationId;
+        this.variantLabel = variantLabel;
     }
 
     @Override
@@ -71,6 +75,7 @@ public class DashboardEvaluationResult implements ToXContentObject {
         xContentBuilder.field(VALUE, this.value);
         xContentBuilder.field(APPLICATION, this.application.trim());
         xContentBuilder.field(EVALUATION_ID, this.evaluationId.trim());
+        xContentBuilder.field(VARIANT_LABEL, this.variantLabel.trim());
         return xContentBuilder.endObject();
     }
 
@@ -108,5 +113,9 @@ public class DashboardEvaluationResult implements ToXContentObject {
 
     public String evaluationId() {
         return evaluationId;
+    }
+
+    public String variantLabel() {
+        return variantLabel;
     }
 } 

--- a/src/main/java/org/opensearch/searchrelevance/model/DashboardEvaluationResult.java
+++ b/src/main/java/org/opensearch/searchrelevance/model/DashboardEvaluationResult.java
@@ -1,0 +1,112 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+package org.opensearch.searchrelevance.model;
+
+import java.io.IOException;
+import java.util.Map;
+
+import org.opensearch.core.xcontent.ToXContentObject;
+import org.opensearch.core.xcontent.XContentBuilder;
+
+/**
+ * DashboardEvaluationResult is a system index object that stores evaluation results for dashboard display.
+ */
+public class DashboardEvaluationResult implements ToXContentObject {
+    public static final String ID = "id";
+    public static final String TIMESTAMP = "timestamp";
+    public static final String SEARCH_CONFIG = "search_config";
+    public static final String QUERY_SET_ID = "query_set_id";
+    public static final String QUERY = "query";
+    public static final String METRIC = "metric";
+    public static final String VALUE = "value";
+    public static final String APPLICATION = "application";
+    public static final String EVALUATION_ID = "evaluation_id";
+
+    private final String id;
+    private final String timestamp;
+    private final String searchConfig;
+    private final String querySetId;
+    private final String query;
+    private final String metric;
+    private final float value;
+    private final String application;
+    private final String evaluationId;
+
+    public DashboardEvaluationResult(
+        String id,
+        String timestamp,
+        String searchConfig,
+        String querySetId,
+        String query,
+        String metric,
+        float value,
+        String application,
+        String evaluationId
+    ) {
+        this.id = id;
+        this.timestamp = timestamp;
+        this.searchConfig = searchConfig;
+        this.querySetId = querySetId;
+        this.query = query;
+        this.metric = metric;
+        this.value = value;
+        this.application = application;
+        this.evaluationId = evaluationId;
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        XContentBuilder xContentBuilder = builder.startObject();
+        xContentBuilder.field(ID, this.id.trim());
+        xContentBuilder.field(TIMESTAMP, this.timestamp.trim());
+        xContentBuilder.field(SEARCH_CONFIG, this.searchConfig.trim());
+        xContentBuilder.field(QUERY_SET_ID, this.querySetId.trim());
+        xContentBuilder.field(QUERY, this.query.trim());
+        xContentBuilder.field(METRIC, this.metric.trim());
+        xContentBuilder.field(VALUE, this.value);
+        xContentBuilder.field(APPLICATION, this.application.trim());
+        xContentBuilder.field(EVALUATION_ID, this.evaluationId.trim());
+        return xContentBuilder.endObject();
+    }
+
+    public String id() {
+        return id;
+    }
+
+    public String timestamp() {
+        return timestamp;
+    }
+
+    public String searchConfig() {
+        return searchConfig;
+    }
+
+    public String querySetId() {
+        return querySetId;
+    }
+
+    public String query() {
+        return query;
+    }
+
+    public String metric() {
+        return metric;
+    }
+
+    public float value() {
+        return value;
+    }
+
+    public String application() {
+        return application;
+    }
+
+    public String evaluationId() {
+        return evaluationId;
+    }
+} 

--- a/src/main/java/org/opensearch/searchrelevance/model/ExperimentVariant.java
+++ b/src/main/java/org/opensearch/searchrelevance/model/ExperimentVariant.java
@@ -31,6 +31,7 @@ public class ExperimentVariant implements ToXContentObject {
     public static final String EXPERIMENT_ID = "experimentId";
     public static final String PARAMETERS = "parameters";
     public static final String RESULTS = "results";
+    public static final String LABEL = "label";
 
     /**
      * Identifier of the system index
@@ -42,6 +43,7 @@ public class ExperimentVariant implements ToXContentObject {
     private final String experimentId;
     private final Map<String, Object> parameters;
     private final Map<String, Object> results;
+    private final String label;
 
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
@@ -53,6 +55,9 @@ public class ExperimentVariant implements ToXContentObject {
         xContentBuilder.field(EXPERIMENT_ID, this.experimentId.trim());
         xContentBuilder.field(PARAMETERS, this.parameters);
         xContentBuilder.field(RESULTS, this.results);
+        if (this.label != null) {
+            xContentBuilder.field(LABEL, this.label);
+        }
         return xContentBuilder.endObject();
     }
 }

--- a/src/main/java/org/opensearch/searchrelevance/plugin/SearchRelevancePlugin.java
+++ b/src/main/java/org/opensearch/searchrelevance/plugin/SearchRelevancePlugin.java
@@ -42,6 +42,7 @@ import org.opensearch.repositories.RepositoriesService;
 import org.opensearch.rest.RestController;
 import org.opensearch.rest.RestHandler;
 import org.opensearch.script.ScriptService;
+import org.opensearch.searchrelevance.dao.DashboardEvaluationResultDao;
 import org.opensearch.searchrelevance.dao.EvaluationResultDao;
 import org.opensearch.searchrelevance.dao.ExperimentDao;
 import org.opensearch.searchrelevance.dao.ExperimentVariantDao;
@@ -117,6 +118,7 @@ public class SearchRelevancePlugin extends Plugin implements ActionPlugin, Syste
     private JudgmentDao judgmentDao;
     private EvaluationResultDao evaluationResultDao;
     private JudgmentCacheDao judgmentCacheDao;
+    private DashboardEvaluationResultDao dashboardEvaluationResultDao;
     private MLAccessor mlAccessor;
     private MetricsHelper metricsHelper;
     private SearchRelevanceSettingsAccessor settingsAccessor;
@@ -155,9 +157,17 @@ public class SearchRelevancePlugin extends Plugin implements ActionPlugin, Syste
         this.judgmentDao = new JudgmentDao(searchRelevanceIndicesManager);
         this.evaluationResultDao = new EvaluationResultDao(searchRelevanceIndicesManager);
         this.judgmentCacheDao = new JudgmentCacheDao(searchRelevanceIndicesManager);
+        this.dashboardEvaluationResultDao = new DashboardEvaluationResultDao(searchRelevanceIndicesManager);
         MachineLearningNodeClient mlClient = new MachineLearningNodeClient(client);
         this.mlAccessor = new MLAccessor(mlClient);
-        this.metricsHelper = new MetricsHelper(clusterService, client, judgmentDao, evaluationResultDao, experimentVariantDao);
+        this.metricsHelper = new MetricsHelper(
+            clusterService,
+            client,
+            judgmentDao,
+            evaluationResultDao,
+            experimentVariantDao,
+            dashboardEvaluationResultDao
+        );
         this.settingsAccessor = new SearchRelevanceSettingsAccessor(clusterService, environment.settings());
         this.clusterUtil = new ClusterUtil(clusterService);
         this.infoStatsManager = new InfoStatsManager(settingsAccessor);

--- a/src/main/java/org/opensearch/searchrelevance/transport/experiment/PutExperimentTransportAction.java
+++ b/src/main/java/org/opensearch/searchrelevance/transport/experiment/PutExperimentTransportAction.java
@@ -246,6 +246,15 @@ public class PutExperimentTransportAction extends HandledTransportAction<PutExpe
                         )
                     );
                     String experimentVariantId = UUID.randomUUID().toString();
+                    
+                    float[] weightsArray = experimentVariantDTO.getQueryWeightsForCombination();
+                    String firstWeight = weightsArray != null && weightsArray.length > 0 ? String.valueOf(weightsArray[0]) : "null";
+                    
+                    String variantLabel = makeDashName(experimentVariantId,
+                        firstWeight + "," +
+                        experimentVariantDTO.getNormalizationTechnique() + "," +
+                        experimentVariantDTO.getCombinationTechnique()
+                    );
                     ExperimentVariant experimentVariant = new ExperimentVariant(
                         experimentVariantId,
                         TimeUtils.getTimestamp(),
@@ -253,7 +262,8 @@ public class PutExperimentTransportAction extends HandledTransportAction<PutExpe
                         AsyncStatus.PROCESSING,
                         experimentId,
                         parameters,
-                        Map.of()
+                        Map.of(),
+                        variantLabel
                     );
                     experimentVariants.add(experimentVariant);
                     experimentVariantDao.putExperimentVariant(experimentVariant, ActionListener.wrap(response -> {}, e -> {}));

--- a/src/main/resources/mappings/dashboard_evaluation_result.json
+++ b/src/main/resources/mappings/dashboard_evaluation_result.json
@@ -1,5 +1,5 @@
 {
-  "properties": {
+  "properties":_ {
     "id": { "type": "keyword" },
     "timestamp": { "type": "date", "format": "strict_date_time" },
     "search_config": { "type": "keyword" },
@@ -8,6 +8,6 @@
     "metric": { "type": "keyword" },
     "value": { "type": "float" },
     "application": { "type": "keyword" },
-    "evaluation_id": { "type": "keyword" }
-  }
+    "evaluation_id": { "type": "keyword" },
+    "variant_label": { "type": "keyword" }
 } 

--- a/src/main/resources/mappings/dashboard_evaluation_result.json
+++ b/src/main/resources/mappings/dashboard_evaluation_result.json
@@ -1,0 +1,13 @@
+{
+  "properties": {
+    "id": { "type": "keyword" },
+    "timestamp": { "type": "date", "format": "strict_date_time" },
+    "search_config": { "type": "keyword" },
+    "query_set_id": { "type": "keyword" },
+    "query": { "type": "keyword" },
+    "metric": { "type": "keyword" },
+    "value": { "type": "float" },
+    "application": { "type": "keyword" },
+    "evaluation_id": { "type": "keyword" }
+  }
+} 

--- a/src/main/resources/mappings/dashboard_evaluation_result.json
+++ b/src/main/resources/mappings/dashboard_evaluation_result.json
@@ -1,5 +1,5 @@
 {
-  "properties":_ {
+  "properties": {
     "id": { "type": "keyword" },
     "timestamp": { "type": "date", "format": "strict_date_time" },
     "search_config": { "type": "keyword" },
@@ -10,4 +10,5 @@
     "application": { "type": "keyword" },
     "evaluation_id": { "type": "keyword" },
     "variant_label": { "type": "keyword" }
+  }
 } 

--- a/src/main/resources/mappings/experiment_variant.json
+++ b/src/main/resources/mappings/experiment_variant.json
@@ -5,6 +5,7 @@
     "type": { "type": "keyword" },
     "status": { "type": "keyword" },
     "experimentId": { "type": "keyword" },
+    "label": { "type": "keyword" },
     "parameters": { "type":  "object", "dynamic": false },
     "results": {
       "type": "nested",

--- a/src/test/java/org/opensearch/searchrelevance/experiment/QuerySourceUtilTests.java
+++ b/src/test/java/org/opensearch/searchrelevance/experiment/QuerySourceUtilTests.java
@@ -29,6 +29,7 @@ public class QuerySourceUtilTests extends OpenSearchTestCase {
             .parameters(
                 Map.of(EXPERIMENT_OPTION_NORMALIZATION_TECHNIQUE, "min_max", EXPERIMENT_OPTION_COMBINATION_TECHNIQUE, "arithmetic_mean")
             )
+            .label("test-label")
             .build();
 
         // When


### PR DESCRIPTION
### Description
This PR stores experiment results data in a form that can be used by Dashboards, in particular:
 * The plugin uses an additional index `srw_metrics_search-relevance-evaluation-result`, using the prefix `srw_metrics*` expected by the evaluation Dashboards.
 * The metrics data is disaggregated such that there is a row per metric, value pair.

### Example data
Note in particular:
 * evaluation_id matches the experiment id used in the SRW plugin.
 * The search configuration and query set fields are populated by the beginning of the UUID and it uses the user given id after the column (SC0 and QS0, terrible names, I know).

```
    "hits": [
      {
        "_index": "srw_metrics_search-relevance-evaluation-result",
        "_id": "26dd55d5-1f9c-4baa-b088-4ca162bfecbe",
        "_score": 1,
        "_source": {
          "id": "26dd55d5-1f9c-4baa-b088-4ca162bfecbe",
          "timestamp": "2025-06-05T13:32:26.864Z",
          "search_config": "1ce26df7: SC0",
          "query_set_id": "60e18d19: QS0",
          "query": "computer",
          "metric": "coverage",
          "value": "0.0",
          "application": "search-relevance-workbench",
          "evaluation_id": "67b4dedd-5b07-4313-ac49-cdebbe80a383"
        }
      },
      {
        "_index": "srw_metrics_search-relevance-evaluation-result",
        "_id": "8642eb46-d399-43ee-a2b8-dff98de16f3c",
        "_score": 1,
        "_source": {
          "id": "8642eb46-d399-43ee-a2b8-dff98de16f3c",
          "timestamp": "2025-06-05T13:32:26.868Z",
          "search_config": "1ce26df7: SC0",
          "query_set_id": "60e18d19: QS0",
          "query": "computer",
          "metric": "precision@5",
          "value": "0.0",
          "application": "search-relevance-workbench",
          "evaluation_id": "67b4dedd-5b07-4313-ac49-cdebbe80a383"
        }
      },

```

### Still to improve
The code that creates the Dashboard metrics does not at the moment have a dependency to ensure that the "COMPLETED" status is only set when all entries are created.

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
