### PR TITLE
Updated plugin version to 3.2 after 3.1 release

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,7 @@ import java.util.stream.Collectors
 
 buildscript {
     ext {
-        opensearch_version = System.getProperty("opensearch.version", "3.1.0-SNAPSHOT")
+        opensearch_version = System.getProperty("opensearch.version", "3.2.0-SNAPSHOT")
         isSnapshot = "true" == System.getProperty("build.snapshot", "true")
         buildVersionQualifier = System.getProperty("build.version_qualifier", "")
         // 2.2.0-SNAPSHOT -> 2.2.0.0-SNAPSHOT


### PR DESCRIPTION
### Description
Bump plugin version to 3.2 to follow the release process and the rest of OpenSearch plugins. Will keep failing until all our dependencies are done with the same version bump on their side.

### Issues Resolved
https://github.com/opensearch-project/search-relevance/issues/149

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
