### PR TITLE
Fixed problem with putting UBI judgments

### DIFF
--- a/src/main/java/org/opensearch/searchrelevance/judgments/clickmodel/coec/CoecClickModel.java
+++ b/src/main/java/org/opensearch/searchrelevance/judgments/clickmodel/coec/CoecClickModel.java
@@ -192,6 +192,11 @@ public class CoecClickModel extends ClickModel {
                     try {
                         UbiEvent event = JsonUtils.fromJson(hit.getSourceAsString(), UbiEvent.class);
                         String userQuery = event.getUserQuery();
+                        // In some events the attributes or userQuery can be null.
+                        if (userQuery == null || event.getEventAttributes() == null || event.getEventAttributes().getObject() == null) {
+                            continue;
+                        }
+                        
                         String objectId = event.getEventAttributes().getObject().getObjectId();
                         String action = event.getActionName();
                         int rank = event.getEventAttributes().getPosition().getOrdinal();

--- a/src/main/java/org/opensearch/searchrelevance/judgments/clickmodel/coec/CoecClickModel.java
+++ b/src/main/java/org/opensearch/searchrelevance/judgments/clickmodel/coec/CoecClickModel.java
@@ -84,7 +84,7 @@ public class CoecClickModel extends ClickModel {
 
         // Add aggregations to see distribution
         TermsAggregationBuilder actionAgg = AggregationBuilders.terms("actions")
-            .field("action_name")
+            .field("action_name.keyword")
             .subAggregation(
                 AggregationBuilders.terms("positions").field("event_attributes.position.ordinal").size(parameters.getMaxRank())
             );
@@ -196,7 +196,7 @@ public class CoecClickModel extends ClickModel {
                         if (userQuery == null || event.getEventAttributes() == null || event.getEventAttributes().getObject() == null) {
                             continue;
                         }
-                        
+
                         String objectId = event.getEventAttributes().getObject().getObjectId();
                         String action = event.getActionName();
                         int rank = event.getEventAttributes().getPosition().getOrdinal();

--- a/src/main/java/org/opensearch/searchrelevance/model/Judgment.java
+++ b/src/main/java/org/opensearch/searchrelevance/model/Judgment.java
@@ -54,12 +54,24 @@ public class Judgment implements ToXContentObject {
             xContentBuilder.startObject();
             xContentBuilder.field("query", judgment.get("query"));
             xContentBuilder.startArray("ratings");
-            for (Map<String, Object> rating : (List<Map<String, Object>>) judgment.get("ratings")) {
-                xContentBuilder.startObject();
-                for (Map.Entry<String, Object> entry : rating.entrySet()) {
+            // As it turns out, the ratings object in a judgment is not a list but instead an
+            // object. {ratings={B077ZJXCTS=0.000, B071S6LTJJ=0.000,
+            // B01IDSPDJI=0.000, B074V6Q1DR=0.000, B07QRCGL3G=0.000}, query=yeezy}
+            if ((judgment.get("ratings")) instanceof Map) {
+                Map<String, Object> ratings = (Map<String, Object>) judgment.get("ratings");
+                for (Map.Entry<String, Object> entry : ratings.entrySet()) {
+                    xContentBuilder.startObject();
                     xContentBuilder.field(entry.getKey(), entry.getValue());
+                    xContentBuilder.endObject();
                 }
-                xContentBuilder.endObject();
+            } else {
+                for (Map<String, Object> rating : (List<Map<String, Object>>) judgment.get("ratings")) {
+                    xContentBuilder.startObject();
+                    for (Map.Entry<String, Object> entry : rating.entrySet()) {
+                        xContentBuilder.field(entry.getKey(), entry.getValue());
+                    }
+                    xContentBuilder.endObject();
+                }
             }
             xContentBuilder.endArray();
             xContentBuilder.endObject();


### PR DESCRIPTION
### Description
Earlier, it was reported that putting UBI judgments returned an error when using the implicit judgments coec click model. To reproduce the error, I ran demo.sh and then tried to receive the judgment that was created using the However, I found that the field that was being aggregated over was not the right type, and that there were a few null values. Unfortunately, while this fix gets us closer, and returned the expected values earlier in the day, when I tried it on the most up to date version, the field count limit was exceeded. 

### Issues Resolved


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
