### PR TITLE
Fixed missing variants in Hybrid Optimizer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,5 +9,6 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Removed
 
 ### Fixed
+- Fixed missing variants in Hybrid Optimizer ([#124](https://github.com/opensearch-project/search-relevance/pull/124))
 
 ### Security

--- a/src/main/java/org/opensearch/searchrelevance/experiment/ExperimentOptionsForHybridSearch.java
+++ b/src/main/java/org/opensearch/searchrelevance/experiment/ExperimentOptionsForHybridSearch.java
@@ -41,8 +41,23 @@ public class ExperimentOptionsForHybridSearch implements ExperimentOptions {
         for (String normalizationTechnique : normalizationTechniques) {
             for (String combinationTechnique : combinationTechniques) {
                 if (includeWeights) {
-                    for (float queryWeightForCombination = weightsRange.getRangeMin(); queryWeightForCombination <= weightsRange
-                        .getRangeMax(); queryWeightForCombination += weightsRange.getIncrement()) {
+                    // use integer-based approach to avoid floating-point precision issues
+                    float min = weightsRange.getRangeMin();
+                    float max = weightsRange.getRangeMax();
+                    float increment = weightsRange.getIncrement();
+
+                    // calculate number of steps to ensure we include all values including the max
+                    int steps = Math.round((max - min) / increment) + 1;
+
+                    for (int i = 0; i < steps; i++) {
+                        // calculate weight, ensuring the last step is exactly the max value
+                        float queryWeightForCombination;
+                        if (i == steps - 1) {
+                            queryWeightForCombination = max;
+                        } else {
+                            queryWeightForCombination = min + (i * increment);
+                        }
+
                         allPossibleParameterCombinations.add(
                             ExperimentVariantHybridSearchDTO.builder()
                                 .normalizationTechnique(normalizationTechnique)

--- a/src/main/java/org/opensearch/searchrelevance/experiment/QuerySourceUtil.java
+++ b/src/main/java/org/opensearch/searchrelevance/experiment/QuerySourceUtil.java
@@ -67,15 +67,15 @@ public class QuerySourceUtil {
      */
     public static void validateHybridQuery(Map<String, Object> fullQueryMap) throws IOException {
         if (fullQueryMap.containsKey("query") == false || fullQueryMap.get("query") instanceof Map == false) {
-            throw new IllegalArgumentException("query in search configuration does not have query");
+            throw new IllegalArgumentException("search configuration must have at least one query");
         }
         Map<String, Object> queryMap = (Map<String, Object>) fullQueryMap.get("query");
         if (queryMap.containsKey("hybrid") == false || queryMap.get("hybrid") instanceof Map<?, ?> == false) {
-            throw new IllegalArgumentException("query in search configuration does must be of type hybrid");
+            throw new IllegalArgumentException("query in search configuration must be of type hybrid");
         }
         Map<String, Object> hybridMap = (Map<String, Object>) queryMap.get("hybrid");
         if (hybridMap.containsKey("queries") == false || hybridMap.get("queries") instanceof List<?> == false) {
-            throw new IllegalArgumentException("hybrid query in search configuration does not have queries");
+            throw new IllegalArgumentException("hybrid query in search configuration does not have sub-queries");
         }
         List<?> queriesMap = (List<?>) hybridMap.get("queries");
         if (queriesMap.size() != NUMBER_OF_SUBQUERIES_IN_HYBRID_QUERY) {

--- a/src/test/java/org/opensearch/searchrelevance/action/experiments/ExperimentIT.java
+++ b/src/test/java/org/opensearch/searchrelevance/action/experiments/ExperimentIT.java
@@ -10,6 +10,7 @@ package org.opensearch.searchrelevance.action.experiments;
 import static org.opensearch.searchrelevance.common.PluginConstants.EVALUATION_RESULT_INDEX;
 import static org.opensearch.searchrelevance.common.PluginConstants.EXPERIMENTS_URI;
 import static org.opensearch.searchrelevance.common.PluginConstants.EXPERIMENT_INDEX;
+import static org.opensearch.searchrelevance.common.PluginConstants.EXPERIMENT_VARIANT_INDEX;
 import static org.opensearch.searchrelevance.common.PluginConstants.JUDGMENTS_URL;
 import static org.opensearch.searchrelevance.common.PluginConstants.QUERYSETS_URL;
 import static org.opensearch.searchrelevance.common.PluginConstants.SEARCH_CONFIGURATIONS_URL;
@@ -68,6 +69,12 @@ public class ExperimentIT extends BaseSearchRelevanceIT {
         )
     );
     private static final String INDEX_NAME_ESCI = "ecommerce";
+    // Expected number of variants per query for HYBRID_OPTIMIZER experiments
+    private static final int EXPECTED_VARIANTS_PER_QUERY = 66;
+    // Timeout values
+    private static final int MAX_POLL_RETRIES = 15;
+    private static final int POLL_INTERVAL_MS = 10000; // 10 seconds
+    private static final int POST_COMPLETION_WAIT_MS = 10000; // 10 seconds
 
     @SneakyThrows
     public void testPointwiseEvaluationExperiment_whenQueryWithPlaceholder_thenSuccessful() {
@@ -86,6 +93,49 @@ public class ExperimentIT extends BaseSearchRelevanceIT {
         assertEvaluationResults(queryTextToEvaluationId, judgmentId, searchConfigurationId);
 
         deleteIndex(INDEX_NAME_ESCI);
+    }
+
+    @SneakyThrows
+    public void testHybridOptimizerExperiment_whenHybridQueries_thenSuccessful() {
+        // This test is a best-effort test that verifies hybrid optimizer experiments
+        // It may be affected by system resource constraints in CI environments
+
+        // Arrange
+        initializeIndexIfNotExist(INDEX_NAME_ESCI);
+
+        String hybridSearchConfigId = createHybridSearchConfiguration();
+        String querySetId = createQuerySet();
+        String judgmentId = createJudgment();
+
+        try {
+            // Act
+            String experimentId = createHybridOptimizerExperiment(querySetId, hybridSearchConfigId, judgmentId);
+
+            // Wait for the experiment to be created and indexed
+            Thread.sleep(5000);
+
+            // Assert experiment exists with correct type
+            // We don't wait for completion since it may time out in constrained environments
+            Map<String, Object> experimentSource = getExperiment(experimentId);
+            assertNotNull("Experiment should exist", experimentSource);
+            assertEquals("HYBRID_OPTIMIZER", experimentSource.get("type"));
+            assertEquals(querySetId, experimentSource.get("querySetId"));
+
+            // If experiment completed, try to verify variants for a well-known query
+            // This is a best-effort verification that may be skipped if resources are constrained
+            if ("COMPLETED".equals(experimentSource.get("status"))) {
+                try {
+                    // Use a query we know has judgments
+                    String sampleQueryTerm = "button"; // Known to have judgments
+                    assertHybridOptimizerExperimentVariantsForQuery(experimentId, sampleQueryTerm);
+                } catch (Exception e) {
+                    // Log but don't fail the test if variant verification fails
+                    logger.error("Couldn't retrieve judgements for query text", e);
+                }
+            }
+        } finally {
+            deleteIndex(INDEX_NAME_ESCI);
+        }
     }
 
     private void assertEvaluationResults(Map<String, String> queryTextToEvaluationId, String judgmentId, String searchConfigurationId)
@@ -193,6 +243,270 @@ public class ExperimentIT extends BaseSearchRelevanceIT {
         return queryTextToEvaluationId;
     }
 
+    private void assertHybridOptimizerExperimentVariantsForQuery(String experimentId, String queryText) throws IOException {
+        // First get all evaluation results for this query text
+        List<String> evaluationIds = getEvaluationResultIdsForQuery(queryText);
+
+        // We should have found some evaluation results
+        assertFalse("Should have evaluation results for query: " + queryText, evaluationIds.isEmpty());
+
+        // Now get the experiment variants that reference these evaluation result IDs
+        List<Map<String, Object>> variants = getExperimentVariantsForEvaluationIds(experimentId, evaluationIds);
+
+        // We should have found some experiment variants
+        assertFalse("Should have experiment variants for query: " + queryText, variants.isEmpty());
+
+        // We should have multiple variants for the query
+        assertEquals(EXPECTED_VARIANTS_PER_QUERY, variants.size());
+
+        // Verify structure of a few variants
+        int variantsToCheck = Math.min(3, variants.size());
+
+        for (int i = 0; i < variantsToCheck; i++) {
+            Map<String, Object> source = variants.get(i);
+            assertNotNull(source);
+
+            assertEquals(experimentId, source.get("experimentId"));
+
+            // Parameters are nested in a "parameters" object
+            Map<String, Object> parameters = (Map<String, Object>) source.get("parameters");
+            assertNotNull("Parameters object should exist", parameters);
+            assertNotNull("Normalization should exist", parameters.get("normalization"));
+            assertNotNull("Combination should exist", parameters.get("combination"));
+            assertNotNull("Weights should exist", parameters.get("weights"));
+
+            // Check results
+            Map<String, Object> results = (Map<String, Object>) source.get("results");
+            assertNotNull("Results should exist", results);
+            String evaluationResultId = (String) results.get("evaluationResultId");
+            assertNotNull("Evaluation result ID should exist", evaluationResultId);
+
+            // Verify the evaluation result exists and has the correct query text
+            verifyEvaluationResult(evaluationResultId, queryText);
+        }
+    }
+
+    private List<String> getEvaluationResultIdsForQuery(String queryText) throws IOException {
+        String getEvaluationResultsUrl = String.join("/", EVALUATION_RESULT_INDEX, "_search");
+        String evaluationResultsQuery = "{ \"size\": 100, \"query\": { \"term\": { \"searchText\": \"" + queryText + "\" } } }";
+
+        Response getEvaluationResponse = makeRequest(
+            client(),
+            RestRequest.Method.POST.name(),
+            getEvaluationResultsUrl,
+            null,
+            toHttpEntity(evaluationResultsQuery),
+            ImmutableList.of(new BasicHeader(HttpHeaders.USER_AGENT, DEFAULT_USER_AGENT))
+        );
+
+        Map<String, Object> getEvaluationResultJson = entityAsMap(getEvaluationResponse);
+        Map<String, Object> hitsObj = (Map<String, Object>) getEvaluationResultJson.get("hits");
+        List<Map<String, Object>> evaluationHits = (List<Map<String, Object>>) hitsObj.get("hits");
+
+        // Extract the evaluation result IDs
+        List<String> evaluationIds = new ArrayList<>();
+        for (Map<String, Object> hit : evaluationHits) {
+            String evalId = (String) hit.get("_id");
+            evaluationIds.add(evalId);
+        }
+
+        return evaluationIds;
+    }
+
+    private List<Map<String, Object>> getExperimentVariantsForEvaluationIds(String experimentId, List<String> evaluationIds)
+        throws IOException {
+        if (evaluationIds.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        String getVariantsUrl = String.join("/", EXPERIMENT_VARIANT_INDEX, "_search");
+
+        // Build the nested query for evaluationResultId
+        StringBuilder termsBuilder = new StringBuilder();
+        for (int i = 0; i < evaluationIds.size(); i++) {
+            termsBuilder.append("\"").append(evaluationIds.get(i)).append("\"");
+            if (i < evaluationIds.size() - 1) {
+                termsBuilder.append(", ");
+            }
+        }
+
+        // Use nested query for results.evaluationResultId
+        String nestedQuery = "{ \"size\": 100, \"query\": { \"bool\": { \"must\": [ "
+            + "  { \"term\": { \"experimentId\": \""
+            + experimentId
+            + "\" } }, "
+            + "  { \"nested\": { "
+            + "      \"path\": \"results\", "
+            + "      \"query\": { "
+            + "        \"terms\": { "
+            + "          \"results.evaluationResultId\": ["
+            + termsBuilder.toString()
+            + "]"
+            + "        } "
+            + "      } "
+            + "    } "
+            + "  } "
+            + "] } } }";
+
+        Response getVariantsResponse = makeRequest(
+            client(),
+            RestRequest.Method.POST.name(),
+            getVariantsUrl,
+            null,
+            toHttpEntity(nestedQuery),
+            ImmutableList.of(new BasicHeader(HttpHeaders.USER_AGENT, DEFAULT_USER_AGENT))
+        );
+
+        Map<String, Object> getVariantsResultJson = entityAsMap(getVariantsResponse);
+        Map<String, Object> variantHitsObj = (Map<String, Object>) getVariantsResultJson.get("hits");
+        List<Map<String, Object>> variantHits = (List<Map<String, Object>>) variantHitsObj.get("hits");
+
+        // Extract the sources
+        List<Map<String, Object>> sources = new ArrayList<>();
+        for (Map<String, Object> hit : variantHits) {
+            sources.add((Map<String, Object>) hit.get("_source"));
+        }
+
+        return sources;
+    }
+
+    private void verifyEvaluationResult(String evaluationResultId, String queryText) throws IOException {
+        String getEvaluationByIdUrl = String.join("/", EVALUATION_RESULT_INDEX, "_doc", evaluationResultId);
+        Response getEvaluationResponse = makeRequest(
+            client(),
+            RestRequest.Method.GET.name(),
+            getEvaluationByIdUrl,
+            null,
+            null,
+            ImmutableList.of(new BasicHeader(HttpHeaders.USER_AGENT, DEFAULT_USER_AGENT))
+        );
+        Map<String, Object> getEvaluationResultJson = entityAsMap(getEvaluationResponse);
+        assertNotNull(getEvaluationResultJson);
+
+        Map<String, Object> evaluationSource = (Map<String, Object>) getEvaluationResultJson.get("_source");
+        assertNotNull(evaluationSource);
+
+        // Verify the search text matches the query
+        assertEquals("Evaluation search text should match query", queryText, evaluationSource.get("searchText"));
+
+        // Verify we have metrics
+        List<Map> metrics = (List<Map>) evaluationSource.get("metrics");
+        assertNotNull("Metrics should exist", metrics);
+        assertFalse("Metrics should not be empty", metrics.isEmpty());
+
+        // Verify we have document IDs
+        List<String> documentIds = (List<String>) evaluationSource.get("documentIds");
+        assertNotNull("Document IDs should exist", documentIds);
+        assertFalse("Document IDs should not be empty", documentIds.isEmpty());
+    }
+
+    private void assertHybridOptimizerExperimentCreation(
+        Map<String, Object> source,
+        String judgmentId,
+        String searchConfigurationId,
+        String querySetId
+    ) {
+        assertNotNull(source.get("id"));
+        assertNotNull(source.get("timestamp"));
+
+        List<String> judgmentList = (List<String>) source.get("judgmentList");
+        assertNotNull(judgmentList);
+        assertEquals(1, judgmentList.size());
+        assertEquals(judgmentId, judgmentList.get(0));
+
+        List<String> searchConfigurationList = (List<String>) source.get("searchConfigurationList");
+        assertNotNull(searchConfigurationList);
+        assertEquals(1, searchConfigurationList.size());
+        assertEquals(searchConfigurationId, searchConfigurationList.get(0));
+
+        assertEquals("HYBRID_OPTIMIZER", source.get("type"));
+        assertEquals(querySetId, source.get("querySetId"));
+    }
+
+    private Map<String, Object> getExperiment(String experimentId) throws IOException {
+        String getExperimentByIdUrl = String.join("/", EXPERIMENT_INDEX, "_doc", experimentId);
+        Response getExperimentResponse = makeRequest(
+            client(),
+            RestRequest.Method.GET.name(),
+            getExperimentByIdUrl,
+            null,
+            null,
+            ImmutableList.of(new BasicHeader(HttpHeaders.USER_AGENT, DEFAULT_USER_AGENT))
+        );
+        Map<String, Object> getExperimentResultJson = entityAsMap(getExperimentResponse);
+        assertNotNull(getExperimentResultJson);
+        assertEquals(experimentId, getExperimentResultJson.get("_id").toString());
+
+        return (Map<String, Object>) getExperimentResultJson.get("_source");
+    }
+
+    private Map<String, Object> pollExperimentUntilCompleted(String experimentId) throws IOException {
+        Map<String, Object> source = null;
+        String getExperimentByIdUrl = String.join("/", EXPERIMENT_INDEX, "_doc", experimentId);
+
+        int retryCount = 0;
+        String status = "PROCESSING";
+
+        while (("PROCESSING".equals(status) || status == null) && retryCount < MAX_POLL_RETRIES) {
+            Response getExperimentResponse = makeRequest(
+                client(),
+                RestRequest.Method.GET.name(),
+                getExperimentByIdUrl,
+                null,
+                null,
+                ImmutableList.of(new BasicHeader(HttpHeaders.USER_AGENT, DEFAULT_USER_AGENT))
+            );
+            Map<String, Object> getExperimentResultJson = entityAsMap(getExperimentResponse);
+            assertNotNull(getExperimentResultJson);
+            assertEquals(experimentId, getExperimentResultJson.get("_id").toString());
+
+            source = (Map<String, Object>) getExperimentResultJson.get("_source");
+            assertNotNull(source);
+            status = (String) source.get("status");
+
+            if ("PROCESSING".equals(status) || status == null) {
+                retryCount++;
+                try {
+                    Thread.sleep(POLL_INTERVAL_MS);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    break;
+                }
+            }
+        }
+
+        // Assert that we have a valid experiment status
+        assertNotNull("Experiment status should not be null", status);
+
+        // Refresh all related indices to ensure documents are available for search
+        makeRequest(
+            client(),
+            RestRequest.Method.POST.name(),
+            EXPERIMENT_VARIANT_INDEX + "/_refresh",
+            null,
+            null,
+            ImmutableList.of(new BasicHeader(HttpHeaders.USER_AGENT, DEFAULT_USER_AGENT))
+        );
+
+        makeRequest(
+            client(),
+            RestRequest.Method.POST.name(),
+            EVALUATION_RESULT_INDEX + "/_refresh",
+            null,
+            null,
+            ImmutableList.of(new BasicHeader(HttpHeaders.USER_AGENT, DEFAULT_USER_AGENT))
+        );
+
+        // Add delay to ensure data propagation
+        try {
+            Thread.sleep(POST_COMPLETION_WAIT_MS);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+
+        return source;
+    }
+
     private String createExperiment(String querySetId, String searchConfigurationId, String judgmentId) throws IOException,
         URISyntaxException, InterruptedException {
         String createExperimentBody = replacePlaceholders(
@@ -213,6 +527,27 @@ public class ExperimentIT extends BaseSearchRelevanceIT {
         assertEquals("CREATED", createExperimentResultJson.get("experiment_result").toString());
 
         Thread.sleep(1000);
+        return experimentId;
+    }
+
+    private String createHybridOptimizerExperiment(String querySetId, String searchConfigurationId, String judgmentId) throws IOException,
+        URISyntaxException, InterruptedException {
+        String createExperimentBody = replacePlaceholders(
+            Files.readString(Path.of(classLoader.getResource("experiment/CreateExperimentHybridOptimizer.json").toURI())),
+            Map.of("query_set_id", querySetId, "search_config_id", searchConfigurationId, "judgment_id", judgmentId)
+        );
+        Response createExperimentResponse = makeRequest(
+            client(),
+            RestRequest.Method.PUT.name(),
+            EXPERIMENTS_URI,
+            null,
+            toHttpEntity(createExperimentBody),
+            ImmutableList.of(new BasicHeader(HttpHeaders.USER_AGENT, DEFAULT_USER_AGENT))
+        );
+        Map<String, Object> createExperimentResultJson = entityAsMap(createExperimentResponse);
+        String experimentId = createExperimentResultJson.get("experiment_id").toString();
+        assertNotNull(experimentId);
+        assertEquals("CREATED", createExperimentResultJson.get("experiment_result").toString());
         return experimentId;
     }
 
@@ -255,6 +590,25 @@ public class ExperimentIT extends BaseSearchRelevanceIT {
     private String createSearchConfiguration() {
         String createSearchConfigurationRequestBody = Files.readString(
             Path.of(classLoader.getResource("searchconfig/CreateSearchConfigurationQueryWithPlaceholder.json").toURI())
+        );
+        Response createSearchConfigurationResponse = makeRequest(
+            client(),
+            RestRequest.Method.PUT.name(),
+            SEARCH_CONFIGURATIONS_URL,
+            null,
+            toHttpEntity(createSearchConfigurationRequestBody),
+            ImmutableList.of(new BasicHeader(HttpHeaders.USER_AGENT, DEFAULT_USER_AGENT))
+        );
+        Map<String, Object> createSearchConfigurationResultJson = entityAsMap(createSearchConfigurationResponse);
+        String searchConfigurationId = createSearchConfigurationResultJson.get("search_configuration_id").toString();
+        assertNotNull(searchConfigurationId);
+        return searchConfigurationId;
+    }
+
+    @SneakyThrows
+    private String createHybridSearchConfiguration() {
+        String createSearchConfigurationRequestBody = Files.readString(
+            Path.of(classLoader.getResource("searchconfig/CreateSearchConfigurationHybridQuery.json").toURI())
         );
         Response createSearchConfigurationResponse = makeRequest(
             client(),

--- a/src/test/java/org/opensearch/searchrelevance/experiment/ExperimentOptionsForHybridSearchTests.java
+++ b/src/test/java/org/opensearch/searchrelevance/experiment/ExperimentOptionsForHybridSearchTests.java
@@ -1,0 +1,210 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+package org.opensearch.searchrelevance.experiment;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.opensearch.test.OpenSearchTestCase;
+
+public class ExperimentOptionsForHybridSearchTests extends OpenSearchTestCase {
+
+    private static final float DELTA_FOR_FLOAT_ASSERTION = 0.0001f;
+
+    public void testGetParameterCombinations_whenIncludeWeightsTrue_thenReturnAllCombinations() {
+        // Given
+        Set<String> normalizationTechniques = Set.of("min_max", "l2");
+        Set<String> combinationTechniques = Set.of("arithmetic_mean", "harmonic_mean");
+        ExperimentOptionsForHybridSearch.WeightsRange weightsRange = ExperimentOptionsForHybridSearch.WeightsRange.builder()
+            .rangeMin(0.0f)
+            .rangeMax(1.0f)
+            .increment(0.5f)
+            .build();
+
+        ExperimentOptionsForHybridSearch options = ExperimentOptionsForHybridSearch.builder()
+            .normalizationTechniques(normalizationTechniques)
+            .combinationTechniques(combinationTechniques)
+            .weightsRange(weightsRange)
+            .build();
+
+        // When
+        List<ExperimentVariantHybridSearchDTO> result = options.getParameterCombinations(true);
+
+        // Then
+        assertNotNull(result);
+        assertEquals(12, result.size()); // 2 normalization * 2 combination * 2 weight values (0.0, 0.5, 1.0)
+
+        // Verify first combination
+        ExperimentVariantHybridSearchDTO firstCombination = result.get(0);
+        assertEquals("min_max", firstCombination.getNormalizationTechnique());
+        assertEquals("arithmetic_mean", firstCombination.getCombinationTechnique());
+        assertEquals(0.0f, firstCombination.getQueryWeightsForCombination()[0], DELTA_FOR_FLOAT_ASSERTION);
+        assertEquals(1.0f, firstCombination.getQueryWeightsForCombination()[1], DELTA_FOR_FLOAT_ASSERTION);
+
+        // Verify last combination
+        ExperimentVariantHybridSearchDTO lastCombination = result.get(result.size() - 1);
+        assertEquals("l2", lastCombination.getNormalizationTechnique());
+        assertEquals("harmonic_mean", lastCombination.getCombinationTechnique());
+        assertEquals(1.0f, lastCombination.getQueryWeightsForCombination()[0], DELTA_FOR_FLOAT_ASSERTION);
+        assertEquals(0.0f, lastCombination.getQueryWeightsForCombination()[1], DELTA_FOR_FLOAT_ASSERTION);
+    }
+
+    public void testGetParameterCombinations_whenIncludeWeightsFalse_thenReturnDefaultWeights() {
+        // Given
+        Set<String> normalizationTechniques = Set.of("min_max", "l2");
+        Set<String> combinationTechniques = Set.of("arithmetic_mean", "harmonic_mean");
+        ExperimentOptionsForHybridSearch.WeightsRange weightsRange = ExperimentOptionsForHybridSearch.WeightsRange.builder()
+            .rangeMin(0.0f)
+            .rangeMax(1.0f)
+            .increment(0.5f)
+            .build();
+
+        ExperimentOptionsForHybridSearch options = ExperimentOptionsForHybridSearch.builder()
+            .normalizationTechniques(normalizationTechniques)
+            .combinationTechniques(combinationTechniques)
+            .weightsRange(weightsRange)
+            .build();
+
+        // When
+        List<ExperimentVariantHybridSearchDTO> result = options.getParameterCombinations(false);
+
+        // Then
+        assertNotNull(result);
+        assertEquals(4, result.size()); // 2 normalization * 2 combination techniques
+
+        // Verify all combinations have default weights
+        for (ExperimentVariantHybridSearchDTO combination : result) {
+            assertEquals(0.5f, combination.getQueryWeightsForCombination()[0], DELTA_FOR_FLOAT_ASSERTION);
+            assertEquals(0.5f, combination.getQueryWeightsForCombination()[1], DELTA_FOR_FLOAT_ASSERTION);
+        }
+    }
+
+    public void testGetParameterCombinations_whenEmptyTechniques_thenReturnEmptyList() {
+        // Given
+        Set<String> emptySet = new HashSet<>();
+        ExperimentOptionsForHybridSearch.WeightsRange weightsRange = ExperimentOptionsForHybridSearch.WeightsRange.builder()
+            .rangeMin(0.0f)
+            .rangeMax(1.0f)
+            .increment(0.5f)
+            .build();
+
+        ExperimentOptionsForHybridSearch options = ExperimentOptionsForHybridSearch.builder()
+            .normalizationTechniques(emptySet)
+            .combinationTechniques(Set.of("arithmetic_mean"))
+            .weightsRange(weightsRange)
+            .build();
+
+        // When
+        List<ExperimentVariantHybridSearchDTO> result = options.getParameterCombinations(true);
+
+        // Then
+        assertNotNull(result);
+        assertEquals(0, result.size());
+    }
+
+    public void testWeightsRange_gettersAndSetters() {
+        // Given
+        ExperimentOptionsForHybridSearch.WeightsRange weightsRange = ExperimentOptionsForHybridSearch.WeightsRange.builder()
+            .rangeMin(0.1f)
+            .rangeMax(0.9f)
+            .increment(0.2f)
+            .build();
+
+        // Then
+        assertEquals(0.1f, weightsRange.getRangeMin(), DELTA_FOR_FLOAT_ASSERTION);
+        assertEquals(0.9f, weightsRange.getRangeMax(), DELTA_FOR_FLOAT_ASSERTION);
+        assertEquals(0.2f, weightsRange.getIncrement(), DELTA_FOR_FLOAT_ASSERTION);
+    }
+
+    public void testExperimentOptionsForHybridSearch_gettersAndSetters() {
+        // Given
+        Set<String> normalizationTechniques = Set.of("min_max");
+        Set<String> combinationTechniques = Set.of("arithmetic_mean");
+        ExperimentOptionsForHybridSearch.WeightsRange weightsRange = ExperimentOptionsForHybridSearch.WeightsRange.builder()
+            .rangeMin(0.0f)
+            .rangeMax(1.0f)
+            .increment(0.5f)
+            .build();
+
+        // When
+        ExperimentOptionsForHybridSearch options = ExperimentOptionsForHybridSearch.builder()
+            .normalizationTechniques(normalizationTechniques)
+            .combinationTechniques(combinationTechniques)
+            .weightsRange(weightsRange)
+            .build();
+
+        // Then
+        assertEquals(normalizationTechniques, options.getNormalizationTechniques());
+        assertEquals(combinationTechniques, options.getCombinationTechniques());
+        assertEquals(weightsRange, options.getWeightsRange());
+    }
+
+    public void testGetParameterCombinations_withPreciseIncrements_shouldIncludeAllWeights() {
+        // Given
+        Set<String> normalizationTechniques = Set.of("min_max", "l2");
+        Set<String> combinationTechniques = Set.of("arithmetic_mean", "harmonic_mean", "geometric_mean");
+        ExperimentOptionsForHybridSearch.WeightsRange weightsRange = ExperimentOptionsForHybridSearch.WeightsRange.builder()
+            .rangeMin(0.0f)
+            .rangeMax(1.0f)
+            .increment(0.1f)
+            .build();
+
+        ExperimentOptionsForHybridSearch options = ExperimentOptionsForHybridSearch.builder()
+            .normalizationTechniques(normalizationTechniques)
+            .combinationTechniques(combinationTechniques)
+            .weightsRange(weightsRange)
+            .build();
+
+        // When
+        List<ExperimentVariantHybridSearchDTO> combinations = options.getParameterCombinations(true);
+
+        // Then
+        // 2 normalization techniques * 3 combination techniques * 11 weights (0.0 to 1.0 in 0.1 increments) = 66
+        assertEquals(66, combinations.size());
+
+        // Check that edge cases exist (both [0.0, 1.0] and [1.0, 0.0] weight combinations)
+        boolean foundWeight10 = false;
+        boolean foundWeight01 = false;
+
+        for (ExperimentVariantHybridSearchDTO combo : combinations) {
+            float weight0 = combo.getQueryWeightsForCombination()[0];
+            float weight1 = combo.getQueryWeightsForCombination()[1];
+
+            if (Math.abs(weight0 - 1.0f) < DELTA_FOR_FLOAT_ASSERTION && Math.abs(weight1 - 0.0f) < DELTA_FOR_FLOAT_ASSERTION) {
+                foundWeight10 = true;
+            }
+            if (Math.abs(weight0 - 0.0f) < DELTA_FOR_FLOAT_ASSERTION && Math.abs(weight1 - 1.0f) < DELTA_FOR_FLOAT_ASSERTION) {
+                foundWeight01 = true;
+            }
+        }
+
+        assertTrue("Missing weight combination [1.0, 0.0]", foundWeight10);
+        assertTrue("Missing weight combination [0.0, 1.0]", foundWeight01);
+
+        // Verify that we have all expected weights (0.0, 0.1, 0.2, ..., 0.9, 1.0)
+        Set<Float> uniqueWeights = new HashSet<>();
+        for (ExperimentVariantHybridSearchDTO combo : combinations) {
+            uniqueWeights.add(combo.getQueryWeightsForCombination()[0]);
+        }
+
+        assertEquals("Should have exactly 11 unique weights", 11, uniqueWeights.size());
+
+        // Check if all expected weights exist
+        for (float expected = 0.0f; expected <= 1.0f; expected += 0.1f) {
+            boolean foundWeight = false;
+            for (float actual : uniqueWeights) {
+                if (Math.abs(actual - expected) < DELTA_FOR_FLOAT_ASSERTION) {
+                    foundWeight = true;
+                    break;
+                }
+            }
+            assertTrue("Missing expected weight: " + expected, foundWeight);
+        }
+    }
+}

--- a/src/test/java/org/opensearch/searchrelevance/experiment/QuerySourceUtilTests.java
+++ b/src/test/java/org/opensearch/searchrelevance/experiment/QuerySourceUtilTests.java
@@ -78,7 +78,7 @@ public class QuerySourceUtilTests extends OpenSearchTestCase {
             IllegalArgumentException.class,
             () -> QuerySourceUtil.validateHybridQuery(fullQuery)
         );
-        assertEquals("query in search configuration does not have query", exception.getMessage());
+        assertEquals("search configuration must have at least one query", exception.getMessage());
     }
 
     public void testValidateHybridQuery_InvalidQueryType() {
@@ -89,7 +89,7 @@ public class QuerySourceUtilTests extends OpenSearchTestCase {
             IllegalArgumentException.class,
             () -> QuerySourceUtil.validateHybridQuery(fullQuery)
         );
-        assertEquals("query in search configuration does not have query", exception.getMessage());
+        assertEquals("search configuration must have at least one query", exception.getMessage());
     }
 
     public void testValidateHybridQuery_MissingHybrid() {
@@ -101,7 +101,7 @@ public class QuerySourceUtilTests extends OpenSearchTestCase {
             IllegalArgumentException.class,
             () -> QuerySourceUtil.validateHybridQuery(fullQuery)
         );
-        assertEquals("query in search configuration does must be of type hybrid", exception.getMessage());
+        assertEquals("query in search configuration must be of type hybrid", exception.getMessage());
     }
 
     public void testValidateHybridQuery_InvalidHybridType() {
@@ -114,7 +114,7 @@ public class QuerySourceUtilTests extends OpenSearchTestCase {
             IllegalArgumentException.class,
             () -> QuerySourceUtil.validateHybridQuery(fullQuery)
         );
-        assertEquals("query in search configuration does must be of type hybrid", exception.getMessage());
+        assertEquals("query in search configuration must be of type hybrid", exception.getMessage());
     }
 
     public void testValidateHybridQuery_MissingQueries() {
@@ -128,7 +128,7 @@ public class QuerySourceUtilTests extends OpenSearchTestCase {
             IllegalArgumentException.class,
             () -> QuerySourceUtil.validateHybridQuery(fullQuery)
         );
-        assertEquals("hybrid query in search configuration does not have queries", exception.getMessage());
+        assertEquals("hybrid query in search configuration does not have sub-queries", exception.getMessage());
     }
 
     public void testValidateHybridQuery_InvalidQueriesType() {
@@ -143,7 +143,7 @@ public class QuerySourceUtilTests extends OpenSearchTestCase {
             IllegalArgumentException.class,
             () -> QuerySourceUtil.validateHybridQuery(fullQuery)
         );
-        assertEquals("hybrid query in search configuration does not have queries", exception.getMessage());
+        assertEquals("hybrid query in search configuration does not have sub-queries", exception.getMessage());
     }
 
     public void testValidateHybridQuery_whenOneSubquery_thenFail() {

--- a/src/test/resources/data_esci/CreateIndex.json
+++ b/src/test/resources/data_esci/CreateIndex.json
@@ -4,7 +4,8 @@
       "number_of_shards": 4,
       "number_of_replicas": 0,
       "mapping.total_fields.limit": 20000,
-      "knn": true
+      "knn": true,
+      "refresh_interval": "100ms"
     },
     "analysis": {
       "filter": {

--- a/src/test/resources/experiment/CreateExperimentHybridOptimizer.json
+++ b/src/test/resources/experiment/CreateExperimentHybridOptimizer.json
@@ -1,0 +1,7 @@
+{
+  "querySetId": "{{query_set_id}}",
+  "searchConfigurationList": ["{{search_config_id}}"],
+  "size": 2,
+  "judgmentList": ["{{judgment_id}}"],
+  "type": "HYBRID_OPTIMIZER"
+}

--- a/src/test/resources/searchconfig/CreateSearchConfigurationHybridQuery.json
+++ b/src/test/resources/searchconfig/CreateSearchConfigurationHybridQuery.json
@@ -1,0 +1,6 @@
+{
+    "name": "hybrid_query_1",
+    "index": "ecommerce",
+    "query": "{\"query\":{\"hybrid\":{\"queries\":[{\"match\":{\"title\":\"%SearchText%\"}},{\"match\":{\"category\":\"%SearchText%\"}}]}}}",
+    "searchPipeline": ""
+}


### PR DESCRIPTION
### Description
Missing experiment variants for Hybrid Optimizer caused by floating-point precision errors when incrementing by 0.1 in the for-loop.
With this change we now:
- calculate the exact number of steps needed
- use an integer counter to avoid floating-point accumulation errors
- ensure the maximum value is precisely included by special-casing the last step

### Issues Resolved
https://github.com/opensearch-project/search-relevance/issues/109

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
