### PR TITLE
Change model for query set to more type restrictive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,14 +20,15 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
  - Update demo setup to be include ubi and ecommerce data sets and run in OS 3.1 ([#10](https://github.com/opensearch-project/search-relevance/issues/10))
  - Build search request with normal parsing and wrapper query ([#22](https://github.com/opensearch-project/search-relevance/pull/22))
  - Change aggregation field from `action_name.keyword` to `action_name` to fix implicit judgments calculation ([#15](https://github.com/opensearch-project/search-relevance/issues/10)).
- - Fix COEC calculation: introduce rank in ClickthroughRate class, fix bucket size for positional aggregation, correct COEC claculation ([#23](https://github.com/opensearch-project/search-relevance/issues/23)).
+ - Fix COEC calculation: introduce rank in ClickthroughRate class, fix bucket size for positional aggregation, correct COEC claculation ([#23](https://github.com/opensearch-project/search-relevance/issues/23))
  - LLM Judgment Processor Improvement ([#27](https://github.com/opensearch-project/search-relevance/pull/27))
  - Deal with experiment processing when no experiment variants exist. ([#45](https://github.com/opensearch-project/search-relevance/pull/45))
  - Extend the `src/test/demo.sh` script to support pointwise and hybrid experiments.
  - Enable Search Relevance backend plugin as part of running demo scripts. ([#60](https://github.com/opensearch-project/search-relevance/pull/60))
  - Move from Judgments being "scores" to Judgments being "ratings".  ([#64](https://github.com/opensearch-project/search-relevance/pull/64))
  - Extend hybrid search optimizer demo script to use models. ([#69](https://github.com/opensearch-project/search-relevance/pull/69))
- - Set limit for number of fields programmatically during index creation ([#74](https://github.com/opensearch-project/search-relevance/pull/74)
- - Change model for Judgment entity ([#77](https://github.com/opensearch-project/search-relevance/pull/77)
+ - Set limit for number of fields programmatically during index creation ([#74](https://github.com/opensearch-project/search-relevance/pull/74))
+ - Change model for Judgment entity ([#77](https://github.com/opensearch-project/search-relevance/pull/77))
+ - Change model for Query Set to more type restrictive ([#86](https://github.com/opensearch-project/search-relevance/pull/86))
 
 ### Security

--- a/src/main/java/org/opensearch/searchrelevance/dao/QuerySetDao.java
+++ b/src/main/java/org/opensearch/searchrelevance/dao/QuerySetDao.java
@@ -12,7 +12,7 @@ import static org.opensearch.searchrelevance.indices.SearchRelevanceIndices.QUER
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import org.apache.logging.log4j.LogManager;
@@ -65,7 +65,7 @@ public class QuerySetDao {
         }
         try {
             searchRelevanceIndicesManager.putDoc(
-                querySet.id(),
+                querySet.getId(),
                 querySet.toXContent(XContentFactory.jsonBuilder(), ToXContent.EMPTY_PARAMS),
                 QUERY_SET,
                 listener
@@ -134,8 +134,8 @@ public class QuerySetDao {
                     LOGGER.info("Successfully get response: [{}]", response);
                     QuerySet querySet = convertToQuerySet(response);
                     LOGGER.debug("Converted response into queryset: [{}]", querySet);
-
-                    results.put(METRICS_QUERY_TEXT_FIELD_NAME, new ArrayList<>(querySet.querySetQueries().keySet()));
+                    List<String> queryTexts = querySet.getQuerySetQueries().stream().map(entry -> (String) entry.get("queryText")).toList();
+                    results.put(METRICS_QUERY_TEXT_FIELD_NAME, queryTexts);
                     stepListener.onResponse(results);
                 } catch (Exception e) {
                     LOGGER.error("Failed to convert response: [{}] into queryset.", response);
@@ -161,7 +161,7 @@ public class QuerySetDao {
             .description((String) sourceMap.get(QuerySet.DESCRIPTION))
             .timestamp((String) sourceMap.get(QuerySet.TIME_STAMP))
             .sampling((String) sourceMap.get(QuerySet.SAMPLING))
-            .querySetQueries((Map<String, Integer>) sourceMap.getOrDefault(QuerySet.QUERY_SET_QUERIES, new HashMap<>()))
+            .querySetQueries((List<Map<String, Object>>) sourceMap.getOrDefault(QuerySet.QUERY_SET_QUERIES, new ArrayList<>()))
             .build();
     }
 }

--- a/src/main/java/org/opensearch/searchrelevance/model/QuerySet.java
+++ b/src/main/java/org/opensearch/searchrelevance/model/QuerySet.java
@@ -8,15 +8,21 @@
 package org.opensearch.searchrelevance.model;
 
 import java.io.IOException;
+import java.util.List;
 import java.util.Map;
 
 import org.opensearch.core.xcontent.ToXContent.Params;
 import org.opensearch.core.xcontent.ToXContentObject;
 import org.opensearch.core.xcontent.XContentBuilder;
 
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
 /**
  * QuerySet is a system index object that represents all query set sampling/inserting params.
  */
+@AllArgsConstructor
+@Getter
 public class QuerySet implements ToXContentObject {
 
     public static final String ID = "id";
@@ -34,16 +40,7 @@ public class QuerySet implements ToXContentObject {
     private final String description;
     private final String sampling;
     private final String timestamp;
-    private final Map<String, Integer> querySetQueries;
-
-    public QuerySet(String id, String name, String description, String timestamp, String sampling, Map<String, Integer> querySetQueries) {
-        this.id = id;
-        this.description = description;
-        this.name = name;
-        this.sampling = sampling;
-        this.timestamp = timestamp;
-        this.querySetQueries = querySetQueries;
-    }
+    private final List<Map<String, Object>> querySetQueries;
 
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
@@ -54,11 +51,15 @@ public class QuerySet implements ToXContentObject {
         xContentBuilder.field(SAMPLING, this.sampling == null ? "" : this.sampling.trim());
         xContentBuilder.field(TIME_STAMP, this.timestamp.trim());
         // Add the query_set_queries field
-        xContentBuilder.startObject(QUERY_SET_QUERIES);
-        for (Map.Entry<String, Integer> entry : querySetQueries.entrySet()) {
-            builder.field(entry.getKey(), entry.getValue());
+        xContentBuilder.startArray(QUERY_SET_QUERIES);
+        for (Map<String, Object> query : querySetQueries) {
+            xContentBuilder.startObject();
+            for (Map.Entry<String, Object> entry : query.entrySet()) {
+                xContentBuilder.field(entry.getKey(), entry.getValue());
+            }
+            xContentBuilder.endObject();
         }
-        xContentBuilder.endObject();
+        xContentBuilder.endArray();
         return xContentBuilder.endObject();
     }
 
@@ -68,7 +69,7 @@ public class QuerySet implements ToXContentObject {
         private String description = "";
         private String sampling = "";
         private String timestamp = "";
-        private Map<String, Integer> querySetQueries;
+        private List<Map<String, Object>> querySetQueries;
 
         private Builder() {}
 
@@ -106,7 +107,7 @@ public class QuerySet implements ToXContentObject {
             return this;
         }
 
-        public Builder querySetQueries(Map<String, Integer> querySetQueries) {
+        public Builder querySetQueries(List<Map<String, Object>> querySetQueries) {
             this.querySetQueries = querySetQueries;
             return this;
         }
@@ -123,25 +124,4 @@ public class QuerySet implements ToXContentObject {
             return new Builder(t);
         }
     }
-
-    public String id() {
-        return id;
-    }
-
-    public String name() {
-        return name;
-    }
-
-    public String sampling() {
-        return sampling;
-    }
-
-    public String timestamp() {
-        return timestamp;
-    }
-
-    public Map<String, Integer> querySetQueries() {
-        return querySetQueries;
-    }
-
 }

--- a/src/main/resources/mappings/queryset.json
+++ b/src/main/resources/mappings/queryset.json
@@ -4,7 +4,17 @@
     "timestamp": { "type": "date", "format": "strict_date_time" },
     "name": { "type": "keyword" },
     "description": { "type": "text" },
-    "querySetQueries": { "type": "object" },
+    "querySetQueries": {
+      "type": "nested",
+      "properties": {
+        "queryText": {
+          "type": "text"
+        },
+        "frequency": {
+          "type": "integer"
+        }
+      }
+    },
     "sampling": { "type": "keyword" }
   }
 }

--- a/src/test/java/org/opensearch/searchrelevance/indices/SearchRelevanceIndicesManagerTests.java
+++ b/src/test/java/org/opensearch/searchrelevance/indices/SearchRelevanceIndicesManagerTests.java
@@ -19,6 +19,7 @@ import static org.opensearch.searchrelevance.indices.SearchRelevanceIndices.QUER
 
 import java.io.IOException;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import org.apache.lucene.search.TotalHits;
@@ -161,7 +162,7 @@ public class SearchRelevanceIndicesManagerTests extends OpenSearchTestCase {
     }
 
     public void testPutDocWhenSucceeded() throws IOException {
-        QuerySet querySet = new QuerySet("test_id", "test_name", "test_description", "test_timestamp", "test_sampling", Map.of());
+        QuerySet querySet = new QuerySet("test_id", "test_name", "test_description", "test_sampling", "test_timestamp", List.of());
         XContentBuilder xContentBuilder = querySet.toXContent(XContentFactory.jsonBuilder(), ToXContent.EMPTY_PARAMS);
 
         IndexRequestBuilder indexRequestBuilder = mock(IndexRequestBuilder.class);
@@ -183,7 +184,7 @@ public class SearchRelevanceIndicesManagerTests extends OpenSearchTestCase {
     }
 
     public void testPutDocWhenFailed() throws IOException {
-        QuerySet querySet = new QuerySet("test_id", "test_name", "test_description", "test_timestamp", "test_sampling", Map.of());
+        QuerySet querySet = new QuerySet("test_id", "test_name", "test_description", "test_sampling", "test_timestamp", List.of());
         XContentBuilder xContentBuilder = querySet.toXContent(XContentFactory.jsonBuilder(), ToXContent.EMPTY_PARAMS);
 
         when(client.prepareIndex(QUERY_SET.getIndexName())).thenThrow(
@@ -203,7 +204,7 @@ public class SearchRelevanceIndicesManagerTests extends OpenSearchTestCase {
 
     public void testGetDocByDocIdWhenSucceeded() throws IOException {
         String docId = "test_id";
-        QuerySet querySet = new QuerySet(docId, "test_name", "test_description", "test_timestamp", "test_sampling", Map.of());
+        QuerySet querySet = new QuerySet(docId, "test_name", "test_description", "test_sampling", "test_timestamp", List.of());
         XContentBuilder xContentBuilder = querySet.toXContent(XContentFactory.jsonBuilder(), ToXContent.EMPTY_PARAMS);
 
         Map<String, Object> sourceMap = new HashMap<>();
@@ -268,8 +269,8 @@ public class SearchRelevanceIndicesManagerTests extends OpenSearchTestCase {
     }
 
     public void testListDocsWhenSucceeded() throws IOException {
-        QuerySet querySet1 = new QuerySet("id1", "name1", "desc1", "timestamp1", "sampling1", Map.of());
-        QuerySet querySet2 = new QuerySet("id2", "name2", "desc2", "timestamp2", "sampling2", Map.of());
+        QuerySet querySet1 = new QuerySet("id1", "name1", "desc1", "sampling1", "timestamp1", List.of());
+        QuerySet querySet2 = new QuerySet("id2", "name2", "desc2", "sampling2", "timestamp2", List.of());
 
         SearchHit[] hits = new SearchHit[] {
             new SearchHit(1, "id1", Map.of(), Map.of()).sourceRef(


### PR DESCRIPTION
### Description
Change model for Query Set, new model is model restrictive comparing to "allow all" dynamic mode. 

Fields that are allowed: 
- `queryText` holds the actual test of the user query
- `frequency` number of times this query appears in actual user search, mainly needed by UBI data and is 0 for manually uploaded queries

Example of query set document with new model:

```
{
                    "id": "dd49c93b-eefd-4586-9144-e02e43ead6aa",
                    "name": "query_set",
                    "description": "Test query set",
                    "sampling": "manual",
                    "timestamp": "2025-06-09T19:46:47.172Z",
                    "querySetQueries": [
                        {
                            "queryText": "phone",
                            "frequency": 0
                        },
                        {
                            "queryText": "iphone",
                            "frequency": 0
                        },
                        {
                            "queryText": "steel",
                            "frequency": 0
                        }
                    ]
}
``` 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
