### PR TITLE
Update query set schema to avoid too many fields issue

### DIFF
--- a/src/main/java/org/opensearch/searchrelevance/model/QuerySet.java
+++ b/src/main/java/org/opensearch/searchrelevance/model/QuerySet.java
@@ -8,7 +8,7 @@
 package org.opensearch.searchrelevance.model;
 
 import java.io.IOException;
-import java.util.Map;
+import java.util.List;
 
 import org.opensearch.core.xcontent.ToXContent.Params;
 import org.opensearch.core.xcontent.ToXContentObject;
@@ -34,9 +34,9 @@ public class QuerySet implements ToXContentObject {
     private final String description;
     private final String sampling;
     private final String timestamp;
-    private final Map<String, Integer> querySetQueries;
+    private final List<QuerySetEntry> querySetQueries;
 
-    public QuerySet(String id, String name, String description, String timestamp, String sampling, Map<String, Integer> querySetQueries) {
+    public QuerySet(String id, String name, String description, String timestamp, String sampling, List<QuerySetEntry> querySetQueries) {
         this.id = id;
         this.description = description;
         this.name = name;
@@ -54,11 +54,11 @@ public class QuerySet implements ToXContentObject {
         xContentBuilder.field(SAMPLING, this.sampling == null ? "" : this.sampling.trim());
         xContentBuilder.field(TIME_STAMP, this.timestamp.trim());
         // Add the query_set_queries field
-        xContentBuilder.startObject(QUERY_SET_QUERIES);
-        for (Map.Entry<String, Integer> entry : querySetQueries.entrySet()) {
-            builder.field(entry.getKey(), entry.getValue());
+        xContentBuilder.startArray(QUERY_SET_QUERIES);
+        for (QuerySetEntry entry : querySetQueries) {
+            entry.toXContent(xContentBuilder, params);
         }
-        xContentBuilder.endObject();
+        xContentBuilder.endArray();
         return xContentBuilder.endObject();
     }
 
@@ -68,7 +68,7 @@ public class QuerySet implements ToXContentObject {
         private String description = "";
         private String sampling = "";
         private String timestamp = "";
-        private Map<String, Integer> querySetQueries;
+        private List<QuerySetEntry> querySetQueries;
 
         private Builder() {}
 
@@ -106,13 +106,13 @@ public class QuerySet implements ToXContentObject {
             return this;
         }
 
-        public Builder querySetQueries(Map<String, Integer> querySetQueries) {
+        public Builder querySetQueries(List<QuerySetEntry> querySetQueries) {
             this.querySetQueries = querySetQueries;
             return this;
         }
 
         public QuerySet build() {
-            return new QuerySet(this.id, this.name, this.description, this.sampling, this.timestamp, this.querySetQueries);
+            return new QuerySet(this.id, this.name, this.description, this.timestamp, this.sampling, this.querySetQueries);
         }
 
         public static Builder builder() {
@@ -140,7 +140,7 @@ public class QuerySet implements ToXContentObject {
         return timestamp;
     }
 
-    public Map<String, Integer> querySetQueries() {
+    public List<QuerySetEntry> querySetQueries() {
         return querySetQueries;
     }
 

--- a/src/main/java/org/opensearch/searchrelevance/model/QuerySetEntry.java
+++ b/src/main/java/org/opensearch/searchrelevance/model/QuerySetEntry.java
@@ -1,0 +1,66 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+package org.opensearch.searchrelevance.model;
+
+import java.io.IOException;
+
+import org.opensearch.core.xcontent.ToXContent.Params;
+import org.opensearch.core.xcontent.ToXContentObject;
+import org.opensearch.core.xcontent.XContentBuilder;
+
+/**
+ * QuerySetEntry represents a single query entry in a query set with its text.
+ */
+public class QuerySetEntry implements ToXContentObject {
+
+    public static final String QUERY_TEXT = "queryText";
+
+    private final String queryText;
+
+    public QuerySetEntry(String queryText) {
+        this.queryText = queryText;
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        XContentBuilder xContentBuilder = builder.startObject();
+        xContentBuilder.field(QUERY_TEXT, this.queryText);
+        return xContentBuilder.endObject();
+    }
+
+    public String queryText() {
+        return queryText;
+    }
+
+    public static class Builder {
+        private String queryText;
+
+        private Builder() {}
+
+        private Builder(QuerySetEntry entry) {
+            this.queryText = entry.queryText;
+        }
+
+        public Builder queryText(String queryText) {
+            this.queryText = queryText;
+            return this;
+        }
+
+        public QuerySetEntry build() {
+            return new QuerySetEntry(this.queryText);
+        }
+
+        public static Builder builder() {
+            return new Builder();
+        }
+
+        public static Builder builder(QuerySetEntry entry) {
+            return new Builder(entry);
+        }
+    }
+}

--- a/src/main/resources/mappings/queryset.json
+++ b/src/main/resources/mappings/queryset.json
@@ -4,7 +4,12 @@
     "timestamp": { "type": "date", "format": "strict_date_time" },
     "name": { "type": "keyword" },
     "description": { "type": "text" },
-    "querySetQueries": { "type": "object" },
+    "querySetQueries": {
+      "type": "nested",
+      "properties": {
+        "queryText": { "type": "text" }
+      }
+    },
     "sampling": { "type": "keyword" }
   }
 }

--- a/src/test/java/org/opensearch/searchrelevance/indices/SearchRelevanceIndicesManagerTests.java
+++ b/src/test/java/org/opensearch/searchrelevance/indices/SearchRelevanceIndicesManagerTests.java
@@ -19,6 +19,7 @@ import static org.opensearch.searchrelevance.indices.SearchRelevanceIndices.QUER
 
 import java.io.IOException;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import org.apache.lucene.search.TotalHits;
@@ -161,7 +162,7 @@ public class SearchRelevanceIndicesManagerTests extends OpenSearchTestCase {
     }
 
     public void testPutDocWhenSucceeded() throws IOException {
-        QuerySet querySet = new QuerySet("test_id", "test_name", "test_description", "test_timestamp", "test_sampling", Map.of());
+        QuerySet querySet = new QuerySet("test_id", "test_name", "test_description", "test_timestamp", "test_sampling", List.of());
         XContentBuilder xContentBuilder = querySet.toXContent(XContentFactory.jsonBuilder(), ToXContent.EMPTY_PARAMS);
 
         IndexRequestBuilder indexRequestBuilder = mock(IndexRequestBuilder.class);
@@ -183,7 +184,7 @@ public class SearchRelevanceIndicesManagerTests extends OpenSearchTestCase {
     }
 
     public void testPutDocWhenFailed() throws IOException {
-        QuerySet querySet = new QuerySet("test_id", "test_name", "test_description", "test_timestamp", "test_sampling", Map.of());
+        QuerySet querySet = new QuerySet("test_id", "test_name", "test_description", "test_timestamp", "test_sampling", List.of());
         XContentBuilder xContentBuilder = querySet.toXContent(XContentFactory.jsonBuilder(), ToXContent.EMPTY_PARAMS);
 
         when(client.prepareIndex(QUERY_SET.getIndexName())).thenThrow(
@@ -203,7 +204,7 @@ public class SearchRelevanceIndicesManagerTests extends OpenSearchTestCase {
 
     public void testGetDocByDocIdWhenSucceeded() throws IOException {
         String docId = "test_id";
-        QuerySet querySet = new QuerySet(docId, "test_name", "test_description", "test_timestamp", "test_sampling", Map.of());
+        QuerySet querySet = new QuerySet(docId, "test_name", "test_description", "test_timestamp", "test_sampling", List.of());
         XContentBuilder xContentBuilder = querySet.toXContent(XContentFactory.jsonBuilder(), ToXContent.EMPTY_PARAMS);
 
         Map<String, Object> sourceMap = new HashMap<>();
@@ -268,8 +269,8 @@ public class SearchRelevanceIndicesManagerTests extends OpenSearchTestCase {
     }
 
     public void testListDocsWhenSucceeded() throws IOException {
-        QuerySet querySet1 = new QuerySet("id1", "name1", "desc1", "timestamp1", "sampling1", Map.of());
-        QuerySet querySet2 = new QuerySet("id2", "name2", "desc2", "timestamp2", "sampling2", Map.of());
+        QuerySet querySet1 = new QuerySet("id1", "name1", "desc1", "timestamp1", "sampling1", List.of());
+        QuerySet querySet2 = new QuerySet("id2", "name2", "desc2", "timestamp2", "sampling2", List.of());
 
         SearchHit[] hits = new SearchHit[] {
             new SearchHit(1, "id1", Map.of(), Map.of()).sourceRef(

--- a/src/test/java/org/opensearch/searchrelevance/rest/RestPutQuerySetActionTests.java
+++ b/src/test/java/org/opensearch/searchrelevance/rest/RestPutQuerySetActionTests.java
@@ -32,7 +32,7 @@ public class RestPutQuerySetActionTests extends SearchRelevanceRestTestCase {
         + "\"description\": \"test_description\","
         + "\"sampling\": \"manual\","
         + "\"querySetQueries\": ["
-        + "  {\"queryText\": \"test\", \"referenceAnswer\": \"\"}"
+        + "  {\"queryText\": \"test\"}"
         + "]"
         + "}";
 


### PR DESCRIPTION
### Description
Change model for Query Set, new model is model restrictive comparing to "allow all" dynamic mode. 

Fields that are allowed: 
- `queryText` holds the actual test of the user query

Example of query set document with new model:

```
{
                    "id": "dd49c93b-eefd-4586-9144-e02e43ead6aa",
                    "name": "query_set",
                    "description": "Test query set",
                    "sampling": "manual",
                    "timestamp": "2025-06-09T19:46:47.172Z",
                    "querySetQueries": [
                        {
                            "queryText": "phone"
                        },
                        {
                            "queryText": "iphone"
                        },
                        {
                            "queryText": "steel"
                        }
                    ]
}
``` 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
