### PR TITLE
Added command for running integ tests in remote cluster

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -233,6 +233,27 @@ testClusters.integTest {
     setting 'plugins.search_relevance.workbench_enabled', 'true'
 }
 
+// Remote Integration Tests
+task integTestRemote(type: RestIntegTestTask) {
+    testClassesDirs = sourceSets.test.output.classesDirs
+    classpath = sourceSets.test.runtimeClasspath
+
+    systemProperty "https", System.getProperty("https")
+    systemProperty "user", System.getProperty("user")
+    systemProperty "password", System.getProperty("password")
+
+    systemProperty 'cluster.number_of_nodes', "${_numNodes}"
+
+    systemProperty 'tests.security.manager', 'false'
+
+    // run tests only if cluster has been set via system property
+    if (System.getProperty("tests.rest.cluster") != null) {
+        filter {
+            includeTestsMatching "org.opensearch.searchrelevance.*IT"
+        }
+    }
+}
+
 run {
     useCluster testClusters.integTest
 }


### PR DESCRIPTION
### Description
Adding standard gradle command for running integration tests against remote test cluster. Follow [pattern from other repos](https://github.com/search?q=org%3Aopensearch-project+integTestRemote+language%3AGradle&type=code&l=Gradle). Currently security enabled tests are failing in distribution pipeline, I suspect this is because search-relevance lucking such command.

One open question for me is - do we need to enable index setting that opens up SRW feature? 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
