### PR TITLE
Fixed integration tests failures in distribution pipeline

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -271,7 +271,27 @@ testClusters.integTest {
             debugPort += 1
         }
     }
-    setting 'plugins.search_relevance.workbench_enabled', 'true'
+}
+
+// Remote integration tests
+task integTestRemote(type: RestIntegTestTask) {
+    testClassesDirs = sourceSets.test.output.classesDirs
+    classpath = sourceSets.test.runtimeClasspath
+
+    systemProperty "https", System.getProperty("https")
+    systemProperty "user", System.getProperty("user")
+    systemProperty "password", System.getProperty("password")
+
+    systemProperty 'cluster.number_of_nodes', "${_numNodes}"
+
+    systemProperty 'tests.security.manager', 'false'
+
+    // run tests only if cluster has been set via system property
+    if (System.getProperty("tests.rest.cluster") != null) {
+        filter {
+            includeTestsMatching "org.opensearch.searchrelevance.*IT"
+        }
+    }
 }
 
 run {


### PR DESCRIPTION
We do received autocut for failing tests in distribution pipeline. For non-security tests they are failing because feature flag is not set properly and SRW is disabled. For secure tests error is not clear, adding command similar to other repos.

Fix one issue with failing integration tests, qnd trying to address second:
- enable feature flag as part of test setup
- add task for running on remote cluster

### Issues Resolved
https://github.com/opensearch-project/search-relevance/issues/52

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
