### PR TITLE
bug fix for UBI judgment generation

### DIFF
--- a/src/main/java/org/opensearch/searchrelevance/judgments/UbiJudgmentsProcessor.java
+++ b/src/main/java/org/opensearch/searchrelevance/judgments/UbiJudgmentsProcessor.java
@@ -127,7 +127,7 @@ public class UbiJudgmentsProcessor implements BaseJudgmentsProcessor {
                                 // Add the docId and score to the list for the current query
                                 Map<String, String> docScoreMap = new HashMap<>();
                                 docScoreMap.put("docId", docId);
-                                docScoreMap.put("score", rating);
+                                docScoreMap.put("rating", rating);
                                 docIdScoreList.add(docScoreMap);
                             }
 


### PR DESCRIPTION
### Description
Found a bug in UBI judgment generation, which leads to a failure on pointwise evaluation.
- judgment score found as null due to a name mismatching  



### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
