### PR TITLE
Revert "Migrate data schema from object to nested with explicit field…

### DIFF
--- a/src/main/java/org/opensearch/searchrelevance/experiment/QuerySourceUtil.java
+++ b/src/main/java/org/opensearch/searchrelevance/experiment/QuerySourceUtil.java
@@ -34,15 +34,16 @@ public class QuerySourceUtil {
      * @return definition of a temporary search pipeline
      */
     public static Map<String, Object> createDefinitionOfTemporarySearchPipeline(final ExperimentVariant experimentVariant) {
+        Map<String, Object> experimentVariantParameters = experimentVariant.getParameters();
         Map<String, Object> normalizationTechniqueConfig = new HashMap<>(
-            Map.of("technique", experimentVariant.getParameterValue(EXPERIMENT_OPTION_NORMALIZATION_TECHNIQUE))
+            Map.of("technique", experimentVariantParameters.get(EXPERIMENT_OPTION_NORMALIZATION_TECHNIQUE))
         );
 
         Map<String, Object> combinationTechniqueConfig = new HashMap<>(
-            Map.of("technique", experimentVariant.getParameterValue(EXPERIMENT_OPTION_COMBINATION_TECHNIQUE))
+            Map.of("technique", experimentVariantParameters.get(EXPERIMENT_OPTION_COMBINATION_TECHNIQUE))
         );
-        if (Objects.nonNull(experimentVariant.getParameterValue(EXPERIMENT_OPTION_WEIGHTS_FOR_COMBINATION))) {
-            float[] weights = (float[]) experimentVariant.getParameterValue(EXPERIMENT_OPTION_WEIGHTS_FOR_COMBINATION);
+        if (Objects.nonNull(experimentVariantParameters.get(EXPERIMENT_OPTION_WEIGHTS_FOR_COMBINATION))) {
+            float[] weights = (float[]) experimentVariantParameters.get(EXPERIMENT_OPTION_WEIGHTS_FOR_COMBINATION);
             List<Double> weightsList = new ArrayList<>(weights.length);
             for (float weight : weights) {
                 weightsList.add((double) weight);

--- a/src/main/java/org/opensearch/searchrelevance/model/ExperimentVariant.java
+++ b/src/main/java/org/opensearch/searchrelevance/model/ExperimentVariant.java
@@ -8,7 +8,6 @@
 package org.opensearch.searchrelevance.model;
 
 import java.io.IOException;
-import java.util.List;
 import java.util.Map;
 
 import org.opensearch.core.xcontent.ToXContentObject;
@@ -41,7 +40,7 @@ public class ExperimentVariant implements ToXContentObject {
     private final ExperimentType type;
     private final AsyncStatus status;
     private final String experimentId;
-    private final List<Map<String, Object>> parameters;
+    private final Map<String, Object> parameters;
     private final Map<String, Object> results;
 
     @Override
@@ -55,21 +54,5 @@ public class ExperimentVariant implements ToXContentObject {
         xContentBuilder.field(PARAMETERS, this.parameters);
         xContentBuilder.field(RESULTS, this.results);
         return xContentBuilder.endObject();
-    }
-
-    /**
-     * Get parameter value by name from the nested parameters structure
-     * @param parameterName the name of the parameter to retrieve
-     * @return the parameter value or null if not found
-     */
-    public Object getParameterValue(String parameterName) {
-        if (parameters == null) {
-            return null;
-        }
-        return parameters.stream()
-            .filter(param -> parameterName.equals(param.get("name")))
-            .map(param -> param.get("value"))
-            .findFirst()
-            .orElse(null);
     }
 }

--- a/src/main/java/org/opensearch/searchrelevance/model/Judgment.java
+++ b/src/main/java/org/opensearch/searchrelevance/model/Judgment.java
@@ -36,7 +36,7 @@ public class Judgment implements ToXContentObject {
     private final String name;
     private final AsyncStatus status;
     private final JudgmentType type;
-    private final List<Map<String, Object>> metadata;
+    private final Map<String, Object> metadata;
     private final List<Map<String, Object>> judgmentRatings;
 
     @Override

--- a/src/main/java/org/opensearch/searchrelevance/transport/experiment/PutExperimentTransportAction.java
+++ b/src/main/java/org/opensearch/searchrelevance/transport/experiment/PutExperimentTransportAction.java
@@ -240,7 +240,7 @@ public class PutExperimentTransportAction extends HandledTransportAction<PutExpe
                         ExperimentType.HYBRID_OPTIMIZER,
                         AsyncStatus.PROCESSING,
                         experimentId,
-                        convertMapToNestedList(parameters),
+                        parameters,
                         Map.of()
                     );
                     experimentVariants.add(experimentVariant);
@@ -372,12 +372,5 @@ public class PutExperimentTransportAction extends HandledTransportAction<PutExpe
                 e -> LOGGER.error("Failed to update error status for experiment: " + experimentId, e)
             )
         );
-    }
-
-    /**
-     * Convert flat Map<String, Object> to nested List<Map<String, Object>> format
-     */
-    private List<Map<String, Object>> convertMapToNestedList(Map<String, Object> flatMap) {
-        return flatMap.entrySet().stream().map(entry -> Map.of("name", entry.getKey(), "value", entry.getValue())).toList();
     }
 }

--- a/src/main/java/org/opensearch/searchrelevance/transport/judgment/PutJudgmentTransportAction.java
+++ b/src/main/java/org/opensearch/searchrelevance/transport/judgment/PutJudgmentTransportAction.java
@@ -34,13 +34,10 @@ import org.opensearch.searchrelevance.utils.TimeUtils;
 import org.opensearch.tasks.Task;
 import org.opensearch.transport.TransportService;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-
 public class PutJudgmentTransportAction extends HandledTransportAction<PutJudgmentRequest, IndexResponse> {
     private final ClusterService clusterService;
     private final JudgmentDao judgmentDao;
     private final JudgmentsProcessorFactory judgmentsProcessorFactory;
-    private final ObjectMapper objectMapper = new ObjectMapper();
 
     private static final Logger LOGGER = LogManager.getLogger(PutJudgmentTransportAction.class);
 
@@ -93,77 +90,37 @@ public class PutJudgmentTransportAction extends HandledTransportAction<PutJudgme
         }
     }
 
