### PR TITLE
Disabled indexing for some fields in query set and jugments indexes

### DIFF
--- a/src/main/resources/mappings/judgment.json
+++ b/src/main/resources/mappings/judgment.json
@@ -9,16 +9,19 @@
       "type": "nested",
       "properties": {
         "query": {
-          "type": "text"
+          "type": "text",
+          "index": false
         },
         "ratings": {
           "type": "nested",
           "properties": {
             "docId": {
-              "type": "text"
+              "type": "text",
+              "index": false
             },
             "rating": {
-              "type": "float"
+              "type": "float",
+              "index": false
             }
           }
         }

--- a/src/main/resources/mappings/queryset.json
+++ b/src/main/resources/mappings/queryset.json
@@ -7,7 +7,7 @@
     "querySetQueries": {
       "type": "nested",
       "properties": {
-        "queryText": { "type": "text" }
+        "queryText": { "type": "text", "index": false }
       }
     },
     "sampling": { "type": "keyword" }


### PR DESCRIPTION
### Description
Disable indexing for new fields introduced in https://github.com/opensearch-project/search-relevance/pull/87 and https://github.com/opensearch-project/search-relevance/pull/77 for QuerySet and Judgment indexes. This is safe because we're not using those fields in any search queries or aggregations. This should save compute and memory resources because those fields will not be indexed. 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
