### PR TITLE
[Upport main] Reformatted release notes according to OS stadard schema (#151)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,18 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ## [Unreleased]
 
-### Added
+### Breaking Changes
 
-### Removed
+### Features
 
-### Fixed
-- Fixed missing variants in Hybrid Optimizer ([#124](https://github.com/opensearch-project/search-relevance/pull/124))
-- Run integTests with security as a PR check ([#136](https://github.com/opensearch-project/search-relevance/pull/136))
+### Enhancements
 
-### Security
+### Bug Fixes
+
+### Infrastructure
+
+### Documentation
+
+### Maintenance
+
+### Refactoring

--- a/release-notes/opensearch-search-relevance.release-notes-3.1.0.0.md
+++ b/release-notes/opensearch-search-relevance.release-notes-3.1.0.0.md
@@ -2,31 +2,40 @@
 
 Compatible with OpenSearch 3.1.0
 
-### Added
-- Added new experiment type for hybrid search ([#26](https://github.com/opensearch-project/search-relevance/pull/26))
-- Added feature flag for search relevance workbench ([#34](https://github.com/opensearch-project/search-relevance/pull/34))
-- [Enhancement] Extend data model to adopt different experiment options/parameters ([#29](https://github.com/opensearch-project/search-relevance/issues/29))
-- Added validation for hybrid query structure ([#40](https://github.com/opensearch-project/search-relevance/pull/40))
-- [Enhancement] Add support for importing judgments created externally from SRW.  ([#42](https://github.com/opensearch-project/search-relevance/pull/42)
-- Changing URL for plugin APIs to /_plugin/_search_relevance [backend] ([#62](https://github.com/opensearch-project/search-relevance/pull/62)
-- Added lazy index creation for all APIs ([#65](https://github.com/opensearch-project/search-relevance/pull/65)
-- Realistic test data set based on ESCI (products, queries, judgements) ([#70](https://github.com/opensearch-project/search-relevance/pull/70)
-- [Stats] Add stats API ([#63](https://github.com/opensearch-project/search-relevance/pull/63)))
+### Features
 
-### Fixed
-- Update demo setup to be include ubi and ecommerce data sets and run in OS 3.1 ([#10](https://github.com/opensearch-project/search-relevance/issues/10))
-- Build search request with normal parsing and wrapper query ([#22](https://github.com/opensearch-project/search-relevance/pull/22))
-- Change aggregation field from `action_name.keyword` to `action_name` to fix implicit judgments calculation ([#15](https://github.com/opensearch-project/search-relevance/issues/10)).
-- Fix COEC calculation: introduce rank in ClickthroughRate class, fix bucket size for positional aggregation, correct COEC claculation ([#23](https://github.com/opensearch-project/search-relevance/issues/23)).
-- LLM Judgment Processor Improvement ([#27](https://github.com/opensearch-project/search-relevance/pull/27))
-- Deal with experiment processing when no experiment variants exist. ([#45](https://github.com/opensearch-project/search-relevance/pull/45))
-- Extend the `src/test/demo.sh` script to support pointwise and hybrid experiments.
-- Enable Search Relevance backend plugin as part of running demo scripts. ([#60](https://github.com/opensearch-project/search-relevance/pull/60))
-- Move from Judgments being "scores" to Judgments being "ratings".  ([#64](https://github.com/opensearch-project/search-relevance/pull/64))
-- Extend hybrid search optimizer demo script to use models. ([#69](https://github.com/opensearch-project/search-relevance/pull/69))
-- Set limit for number of fields programmatically during index creation ([#74](https://github.com/opensearch-project/search-relevance/pull/74)
-- Change model for Judgment entity ([#77](https://github.com/opensearch-project/search-relevance/pull/77)
-- Fix judgment handling for implicit judgments to be aligned with data model for Judgment again ([#93](https://github.com/opensearch-project/search-relevance/pull/93)
-- Change model for Experiment and Evaluation Result entities: ([#99](https://github.com/opensearch-project/search-relevance/pull/99))
-- Refactor and fix LLM judgment duplication issue ([#98](https://github.com/opensearch-project/search-relevance/pull/98)))
-- add text validation and query set file size check ([#116](https://github.com/opensearch-project/search-relevance/pull/116)))
+* Added new experiment type for hybrid search ([#26](https://github.com/opensearch-project/search-relevance/pull/26))
+* Added feature flag for search relevance workbench ([#34](https://github.com/opensearch-project/search-relevance/pull/34))
+* Added validation for hybrid query structure ([#40](https://github.com/opensearch-project/search-relevance/pull/40))
+* Add support for importing judgments created externally from SRW ([#42](https://github.com/opensearch-project/search-relevance/pull/42))
+* Changing URL for plugin APIs to /_plugin/_search_relevance [backend] ([#62](https://github.com/opensearch-project/search-relevance/pull/62))
+* Add stats API ([#63](https://github.com/opensearch-project/search-relevance/pull/63))
+
+### Enhancements
+
+* Extend data model to adopt different experiment options/parameters ([#29](https://github.com/opensearch-project/search-relevance/issues/29))
+
+### Bug Fixes
+
+* Update demo setup to be include ubi and ecommerce data sets and run in OS 3.1 ([#10](https://github.com/opensearch-project/search-relevance/issues/10))
+* Build search request with normal parsing and wrapper query ([#22](https://github.com/opensearch-project/search-relevance/pull/22))
+* Change aggregation field from `action_name.keyword` to `action_name` to fix implicit judgments calculation ([#15](https://github.com/opensearch-project/search-relevance/issues/15))
+* Fix COEC calculation: introduce rank in ClickthroughRate class, fix bucket size for positional aggregation, correct COEC calculation ([#23](https://github.com/opensearch-project/search-relevance/issues/23))
+* LLM Judgment Processor Improvement ([#27](https://github.com/opensearch-project/search-relevance/pull/27))
+* Deal with experiment processing when no experiment variants exist ([#45](https://github.com/opensearch-project/search-relevance/pull/45))
+* Enable Search Relevance backend plugin as part of running demo scripts ([#60](https://github.com/opensearch-project/search-relevance/pull/60))
+* Move from Judgments being "scores" to Judgments being "ratings" ([#64](https://github.com/opensearch-project/search-relevance/pull/64))
+* Added lazy index creation for all APIs ([#65](https://github.com/opensearch-project/search-relevance/pull/65))
+* Extend hybrid search optimizer demo script to use models ([#69](https://github.com/opensearch-project/search-relevance/pull/69))
+* Set limit for number of fields programmatically during index creation ([#74](https://github.com/opensearch-project/search-relevance/pull/74))
+* Change model for Judgment entity ([#77](https://github.com/opensearch-project/search-relevance/pull/77))
+* Fix judgment handling for implicit judgments to be aligned with data model for Judgment again ([#93](https://github.com/opensearch-project/search-relevance/pull/93))
+* Change model for Experiment and Evaluation Result entities ([#99](https://github.com/opensearch-project/search-relevance/pull/99))
+* Refactor and fix LLM judgment duplication issue ([#98](https://github.com/opensearch-project/search-relevance/pull/98))
+* Add text validation and query set file size check ([#116](https://github.com/opensearch-project/search-relevance/pull/116))
+* Fixed missing variants in Hybrid Optimizer ([#124](https://github.com/opensearch-project/search-relevance/pull/124))
+
+### Infrastructure
+
+* Run integTests with security as a PR check ([#136](https://github.com/opensearch-project/search-relevance/pull/136))
+* Realistic test data set based on ESCI (products, queries, judgements) ([#70](https://github.com/opensearch-project/search-relevance/pull/70))


### PR DESCRIPTION
Manually to the upport of https://github.com/opensearch-project/search-relevance/pull/151, cherry picked from commit 4b096bbee3022b7e9da7738a0199633ba1315df3

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
