### PR TITLE
Changed http client to secured/admin for cases when we work with protected indexes

### DIFF
--- a/src/test/java/org/opensearch/searchrelevance/action/experiments/ExperimentIT.java
+++ b/src/test/java/org/opensearch/searchrelevance/action/experiments/ExperimentIT.java
@@ -189,7 +189,7 @@ public class ExperimentIT extends BaseSearchRelevanceIT {
     ) throws IOException {
         String getExperimentByIdUrl = String.join("/", EXPERIMENT_INDEX, "_doc", experimentId);
         Response getExperimentResponse = makeRequest(
-            client(),
+            adminClient(),
             RestRequest.Method.GET.name(),
             getExperimentByIdUrl,
             null,
@@ -426,7 +426,7 @@ public class ExperimentIT extends BaseSearchRelevanceIT {
     private Map<String, Object> getExperiment(String experimentId) throws IOException {
         String getExperimentByIdUrl = String.join("/", EXPERIMENT_INDEX, "_doc", experimentId);
         Response getExperimentResponse = makeRequest(
-            client(),
+            adminClient(),
             RestRequest.Method.GET.name(),
             getExperimentByIdUrl,
             null,
@@ -449,7 +449,7 @@ public class ExperimentIT extends BaseSearchRelevanceIT {
 
         while (("PROCESSING".equals(status) || status == null) && retryCount < MAX_POLL_RETRIES) {
             Response getExperimentResponse = makeRequest(
-                client(),
+                adminClient(),
                 RestRequest.Method.GET.name(),
                 getExperimentByIdUrl,
                 null,


### PR DESCRIPTION
Use admin http client for scenarios when we accessing protected/secured index `.plugins-search-relevance-experiment`, this should fix the failed tests runs when security is enabled in OpenSearch cluster. Example of such failed run in distribution CI: https://build.ci.opensearch.org/blue/organizations/jenkins/integ-test/detail/integ-test/9907/pipeline/135

### Issues Resolved
N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
