### PR TITLE
deduplicate judgmentRatings + change some operations to synchronous

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,5 +31,6 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
  - Set limit for number of fields programmatically during index creation ([#74](https://github.com/opensearch-project/search-relevance/pull/74)
  - Change model for Judgment entity ([#77](https://github.com/opensearch-project/search-relevance/pull/77)
  - Fix judgment handling for implicit judgments to be aligned with data model for Judgment again ([#93](https://github.com/opensearch-project/search-relevance/pull/93)
+ - Refactor and fix LLM judgment duplication issue ([#98](https://github.com/opensearch-project/search-relevance/pull/98)))
 
 ### Security

--- a/src/main/java/org/opensearch/searchrelevance/dao/QuerySetDao.java
+++ b/src/main/java/org/opensearch/searchrelevance/dao/QuerySetDao.java
@@ -99,6 +99,14 @@ public class QuerySetDao {
         return searchRelevanceIndicesManager.getDocByDocId(querySetId, QUERY_SET, listener);
     }
 
+    public QuerySet getQuerySetSync(String querySetId) {
+        if (querySetId == null || querySetId.isEmpty()) {
+            throw new SearchRelevanceException("querySetId must not be null or empty", RestStatus.BAD_REQUEST);
+        }
+        SearchResponse response = searchRelevanceIndicesManager.getDocByDocIdSync(querySetId, QUERY_SET);
+        return convertToQuerySet(response);
+    }
+
     /**
      * List query set by source builder
      * @param sourceBuilder - source builder to be searched

--- a/src/main/java/org/opensearch/searchrelevance/dao/SearchConfigurationDao.java
+++ b/src/main/java/org/opensearch/searchrelevance/dao/SearchConfigurationDao.java
@@ -95,6 +95,14 @@ public class SearchConfigurationDao {
         return searchRelevanceIndicesManager.getDocByDocId(searchConfigurationId, SEARCH_CONFIGURATION, listener);
     }
 
+    public SearchConfiguration getSearchConfigurationSync(String searchConfigurationId) {
+        if (searchConfigurationId == null || searchConfigurationId.isEmpty()) {
+            throw new SearchRelevanceException("searchConfigurationId must not be null or empty", RestStatus.BAD_REQUEST);
+        }
+        SearchResponse response = searchRelevanceIndicesManager.getDocByDocIdSync(searchConfigurationId, SEARCH_CONFIGURATION);
+        return convertToSearchConfiguration(response);
+    }
+
     /**
      * List searchConfigurationId by source builder
      * @param sourceBuilder - source builder to be searched

--- a/src/main/java/org/opensearch/searchrelevance/indices/SearchRelevanceIndicesManager.java
+++ b/src/main/java/org/opensearch/searchrelevance/indices/SearchRelevanceIndicesManager.java
@@ -108,6 +108,14 @@ public class SearchRelevanceIndicesManager {
         StashedThreadContext.run(client, () -> client.admin().indices().create(createIndexRequest));
     }
 
+    public SearchResponse getDocByDocIdSync(final String docId, final SearchRelevanceIndices index) {
+        SearchRequest searchRequest = new SearchRequest(index.getIndexName());
+        SearchSourceBuilder sourceBuilder = new SearchSourceBuilder().query(QueryBuilders.termQuery("_id", docId)).size(1);
+        searchRequest.source(sourceBuilder);
+
+        return client.search(searchRequest).actionGet();
+    }
+
     /**
      * Put a doc to the system index
      * @param docId - document id need to be executed


### PR DESCRIPTION
### Description
- change query set, search configuration get to be synchronous. since they're no longer within system indices
- refactor llm judgment processor logics
- update judgment cache upset logics

###Test
- judgment generated
  - ingest 8 query text in queryset
  - then judgment also should have 8 items in judgmentRating with distinct query value
```
"judgmentRatings":  [
    {
        "query": "phone",
        "ratings":  [
            {
                "docId": "B07SVZW34Z",
                "rating": "1.0" 
            },
            {
                "docId": "B07K73P7NX",
                "rating": "0.7" 
            },
            {
                "docId": "B07T99FCD2",
                "rating": "0.1" 
            },
            {
                "docId": "B07V5SBP7N",
                "rating": "1.0" 
            },
            {
                "docId": "B07CW24XX9",
                "rating": "0.0" 
            }
        ]
    },
    {
        "query": "iphone",
        "ratings":  [
            {
                "docId": "B013DDMPXK",
                "rating": "1.0" 
            },
            {
                "docId": "B07DBZDT89",
                "rating": "0.0" 
            },
            {
                "docId": "B078M6HWX5",
                "rating": "0.0" 
            },
            {
                "docId": "B01KBQ6I3A",
                "rating": "0.9" 
            },
            {
                "docId": "B00I7VMJ8K",
                "rating": "0.4" 
            }
        ]
    },
    {
        "query": "steel",
        "ratings":  [
            {
                "docId": "B003D2OO9U",
                "rating": "0.7" 
            },
            {
                "docId": "B07J4FCKHN",
                "rating": "0.6" 
            },
            {
                "docId": "B07S2JP47D",
                "rating": "0.4" 
            },
            {
                "docId": "B01AZB6TQW",
                "rating": "1.0" 
            },
            {
                "docId": "B00J30T252",
                "rating": "0.7" 
            }
        ]
    },
    {
        "query": "keyboard",
        "ratings":  [
            {
                "docId": "B01ALLT2W4",
                "rating": "0.6" 
            },
            {
                "docId": "B01EWXHV0W",
                "rating": "0.4" 
            },
            {
                "docId": "B016DOY9UI",
                "rating": "0.7" 
            },
            {
                "docId": "B07H4L4K35",
                "rating": "0.3" 
            },
            {
                "docId": "B084S6Y6V3",
                "rating": "0.1" 
            }
        ]
    },
    {
        "query": "diamond wheel",
        "ratings":  [
            {
                "docId": "B005JRJFSM",
                "rating": "0.3" 
            },
            {
                "docId": "B07Z5WRGTN",
                "rating": "0.1" 
            },
            {
                "docId": "B0018TWDOI",
                "rating": "0.0" 
            },
            {
                "docId": "B07NQ3CVLN",
                "rating": "0.7" 
            },
            {
                "docId": "B07VLHZQ4W",
                "rating": "0.6" 
            }
        ]
    },
    {
        "query": "button",
        "ratings":  [
            {
                "docId": "B000L70MQO",
                "rating": "0.1" 
            },
            {
                "docId": "B012US1AUS",
                "rating": "0.0" 
            },
            {
                "docId": "B06XNZG28P",
                "rating": "0.1" 
            },
            {
                "docId": "B00MIA3S7W",
                "rating": "1.0" 
            },
            {
                "docId": "B0784TZQHK",
                "rating": "0.4" 
            }
        ]
    },
    {
        "query": "metal frame",
        "ratings":  [
            {
                "docId": "B018WH9HCO",
                "rating": "0.0" 
            },
            {
                "docId": "B07J5RQTTW",
                "rating": "0.9" 
            },
            {
                "docId": "B073DVSQTP",
                "rating": "0.4" 
            },
            {
                "docId": "B072BCYW4K",
                "rating": "0.7" 
            },
            {
                "docId": "B00IAUV5LA",
                "rating": "0.9" 
            }
        ]
    },
    {
        "query": "giangentic form",
        "ratings":  [
            {
                "docId": "B0054G5JQK",
                "rating": "0.0" 
            },
            {
                "docId": "B07PP8F24N",
                "rating": "0.0" 
            },
            {
                "docId": "B07RKRPWK1",
                "rating": "0.0" 
            },
            {
                "docId": "B009RRC2DU",
                "rating": "0.0" 
            },
            {
                "docId": "B00X14Q6E6",
                "rating": "0.1" 
            }
        ]
        

```


### Issues Resolved
- #95 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