-    private List<Map<String, Object>> buildMetadata(PutJudgmentRequest request) {
-        List<Map<String, Object>> metadata = new ArrayList<>();
+    private Map<String, Object> buildMetadata(PutJudgmentRequest request) {
+        Map<String, Object> metadata = new HashMap<>();
         switch (request.getType()) {
             case LLM_JUDGMENT -> {
                 PutLlmJudgmentRequest llmRequest = (PutLlmJudgmentRequest) request;
-                metadata.add(createMetadataEntry(MODEL_ID, llmRequest.getModelId()));
-                metadata.add(createMetadataEntry("querySetId", llmRequest.getQuerySetId()));
-                metadata.add(createMetadataEntry("size", llmRequest.getSize()));
-                metadata.add(createMetadataEntry("searchConfigurationList", llmRequest.getSearchConfigurationList()));
-                metadata.add(createMetadataEntry("tokenLimit", llmRequest.getTokenLimit()));
-                metadata.add(createMetadataEntry("contextFields", llmRequest.getContextFields()));
-                metadata.add(createMetadataEntry("ignoreFailure", llmRequest.isIgnoreFailure()));
+                metadata.put(MODEL_ID, llmRequest.getModelId());
+                metadata.put("querySetId", llmRequest.getQuerySetId());
+                metadata.put("size", llmRequest.getSize());
+                metadata.put("searchConfigurationList", llmRequest.getSearchConfigurationList());
+                metadata.put("tokenLimit", llmRequest.getTokenLimit());
+                metadata.put("contextFields", llmRequest.getContextFields());
+                metadata.put("ignoreFailure", llmRequest.isIgnoreFailure());
             }
             case UBI_JUDGMENT -> {
                 PutUbiJudgmentRequest ubiRequest = (PutUbiJudgmentRequest) request;
-                metadata.add(createMetadataEntry("clickModel", ubiRequest.getClickModel()));
-                metadata.add(createMetadataEntry("maxRank", ubiRequest.getMaxRank()));
+                metadata.put("clickModel", ubiRequest.getClickModel());
+                metadata.put("maxRank", ubiRequest.getMaxRank());
             }
             case IMPORT_JUDGMENT -> {
                 PutImportJudgmentRequest importRequest = (PutImportJudgmentRequest) request;
-                metadata.add(createMetadataEntry("judgmentRatings", importRequest.getJudgmentRatings()));
+                metadata.put("judgmentRatings", importRequest.getJudgmentRatings());
             }
         }
         return metadata;
     }
 
-    /**
-     * Create a metadata entry with name-value structure
-     */
-    private Map<String, Object> createMetadataEntry(String name, Object value) {
-        // Convert complex objects to JSON strings for text field storage
-        if (value instanceof List || value instanceof Map) {
-            try {
-                value = objectMapper.writeValueAsString(value);
-            } catch (Exception e) {
-                value = value.toString();
-            }
-        }
-        return Map.of("name", name, "value", value);
-    }
-
-    /**
-     * Convert nested List<Map<String, Object>> to flat Map<String, Object> format
-     */
-    private Map<String, Object> convertNestedListToMap(List<Map<String, Object>> nestedList) {
-        Map<String, Object> flatMap = new HashMap<>();
-        if (nestedList != null) {
-            for (Map<String, Object> item : nestedList) {
-                Object name = item.get("name");
-                Object value = item.get("value");
-                if (name != null) {
-                    // Try to deserialize JSON strings back to objects
-                    if (value instanceof String && (((String) value).startsWith("[") || ((String) value).startsWith("{"))) {
-                        try {
-                            value = objectMapper.readValue((String) value, Object.class);
-                        } catch (Exception e) {
-                            // Keep as string if parsing fails
-                        }
-                    }
-                    flatMap.put(name.toString(), value);
-                }
-            }
-        }
-        return flatMap;
-    }
-
-    private void triggerAsyncProcessing(String judgmentId, PutJudgmentRequest request, List<Map<String, Object>> metadata) {
+    private void triggerAsyncProcessing(String judgmentId, PutJudgmentRequest request, Map<String, Object> metadata) {
         LOGGER.info("Starting async processing for judgment: {}, type: {}, metadata: {}", judgmentId, request.getType(), metadata);
         BaseJudgmentsProcessor processor = judgmentsProcessorFactory.getProcessor(request.getType());
 
-        processor.generateJudgmentRating(convertNestedListToMap(metadata), ActionListener.wrap(judgmentRatings -> {
+        processor.generateJudgmentRating(metadata, ActionListener.wrap(judgmentRatings -> {
             LOGGER.info(
                 "Generated judgment ratings for {}, ratings size: {}",
                 judgmentId,
@@ -176,7 +133,7 @@ public class PutJudgmentTransportAction extends HandledTransportAction<PutJudgme
     private void updateFinalJudgment(
         String judgmentId,
         PutJudgmentRequest request,
-        List<Map<String, Object>> metadata,
+        Map<String, Object> metadata,
         List<Map<String, Object>> judgmentScores
     ) {
         Judgment finalJudgment = new Judgment(
@@ -207,7 +164,7 @@ public class PutJudgmentTransportAction extends HandledTransportAction<PutJudgme
             request.getName(),
             AsyncStatus.ERROR,
             request.getType(),
-            List.of(createMetadataEntry("error", error.getMessage())),
+            Map.of("error", error.getMessage()),
             new ArrayList<>()
         );
 

--- a/src/main/resources/mappings/experiment.json
+++ b/src/main/resources/mappings/experiment.json
@@ -8,12 +8,6 @@
     "searchConfigurationList": { "type": "keyword" },
     "judgmentList": { "type": "keyword" },
     "size": {"type":  "keyword"},
-    "results": {
-      "type": "nested",
-      "properties": {
-        "metric": { "type": "keyword" },
-        "value": { "type": "double" }
-      }
-    }
+    "results": { "type": "object", "dynamic": false }
   }
 }

--- a/src/main/resources/mappings/experiment_variant.json
+++ b/src/main/resources/mappings/experiment_variant.json
@@ -5,13 +5,7 @@
     "type": { "type": "keyword" },
     "status": { "type": "keyword" },
     "experimentId": { "type": "keyword" },
-    "parameters": {
-      "type": "nested",
-      "properties": {
-        "name": { "type": "keyword" },
-        "value": { "type": "text" }
-      }
-    },
+    "parameters": { "type":  "object", "dynamic": false },
     "results": {
       "type": "nested",
       "properties": {

--- a/src/main/resources/mappings/judgment.json
+++ b/src/main/resources/mappings/judgment.json
@@ -4,13 +4,7 @@
     "timestamp": { "type": "date", "format": "strict_date_time" },
     "name": { "type": "keyword" },
     "type": { "type": "keyword" },
-    "metadata": {
-      "type": "nested",
-      "properties": {
-        "name": { "type": "keyword" },
-        "value": { "type": "object", "enabled": false }
-      }
-    },
+    "metadata": { "type": "object", "dynamic": false },
     "judgmentRatings": {
       "type": "nested",
       "properties": {

--- a/src/test/java/org/opensearch/searchrelevance/experiment/QuerySourceUtilTests.java
+++ b/src/test/java/org/opensearch/searchrelevance/experiment/QuerySourceUtilTests.java
@@ -27,10 +27,7 @@ public class QuerySourceUtilTests extends OpenSearchTestCase {
         // Given
         ExperimentVariant experimentHybridSearchDao = ExperimentVariant.builder()
             .parameters(
-                List.of(
-                    Map.of("name", EXPERIMENT_OPTION_NORMALIZATION_TECHNIQUE, "value", "min_max"),
-                    Map.of("name", EXPERIMENT_OPTION_COMBINATION_TECHNIQUE, "value", "arithmetic_mean")
-                )
+                Map.of(EXPERIMENT_OPTION_NORMALIZATION_TECHNIQUE, "min_max", EXPERIMENT_OPTION_COMBINATION_TECHNIQUE, "arithmetic_mean")
             )
             .build();
 


### PR DESCRIPTION
### Description
… (#101)"
This reverts commit 001dbfecc99113799b0f6f2d7723b5a5b696c237.

The 3.1 release timeline has passed, so we'll hold off on this backward-incompatible change for now.
### Issues Resolved
N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
