### PR TITLE
Set limit for number of fields programmatically during index creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,6 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Removed
 
 ### Fixed
-
  - Update demo setup to be include ubi and ecommerce data sets and run in OS 3.1 ([#10](https://github.com/opensearch-project/search-relevance/issues/10))
  - Build search request with normal parsing and wrapper query ([#22](https://github.com/opensearch-project/search-relevance/pull/22))
  - Change aggregation field from `action_name.keyword` to `action_name` to fix implicit judgments calculation ([#15](https://github.com/opensearch-project/search-relevance/issues/10)).
@@ -28,5 +27,6 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
  - Enable Search Relevance backend plugin as part of running demo scripts. ([#60](https://github.com/opensearch-project/search-relevance/pull/60))
  - Move from Judgments being "scores" to Judgments being "ratings".  ([#64](https://github.com/opensearch-project/search-relevance/pull/64))
  - Extend hybrid search optimizer demo script to use models. ([#69](https://github.com/opensearch-project/search-relevance/pull/69))
+ - Set limit for number of fields programmatically during index creation ([#74](https://github.com/opensearch-project/search-relevance/pull/74)
 
 ### Security

--- a/src/main/java/org/opensearch/searchrelevance/common/PluginConstants.java
+++ b/src/main/java/org/opensearch/searchrelevance/common/PluginConstants.java
@@ -34,6 +34,8 @@ public class PluginConstants {
     /** Use %SearchText% to represent wildcard in queryBody and also refer to the text in the search bar */
     public static final String WILDCARD_QUERY_TEXT = "%SearchText%";
 
+    public static final int MAX_TOTAL_FIELDS_LIMIT = 100_000;
+
     /**
      * Indices constants
      */

--- a/src/main/java/org/opensearch/searchrelevance/indices/SearchRelevanceIndicesManager.java
+++ b/src/main/java/org/opensearch/searchrelevance/indices/SearchRelevanceIndicesManager.java
@@ -7,6 +7,9 @@
  */
 package org.opensearch.searchrelevance.indices;
 
+import static org.opensearch.index.mapper.MapperService.INDEX_MAPPING_TOTAL_FIELDS_LIMIT_SETTING;
+import static org.opensearch.searchrelevance.common.PluginConstants.MAX_TOTAL_FIELDS_LIMIT;
+
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
@@ -27,6 +30,7 @@ import org.opensearch.action.search.ShardSearchFailure;
 import org.opensearch.action.support.WriteRequest;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.io.Streams;
+import org.opensearch.common.settings.Settings;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.rest.RestStatus;
 import org.opensearch.core.xcontent.XContentBuilder;
@@ -71,7 +75,8 @@ public class SearchRelevanceIndicesManager {
             stepListener.onResponse(null);
             return;
         }
-        final CreateIndexRequest createIndexRequest = new CreateIndexRequest(indexName).mapping(mapping);
+        Settings settings = Settings.builder().put(INDEX_MAPPING_TOTAL_FIELDS_LIMIT_SETTING.getKey(), MAX_TOTAL_FIELDS_LIMIT).build();
+        final CreateIndexRequest createIndexRequest = new CreateIndexRequest(indexName).mapping(mapping).settings(settings);
         StashedThreadContext.run(client, () -> client.admin().indices().create(createIndexRequest, new ActionListener<>() {
             @Override
             public void onResponse(final CreateIndexResponse createIndexResponse) {

--- a/src/test/data-esci/schema.json
+++ b/src/test/data-esci/schema.json
@@ -3,7 +3,6 @@
     "index": {
       "number_of_shards": 1,
       "number_of_replicas": 0,
-      "mapping.total_fields.limit": 20000,
       "knn": true
     },
     "analysis": {

--- a/src/test/java/org/opensearch/searchrelevance/indices/SearchRelevanceIndicesManagerTests.java
+++ b/src/test/java/org/opensearch/searchrelevance/indices/SearchRelevanceIndicesManagerTests.java
@@ -13,6 +13,8 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.opensearch.index.mapper.MapperService.INDEX_MAPPING_TOTAL_FIELDS_LIMIT_SETTING;
+import static org.opensearch.searchrelevance.common.PluginConstants.MAX_TOTAL_FIELDS_LIMIT;
 import static org.opensearch.searchrelevance.indices.SearchRelevanceIndices.QUERY_SET;
 
 import java.io.IOException;
@@ -121,6 +123,9 @@ public class SearchRelevanceIndicesManagerTests extends OpenSearchTestCase {
         CreateIndexRequest capturedRequest = requestCaptor.getValue();
         assertEquals(QUERY_SET.getIndexName(), capturedRequest.index());
         assertEquals(QUERY_SET.getMapping(), capturedRequest.mappings());
+        Settings actualIndexSettings = capturedRequest.settings();
+        assertNotNull(actualIndexSettings);
+        assertEquals(Integer.toString(MAX_TOTAL_FIELDS_LIMIT), actualIndexSettings.get(INDEX_MAPPING_TOTAL_FIELDS_LIMIT_SETTING.getKey()));
 
         CreateIndexResponse response = new CreateIndexResponse(true, true, QUERY_SET.getIndexName());
         listenerCaptor.getValue().onResponse(response);

--- a/src/test/scripts/demo.sh
+++ b/src/test/scripts/demo.sh
@@ -330,34 +330,6 @@ exe curl -s -X PUT "localhost:9200/_plugins/_search_relevance/judgments" \
 IMPORTED_JUDGMENT_LIST_ID=`jq -r '.judgment_id' < RES`
 
 echo
-echo Expand total fields limit for SRW indexes 
-
-# TODO Fix the bug the we need to increase the number of fields due to our use of dynamice field
-curl -s -X PUT "http://localhost:9200/.plugins-search-relevance-experiment/_settings" \
--H "Content-type: application/json" \
--d'{
-  "index.mapping.total_fields.limit": 20000
-}'
-
-curl -s -X PUT "http://localhost:9200/search-relevance-judgment/_settings" \
--H "Content-type: application/json" \
--d'{
-  "index.mapping.total_fields.limit": 20000
-}'
-
-curl -s -X PUT "http://localhost:9200/search-relevance-evaluation-result/_settings" \
--H "Content-type: application/json" \
--d'{
-  "index.mapping.total_fields.limit": 20000
-}'
-
-curl -s -X PUT "http://localhost:9200/search-relevance-experiment-variant/_settings" \
--H "Content-type: application/json" \
--d'{
-  "index.mapping.total_fields.limit": 20000
-}'
-
-echo
 echo Upload ESCI Judgments 
 
 exe curl -s -X PUT "localhost:9200/_plugins/_search_relevance/judgments" \

--- a/src/test/scripts/demo_hybrid_optimizer.sh
+++ b/src/test/scripts/demo_hybrid_optimizer.sh
@@ -340,14 +340,7 @@ exe curl -s -X GET "http://localhost:9200/_plugins/_search_relevance/experiments
    }'
 
 echo
-echo Upload ESCI Judgments 
-
-# TODO Fix the bug the we arne't creating the judgement index using our defintion in the api
-curl -s -X PUT "http://localhost:9200/search-relevance-judgment/_settings" \
--H "Content-type: application/json" \
--d'{
-  "index.mapping.total_fields.limit": 20000
-}'
+echo Upload ESCI Judgments
 
 exe curl -s -X PUT "localhost:9200/_plugins/_search_relevance/judgments" \
 -H "Content-type: application/json" \


### PR DESCRIPTION
### Description
Programmatically set limit of fields for search relevance indexes to 100,000 instead of default 1,000. We need a note in documentation that explains how customer can increase it themselves if this limit is not enough. 

Strip out commands that increase this limit in demo script.

### Issues Resolved
https://github.com/opensearch-project/search-relevance/issues/71

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
