### PR TITLE
remove Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,0 @@
-FROM opensearchstaging/opensearch:3.1.0
-
-ADD ./build/distributions/opensearch-search-relevance-3.1.0.0-SNAPSHOT.zip  /tmp/opensearch-search-relevance-3.1.0.0-SNAPSHOT.zip
-RUN /usr/share/opensearch/bin/opensearch-plugin install --batch file:/tmp/opensearch-search-relevance-3.1.0.0-SNAPSHOT.zip
-
-# Until we have a proper home for staging builds
-ADD --chmod=444 https://o19s-public-datasets.s3.amazonaws.com/opensearch-ubi-3.1.0.0-SNAPSHOT.zip  /tmp/opensearch-ubi-3.1.0.0-SNAPSHOT.zip
-RUN /usr/share/opensearch/bin/opensearch-plugin install --batch file:/tmp/opensearch-ubi-3.1.0.0-SNAPSHOT.zip

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   opensearch_search_relevance:
-    build: .
+    image: opensearchstaging/opensearch:3.1.0
     container_name: opensearch_search_relevance
     environment:
       discovery.type: single-node


### PR DESCRIPTION
This PR updates the Docker-based installation.

### Description
The plugins `opensearch-search-relevance` and `opensearch-ubi` are no longer necessary to be included manually in the Dockerfile. They are now included in OpenSearch. This PR removes the Dockerfile.

### Issues Resolved
n/a

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
