### PR TITLE
introduce task scheduler to create LLM judgment as batches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### Infrastructure
 * Added end to end integration tests for experiments ([#154](https://github.com/opensearch-project/search-relevance/pull/154))
+* Enabled tasks scheduling for llm judgments ([#166](https://github.com/opensearch-project/search-relevance/pull/166))
 
 ### Documentation
 

--- a/src/main/java/org/opensearch/searchrelevance/dao/JudgmentCacheDao.java
+++ b/src/main/java/org/opensearch/searchrelevance/dao/JudgmentCacheDao.java
@@ -150,7 +150,10 @@ public class JudgmentCacheDao {
                 SearchHit hit = response.getHits().getHits()[0];
             }
             listener.onResponse(response);
-        }, e -> { listener.onFailure(e); });
+        }, e -> {
+            LOGGER.debug("Cache lookup failed for docId: {} - continuing without cache", documentId);
+            listener.onFailure(e);
+        });
 
         return searchRelevanceIndicesManager.listDocsBySearchRequest(searchSourceBuilder, JUDGMENT_CACHE, wrappedListener);
     }

--- a/src/main/java/org/opensearch/searchrelevance/executors/JudgmentResponseProcessor.java
+++ b/src/main/java/org/opensearch/searchrelevance/executors/JudgmentResponseProcessor.java
@@ -1,0 +1,126 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+package org.opensearch.searchrelevance.executors;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentMap;
+
+import org.opensearch.action.search.SearchResponse;
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.search.SearchHit;
+import org.opensearch.searchrelevance.dao.JudgmentCacheDao;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+
+/**
+ * Handles processing of responses for LLM judgment generation
+ */
+@Log4j2
+@RequiredArgsConstructor
+public class JudgmentResponseProcessor {
+    private final JudgmentCacheDao judgmentCacheDao;
+
+    /**
+     * Process search response and collect hits
+     */
+    public void processSearchResponse(
+        SearchResponse response,
+        String configIndex,
+        ConcurrentMap<String, SearchHit> allHits,
+        JudgmentTaskContext context
+    ) {
+        try {
+            if (response.getHits().getTotalHits().value() == 0) {
+                log.warn("No hits found for search config index: {}", configIndex);
+                context.completeSearchTask(true);
+                return;
+            }
+
+            for (SearchHit hit : response.getHits().getHits()) {
+                allHits.put(hit.getId(), hit);
+            }
+
+            log.debug("Collected {} hits from index: {}", response.getHits().getHits().length, configIndex);
+            context.completeSearchTask(true);
+
+        } catch (Exception e) {
+            log.error("Failed to process search response for index: {}", configIndex, e);
+            context.completeSearchTask(false);
+        }
+    }
+
+    /**
+     * Process cache lookup response
+     */
+    public void processCacheResponse(
+        SearchResponse response,
+        String docId,
+        ConcurrentMap<String, Boolean> processedDocs,
+        JudgmentTaskContext context
+    ) {
+        try {
+            if (response.getHits().getTotalHits().value() > 0) {
+                SearchHit hit = response.getHits().getHits()[0];
+                Map<String, Object> source = hit.getSourceAsMap();
+                String rating = (String) source.get("rating");
+                String storedContextFields = (String) source.get("contextFieldsStr");
+
+                log.info("Found existing judgment for docId: {}, rating: {}, storedContextFields: {}", docId, rating, storedContextFields);
+
+                context.getDocIdToScore().put(docId, rating);
+                processedDocs.put(docId, true);
+            }
+
+            context.completeCacheTask(true);
+
+        } catch (Exception e) {
+            log.error("Failed to process cache response for docId: {}", docId, e);
+            context.completeCacheTask(false);
+        }
+    }
+
+    /**
+     * Handle search failure
+     */
+    public void handleSearchFailure(Exception e, String configIndex, JudgmentTaskContext context) {
+        log.error("Search failed for index: {}", configIndex, e);
+        context.completeSearchTask(false);
+
+        if (!context.isIgnoreFailure()) {
+            context.failJudgment(e);
+        }
+    }
+
+    /**
+     * Handle cache lookup failure
+     */
+    public void handleCacheFailure(Exception e, String docId, JudgmentTaskContext context) {
+        log.error("Cache lookup failed for docId: {}", docId, e);
+        context.completeCacheTask(false);
+    }
+
+    /**
+     * Handle LLM processing failure
+     */
+    public void handleLLMFailure(
+        Exception e,
+        String queryTextWithReference,
+        boolean ignoreFailure,
+        ActionListener<Map<String, String>> listener
+    ) {
+        log.error("LLM processing failed for query: {}", queryTextWithReference, e);
+
+        if (!ignoreFailure) {
+            listener.onFailure(e);
+        } else {
+            log.warn("Ignoring LLM failure due to ignoreFailure=true", e);
+            listener.onResponse(Map.of());
+        }
+    }
+}

--- a/src/main/java/org/opensearch/searchrelevance/executors/JudgmentTaskContext.java
+++ b/src/main/java/org/opensearch/searchrelevance/executors/JudgmentTaskContext.java
@@ -1,0 +1,170 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+package org.opensearch.searchrelevance.executors;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.searchrelevance.model.JudgmentBatchStatus;
+import org.opensearch.searchrelevance.model.SearchConfiguration;
+
+import lombok.Getter;
+import lombok.extern.log4j.Log4j2;
+
+/**
+ * Context for tracking LLM judgment generation tasks for a specific query
+ */
+@Log4j2
+@Getter
+public class JudgmentTaskContext {
+    private final String queryTextWithReference;
+    private final String modelId;
+    private final List<String> contextFields;
+    private final List<SearchConfiguration> searchConfigurations;
+    private final boolean ignoreFailure;
+
+    private final ConcurrentMap<String, String> docIdToScore;
+    private final AtomicInteger pendingSearchTasks;
+    private final AtomicInteger pendingCacheTasks;
+    private final AtomicInteger successfulTasks;
+    private final AtomicInteger failedTasks;
+    private final AtomicBoolean hasTerminated;
+    private final List<Future<?>> pendingTasks;
+    private volatile boolean cancelled;
+
+    private ActionListener<Map<String, String>> completionListener;
+
+    public JudgmentTaskContext(
+        String queryTextWithReference,
+        String modelId,
+        List<String> contextFields,
+        List<SearchConfiguration> searchConfigurations,
+        boolean ignoreFailure,
+        ActionListener<Map<String, String>> completionListener
+    ) {
+        this.queryTextWithReference = queryTextWithReference;
+        this.modelId = modelId;
+        this.contextFields = contextFields;
+        this.searchConfigurations = searchConfigurations;
+        this.ignoreFailure = ignoreFailure;
+        this.completionListener = completionListener;
+
+        this.docIdToScore = new ConcurrentHashMap<>();
+        this.pendingSearchTasks = new AtomicInteger(searchConfigurations.size());
+        this.pendingCacheTasks = new AtomicInteger(0);
+        this.successfulTasks = new AtomicInteger(0);
+        this.failedTasks = new AtomicInteger(0);
+        this.hasTerminated = new AtomicBoolean(false);
+        this.pendingTasks = new CopyOnWriteArrayList<>();
+        this.cancelled = false;
+
+        log.info(
+            "JudgmentTaskContext initialized for query: {} with {} search configurations",
+            queryTextWithReference,
+            searchConfigurations.size()
+        );
+    }
+
+    public void setPendingCacheTasks(int count) {
+        this.pendingCacheTasks.set(count);
+    }
+
+    public void completeSearchTask(boolean success) {
+        if (hasTerminated.get()) return;
+
+        if (success) {
+            successfulTasks.incrementAndGet();
+        } else {
+            failedTasks.incrementAndGet();
+            log.warn("Search task failed for query: {} (ignoreFailure={})", queryTextWithReference, ignoreFailure);
+        }
+
+        if (pendingSearchTasks.decrementAndGet() == 0) {
+            log.debug("All search tasks completed for query: {}", queryTextWithReference);
+        }
+    }
+
+    public void completeCacheTask(boolean success) {
+        if (hasTerminated.get()) return;
+
+        if (success) {
+            successfulTasks.incrementAndGet();
+        } else {
+            failedTasks.incrementAndGet();
+            log.warn("Cache task failed for query: {} (ignoreFailure={})", queryTextWithReference, ignoreFailure);
+        }
+
+        if (pendingCacheTasks.decrementAndGet() == 0) {
+            log.debug("All cache tasks completed for query: {}", queryTextWithReference);
+        }
+    }
+
+    public boolean isAllTasksCompleted() {
+        return hasTerminated.get() || (pendingSearchTasks.get() == 0 && pendingCacheTasks.get() == 0);
+    }
+
+    public void completeJudgment() {
+        if (hasTerminated.get()) return;
+
+        JudgmentBatchStatus status = determineStatus();
+
+        log.info(
+            "Judgment completed for query: {} with {} ratings (success: {}, failed: {}, status: {})",
+            queryTextWithReference,
+            docIdToScore.size(),
+            successfulTasks.get(),
+            failedTasks.get(),
+            status
+        );
+
+        if (completionListener != null) {
+            completionListener.onResponse(docIdToScore);
+        }
+    }
+
+    private JudgmentBatchStatus determineStatus() {
+        if (hasTerminated.get() && !ignoreFailure) {
+            return JudgmentBatchStatus.TERMINATED;
+        }
+
+        int completedTasks = successfulTasks.get() + failedTasks.get();
+
+        if (completedTasks == 0) {
+            return JudgmentBatchStatus.SUCCESS;
+        }
+
+        if (failedTasks.get() == completedTasks) {
+            return JudgmentBatchStatus.ALL_FAILED;
+        } else if (failedTasks.get() > 0) {
+            return JudgmentBatchStatus.PARTIAL_SUCCESS;
+        } else {
+            return JudgmentBatchStatus.SUCCESS;
+        }
+    }
+
+    public JudgmentBatchStatus getStatus() {
+        return determineStatus();
+    }
+
+    public void failJudgment(Exception e) {
+        if (hasTerminated.getAndSet(true)) return;
+
+        log.error("Judgment failed for query: {} (ignoreFailure={})", queryTextWithReference, ignoreFailure, e);
+        if (completionListener != null) {
+            completionListener.onFailure(e);
+        }
+    }
+
+}

--- a/src/main/java/org/opensearch/searchrelevance/executors/LlmJudgmentTaskManager.java
+++ b/src/main/java/org/opensearch/searchrelevance/executors/LlmJudgmentTaskManager.java
@@ -1,0 +1,121 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+package org.opensearch.searchrelevance.executors;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Semaphore;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import org.opensearch.common.inject.Inject;
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.core.rest.RestStatus;
+import org.opensearch.searchrelevance.exception.SearchRelevanceException;
+import org.opensearch.searchrelevance.judgments.JudgmentDataTransformer;
+import org.opensearch.threadpool.ThreadPool;
+
+import lombok.extern.log4j.Log4j2;
+
+/**
+ * Manages concurrent execution of LLM judgment tasks at the query text level
+ */
+@Log4j2
+public class LlmJudgmentTaskManager {
+    private static final String THREAD_POOL_EXECUTOR_NAME = ThreadPool.Names.GENERIC;
+    private static final int DEFAULT_MIN_CONCURRENT_THREADS = 24;
+    private static final int PROCESSOR_NUMBER_DIVISOR = 2;
+    private static final int ALLOCATED_PROCESSORS = Runtime.getRuntime().availableProcessors();
+
+    private final ThreadPool threadPool;
+    private final Semaphore rateLimiter;
+    private final int maxConcurrentTasks;
+
+    @Inject
+    public LlmJudgmentTaskManager(ThreadPool threadPool) {
+        this.threadPool = threadPool;
+        this.maxConcurrentTasks = Math.max(2, Math.min(DEFAULT_MIN_CONCURRENT_THREADS, ALLOCATED_PROCESSORS / PROCESSOR_NUMBER_DIVISOR));
+        this.rateLimiter = new Semaphore(maxConcurrentTasks);
+        log.info(
+            "LlmJudgmentTaskManager initialized with {} max concurrent tasks (processors: {})",
+            maxConcurrentTasks,
+            ALLOCATED_PROCESSORS
+        );
+    }
+
+    public void scheduleTasksAsync(
+        List<String> queryTextWithReferences,
+        Function<String, Map<String, Object>> queryProcessor,
+        boolean ignoreFailure,
+        ActionListener<List<Map<String, Object>>> listener
+    ) {
+        int totalQueries = queryTextWithReferences.size();
+        log.info("Scheduling {} query text tasks for concurrent processing", totalQueries);
+
+        try {
+            List<CompletableFuture<Map<String, Object>>> futures = queryTextWithReferences.stream()
+                .map(queryTextWithReference -> CompletableFuture.supplyAsync(() -> {
+                    try {
+                        rateLimiter.acquire();
+                        try {
+                            return queryProcessor.apply(queryTextWithReference);
+                        } finally {
+                            rateLimiter.release();
+                        }
+                    } catch (Exception e) {
+                        log.warn("Query processing failed, returning empty result for: {}", queryTextWithReference, e);
+                        return JudgmentDataTransformer.createJudgmentResult(queryTextWithReference, Map.of());
+                    }
+                }, threadPool.executor(THREAD_POOL_EXECUTOR_NAME)))
+                .collect(Collectors.toList());
+
+            CompletableFuture.allOf(futures.toArray(new CompletableFuture[0])).whenComplete((v, ex) -> {
+                List<Map<String, Object>> results = futures.stream().map(future -> {
+                    try {
+                        return future.join();
+                    } catch (Exception e) {
+                        log.warn("Individual query future failed, skipping", e);
+                        return null;
+                    }
+                }).filter(result -> result != null).collect(Collectors.toList());
+
+                int processedQueries = results.size();
+                int successQueries = (int) results.stream().mapToLong(result -> {
+                    List<Map<String, String>> ratings = (List<Map<String, String>>) result.get("ratings");
+                    return ratings != null && !ratings.isEmpty() ? 1 : 0;
+                }).sum();
+                int failureQueries = totalQueries - processedQueries;
+
+                if (results.isEmpty() && ex != null) {
+                    log.error("Task manager failed - Total: {}, Processed: 0, Success: 0, Failure: {}", totalQueries, totalQueries, ex);
+                    listener.onFailure(
+                        new SearchRelevanceException("All query text judgments failed", ex, RestStatus.INTERNAL_SERVER_ERROR)
+                    );
+                } else {
+                    log.info(
+                        "Task manager completed - Total: {}, Processed: {}, Success: {}, Failure: {}",
+                        totalQueries,
+                        processedQueries,
+                        successQueries,
+                        failureQueries
+                    );
+                    log.info("Task manager calling listener.onResponse with {} results", results.size());
+                    listener.onResponse(results);
+                }
+            });
+        } catch (Exception e) {
+            log.error("Failed to schedule tasks - Total: {}", totalQueries, e);
+            if (!ignoreFailure) {
+                listener.onFailure(new SearchRelevanceException("Failed to schedule judgment tasks", e, RestStatus.INTERNAL_SERVER_ERROR));
+            } else {
+                listener.onResponse(List.of());
+            }
+        }
+    }
+}

--- a/src/main/java/org/opensearch/searchrelevance/indices/SearchRelevanceIndicesManager.java
+++ b/src/main/java/org/opensearch/searchrelevance/indices/SearchRelevanceIndicesManager.java
@@ -71,6 +71,7 @@ public class SearchRelevanceIndicesManager {
             stepListener.onResponse(null);
             return;
         }
+
         final CreateIndexRequest createIndexRequest = new CreateIndexRequest(indexName).mapping(mapping);
         StashedThreadContext.run(client, () -> client.admin().indices().create(createIndexRequest, new ActionListener<>() {
             @Override
@@ -86,8 +87,8 @@ public class SearchRelevanceIndicesManager {
                     stepListener.onResponse(null);
                     return;
                 }
-                log.error("Failed to create index [{}]", indexName, e);
-                stepListener.onFailure(e);
+                log.warn("Failed to create index [{}] - continuing without cache optimization", indexName);
+                stepListener.onResponse(null);
             }
         }));
     }

--- a/src/main/java/org/opensearch/searchrelevance/judgments/JudgmentDataTransformer.java
+++ b/src/main/java/org/opensearch/searchrelevance/judgments/JudgmentDataTransformer.java
@@ -1,0 +1,38 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+package org.opensearch.searchrelevance.judgments;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * Handles data transformation for judgment processing
+ */
+public class JudgmentDataTransformer {
+
+    public static Map<String, Object> createJudgmentResult(String queryTextWithReference, Map<String, String> docIdToScore) {
+        Map<String, Object> judgmentForQuery = new HashMap<>();
+        judgmentForQuery.put("query", queryTextWithReference);
+
+        List<Map<String, String>> docIdRatings = docIdToScore == null
+            ? List.of()
+            : docIdToScore.entrySet()
+                .stream()
+                .map(entry -> Map.of("docId", entry.getKey(), "rating", entry.getValue()))
+                .collect(Collectors.toList());
+
+        judgmentForQuery.put("ratings", docIdRatings);
+        return judgmentForQuery;
+    }
+
+    public static String extractQueryText(String queryTextWithReference, String delimiter) {
+        return queryTextWithReference.split(delimiter, 2)[0];
+    }
+}

--- a/src/main/java/org/opensearch/searchrelevance/judgments/JudgmentsProcessorFactory.java
+++ b/src/main/java/org/opensearch/searchrelevance/judgments/JudgmentsProcessorFactory.java
@@ -13,6 +13,7 @@ import org.opensearch.searchrelevance.dao.QuerySetDao;
 import org.opensearch.searchrelevance.dao.SearchConfigurationDao;
 import org.opensearch.searchrelevance.ml.MLAccessor;
 import org.opensearch.searchrelevance.model.JudgmentType;
+import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.transport.client.Client;
 
 public class JudgmentsProcessorFactory {
@@ -20,8 +21,8 @@ public class JudgmentsProcessorFactory {
     private final QuerySetDao querySetDao;
     private final SearchConfigurationDao searchConfigurationDao;
     private final JudgmentCacheDao judgmentCacheDao;
-
     private final Client client;
+    private final ThreadPool threadPool;
 
     @Inject
     public JudgmentsProcessorFactory(
@@ -29,18 +30,27 @@ public class JudgmentsProcessorFactory {
         QuerySetDao querySetDao,
         SearchConfigurationDao searchConfigurationDao,
         JudgmentCacheDao judgmentCacheDao,
-        Client client
+        Client client,
+        ThreadPool threadPool
     ) {
         this.mlAccessor = mlAccessor;
         this.querySetDao = querySetDao;
         this.searchConfigurationDao = searchConfigurationDao;
         this.judgmentCacheDao = judgmentCacheDao;
         this.client = client;
+        this.threadPool = threadPool;
     }
 
     public BaseJudgmentsProcessor getProcessor(JudgmentType type) {
         return switch (type) {
-            case LLM_JUDGMENT -> new LlmJudgmentsProcessor(mlAccessor, querySetDao, searchConfigurationDao, judgmentCacheDao, client);
+            case LLM_JUDGMENT -> new LlmJudgmentsProcessor(
+                mlAccessor,
+                querySetDao,
+                searchConfigurationDao,
+                judgmentCacheDao,
+                client,
+                threadPool
+            );
             case UBI_JUDGMENT -> new UbiJudgmentsProcessor(client);
             case IMPORT_JUDGMENT -> new ImportJudgmentsProcessor(client);
             default -> throw new IllegalArgumentException("Unsupported judgment type: " + type);

--- a/src/main/java/org/opensearch/searchrelevance/ml/ChunkProcessingContext.java
+++ b/src/main/java/org/opensearch/searchrelevance/ml/ChunkProcessingContext.java
@@ -1,0 +1,60 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+package org.opensearch.searchrelevance.ml;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.opensearch.core.action.ActionListener;
+
+/**
+ * Context for tracking chunk processing state during ML prediction
+ */
+public class ChunkProcessingContext {
+    private static final Logger LOGGER = LogManager.getLogger(ChunkProcessingContext.class);
+
+    private final ConcurrentMap<Integer, String> succeededChunks = new ConcurrentHashMap<>();
+    private final ConcurrentMap<Integer, String> failedChunks = new ConcurrentHashMap<>();
+    private final AtomicInteger processedChunks = new AtomicInteger(0);
+    private final int totalChunks;
+    private final ActionListener<ChunkResult> progressListener;
+
+    public ChunkProcessingContext(int totalChunks, ActionListener<ChunkResult> progressListener) {
+        this.totalChunks = totalChunks;
+        this.progressListener = progressListener;
+    }
+
+    public void handleSuccess(int chunkIndex, String response) {
+        succeededChunks.put(chunkIndex, response);
+        completeChunk(chunkIndex);
+    }
+
+    public void handleFailure(int chunkIndex, Exception error) {
+        failedChunks.put(chunkIndex, error.getMessage());
+        completeChunk(chunkIndex);
+    }
+
+    private void completeChunk(int chunkIndex) {
+        try {
+            int processed = processedChunks.incrementAndGet();
+            boolean isLastChunk = processed == totalChunks;
+
+            ChunkResult result = new ChunkResult(chunkIndex, totalChunks, isLastChunk, succeededChunks, failedChunks);
+
+            progressListener.onResponse(result);
+
+            // Always report results, let caller decide how to handle failures
+        } catch (Exception e) {
+            LOGGER.error("Error handling chunk completion for chunk {}", chunkIndex, e);
+            progressListener.onFailure(e);
+        }
+    }
+}

--- a/src/main/java/org/opensearch/searchrelevance/ml/ChunkResult.java
+++ b/src/main/java/org/opensearch/searchrelevance/ml/ChunkResult.java
@@ -49,6 +49,10 @@ public class ChunkResult {
         this.failedChunks = new HashMap<>(failedChunks);
     }
 
+    public int getChunkIndex() {
+        return chunkIndex;
+    }
+
     public int getSuccessfulChunksCount() {
         return succeededChunks.size();
     }

--- a/src/main/java/org/opensearch/searchrelevance/ml/MLAccessor.java
+++ b/src/main/java/org/opensearch/searchrelevance/ml/MLAccessor.java
@@ -7,56 +7,31 @@
  */
 package org.opensearch.searchrelevance.ml;
 
-import static org.opensearch.searchrelevance.common.MLConstants.INPUT_FORMAT_SEARCH;
-import static org.opensearch.searchrelevance.common.MLConstants.INPUT_FORMAT_SEARCH_WITH_REFERENCE;
-import static org.opensearch.searchrelevance.common.MLConstants.PARAM_MESSAGES_FIELD;
-import static org.opensearch.searchrelevance.common.MLConstants.PROMPT_JSON_MESSAGES_SHELL;
-import static org.opensearch.searchrelevance.common.MLConstants.PROMPT_SEARCH_RELEVANCE;
-import static org.opensearch.searchrelevance.common.MLConstants.RESPONSE_CHOICES_FIELD;
-import static org.opensearch.searchrelevance.common.MLConstants.RESPONSE_CONTENT_FIELD;
-import static org.opensearch.searchrelevance.common.MLConstants.RESPONSE_MESSAGE_FIELD;
-import static org.opensearch.searchrelevance.common.MLConstants.escapeJson;
-
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
-import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicInteger;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-import org.opensearch.common.xcontent.XContentFactory;
 import org.opensearch.core.action.ActionListener;
-import org.opensearch.core.common.util.CollectionUtils;
-import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.ml.client.MachineLearningNodeClient;
-import org.opensearch.ml.common.FunctionName;
-import org.opensearch.ml.common.dataset.remote.RemoteInferenceInputDataSet;
 import org.opensearch.ml.common.input.MLInput;
-import org.opensearch.ml.common.output.MLOutput;
-import org.opensearch.ml.common.output.model.ModelTensor;
-import org.opensearch.ml.common.output.model.ModelTensorOutput;
-import org.opensearch.ml.common.output.model.ModelTensors;
+
+import lombok.extern.log4j.Log4j2;
 
 /**
  * This is a ml-commons accessor that will call predict API and process ml input/output.
  */
+@Log4j2
 public class MLAccessor {
-    private MachineLearningNodeClient mlClient;
+    private final MachineLearningNodeClient mlClient;
+    private final MLInputOutputTransformer transformer;
 
-    private static final Logger LOGGER = LogManager.getLogger(MLAccessor.class);
     private static final int MAX_RETRY_NUMBER = 3;
     private static final long RETRY_DELAY_MS = 1000;
 
     public MLAccessor(MachineLearningNodeClient mlClient) {
         this.mlClient = mlClient;
+        this.transformer = new MLInputOutputTransformer();
     }
 
     public void predict(
@@ -65,53 +40,31 @@ public class MLAccessor {
         String searchText,
         String reference,
         Map<String, String> hits,
-        boolean ignoreFailure,
-        ActionListener<ChunkResult> progressListener  // For individual chunk
+        ActionListener<ChunkResult> progressListener
     ) {
-        List<MLInput> mlInputs = getMLInputs(tokenLimit, searchText, reference, hits);
-        LOGGER.info("Number of chunks: {}", mlInputs.size());
+        List<MLInput> mlInputs = transformer.createMLInputs(tokenLimit, searchText, reference, hits);
+        log.info("Number of chunks: {}", mlInputs.size());
 
-        ConcurrentMap<Integer, String> succeededChunks = new ConcurrentHashMap<>();
-        ConcurrentHashMap<Integer, String> failedChunks = new ConcurrentHashMap<>();
-        AtomicInteger processedChunks = new AtomicInteger(0);
+        ChunkProcessingContext context = new ChunkProcessingContext(mlInputs.size(), progressListener);
 
         for (int i = 0; i < mlInputs.size(); i++) {
-            final int chunkIndex = i;
-            predictSingleChunkWithRetry(modelId, mlInputs.get(chunkIndex), chunkIndex, 0, new ActionListener<String>() {
-                @Override
-                public void onResponse(String response) {
-                    LOGGER.info("Chunk {} processed successfully", chunkIndex);
-                    String processedResponse = response.substring(1, response.length() - 1); // remove brackets
-                    handleChunkCompletion(
-                        chunkIndex,
-                        processedResponse,
-                        null,
-                        mlInputs.size(),
-                        succeededChunks,
-                        failedChunks,
-                        ignoreFailure,
-                        processedChunks,
-                        progressListener
-                    );
-                }
-
-                @Override
-                public void onFailure(Exception e) {
-                    LOGGER.error("Chunk {} failed after all retries", chunkIndex, e);
-                    handleChunkCompletion(
-                        chunkIndex,
-                        null,
-                        e,
-                        mlInputs.size(),
-                        succeededChunks,
-                        failedChunks,
-                        ignoreFailure,
-                        processedChunks,
-                        progressListener
-                    );
-                }
-            });
+            processChunk(modelId, mlInputs.get(i), i, context);
         }
+    }
+
+    private void processChunk(String modelId, MLInput mlInput, int chunkIndex, ChunkProcessingContext context) {
+        predictSingleChunkWithRetry(modelId, mlInput, chunkIndex, 0, ActionListener.wrap(response -> {
+            log.info("Chunk {} processed successfully", chunkIndex);
+            String processedResponse = cleanResponse(response);
+            context.handleSuccess(chunkIndex, processedResponse);
+        }, e -> {
+            log.error("Chunk {} failed after all retries", chunkIndex, e);
+            context.handleFailure(chunkIndex, e);
+        }));
+    }
+
+    private String cleanResponse(String response) {
+        return response.substring(1, response.length() - 1); // remove brackets
     }
 
     private void predictSingleChunkWithRetry(
@@ -130,7 +83,7 @@ public class MLAccessor {
             @Override
             public void onFailure(Exception e) {
                 if (retryCount < MAX_RETRY_NUMBER) {
-                    LOGGER.warn("Chunk {} failed, attempt {}/{}. Retrying...", chunkIndex, retryCount + 1, MAX_RETRY_NUMBER);
+                    log.warn("Chunk {} failed, attempt {}/{}. Retrying...", chunkIndex, retryCount + 1, MAX_RETRY_NUMBER);
 
                     long delay = RETRY_DELAY_MS * (long) Math.pow(2, retryCount);
                     scheduleRetry(() -> predictSingleChunkWithRetry(modelId, mlInput, chunkIndex, retryCount + 1, chunkListener), delay);
@@ -149,172 +102,8 @@ public class MLAccessor {
         mlClient.predict(
             modelId,
             mlInput,
-            ActionListener.wrap(mlOutput -> listener.onResponse(extractResponseContent(mlOutput)), listener::onFailure)
+            ActionListener.wrap(mlOutput -> listener.onResponse(transformer.extractResponseContent(mlOutput)), listener::onFailure)
         );
-    }
-
-    private List<MLInput> getMLInputs(int tokenLimit, String searchText, String reference, Map<String, String> hits) {
-        List<MLInput> mlInputs = new ArrayList<>();
-        Map<String, String> currentChunk = new HashMap<>();
-
-        for (Map.Entry<String, String> entry : hits.entrySet()) {
-            Map<String, String> tempChunk = new HashMap<>(currentChunk);
-            tempChunk.put(entry.getKey(), entry.getValue());
-
-            String messages = formatMessages(searchText, reference, tempChunk);
-            int totalTokens = TokenizerUtil.countTokens(messages);
-
-            if (totalTokens > tokenLimit) {
-                if (currentChunk.isEmpty()) {
-                    // Single entry exceeds token limit
-                    LOGGER.warn("Entry with key {} causes total tokens to exceed limit of {}", entry.getKey(), tokenLimit);
-                    Map<String, String> singleEntryChunk = new HashMap<>();
-
-                    // Calculate tokens for the message with just this entry
-                    Map<String, String> testChunk = new HashMap<>();
-                    testChunk.put(entry.getKey(), entry.getValue());
-                    String testMessages = formatMessages(searchText, reference, testChunk);
-                    int excessTokens = TokenizerUtil.countTokens(testMessages) - tokenLimit;
-
-                    // Truncate the entry value
-                    int currentTokens = TokenizerUtil.countTokens(entry.getValue());
-                    String truncatedValue = TokenizerUtil.truncateString(entry.getValue(), Math.max(1, currentTokens - excessTokens));
-                    singleEntryChunk.put(entry.getKey(), truncatedValue);
-                    mlInputs.add(createMLInput(searchText, reference, singleEntryChunk));
-                } else {
-                    // Current chunk is full, add it and start new chunk
-                    mlInputs.add(createMLInput(searchText, reference, currentChunk));
-                    currentChunk = new HashMap<>();
-                    currentChunk.put(entry.getKey(), entry.getValue());
-                }
-            } else {
-                // Can add entry to current chunk
-                currentChunk.put(entry.getKey(), entry.getValue());
-            }
-        }
-
-        if (!currentChunk.isEmpty()) {
-            mlInputs.add(createMLInput(searchText, reference, currentChunk));
-        }
-
-        return mlInputs;
-    }
-
-    private String formatMessages(String searchText, String reference, Map<String, String> hits) {
-        try {
-            String hitsJson;
-            try (XContentBuilder builder = XContentFactory.jsonBuilder()) {
-                builder.startArray();
-                for (Map.Entry<String, String> hit : hits.entrySet()) {
-                    builder.startObject();
-                    builder.field("id", hit.getKey());
-                    builder.field("source", hit.getValue());
-                    builder.endObject();
-                }
-                builder.endArray();
-                hitsJson = builder.toString();
-            }
-            String userContent;
-            if (Objects.isNull(reference) || reference.isEmpty()) {
-                userContent = String.format(Locale.ROOT, INPUT_FORMAT_SEARCH, searchText, hitsJson);
-            } else {
-                userContent = String.format(Locale.ROOT, INPUT_FORMAT_SEARCH_WITH_REFERENCE, searchText, reference, hitsJson);
-            }
-            return String.format(Locale.ROOT, PROMPT_JSON_MESSAGES_SHELL, PROMPT_SEARCH_RELEVANCE, escapeJson(userContent));
-        } catch (IOException e) {
-            LOGGER.error("Error converting hits to JSON string", e);
-            throw new IllegalArgumentException("Failed to process hits", e);
-        }
-    }
-
-    private MLInput createMLInput(String searchText, String reference, Map<String, String> hits) {
-        Map<String, String> parameters = new HashMap<>();
-        parameters.put(PARAM_MESSAGES_FIELD, formatMessages(searchText, reference, hits));
-        return MLInput.builder().algorithm(FunctionName.REMOTE).inputDataset(new RemoteInferenceInputDataSet(parameters)).build();
-    }
-
-    private String extractResponseContent(MLOutput mlOutput) {
-        if (!(mlOutput instanceof ModelTensorOutput)) {
-            throw new IllegalArgumentException("Expected ModelTensorOutput, but got " + mlOutput.getClass().getSimpleName());
-        }
-
-        ModelTensorOutput modelTensorOutput = (ModelTensorOutput) mlOutput;
-        List<ModelTensors> tensorOutputList = modelTensorOutput.getMlModelOutputs();
-
-        if (CollectionUtils.isEmpty(tensorOutputList) || CollectionUtils.isEmpty(tensorOutputList.get(0).getMlModelTensors())) {
-            throw new IllegalStateException(
-                "Empty model result produced. Expected at least [1] tensor output and [1] model tensor, but got [0]"
-            );
-        }
-
-        ModelTensor tensor = tensorOutputList.get(0).getMlModelTensors().get(0);
-        Map<String, ?> dataMap = tensor.getDataAsMap();
-
-        Map<String, ?> choices = (Map<String, ?>) ((List<?>) dataMap.get(RESPONSE_CHOICES_FIELD)).get(0);
-        Map<String, ?> message = (Map<String, ?>) choices.get(RESPONSE_MESSAGE_FIELD);
-        String content = (String) message.get(RESPONSE_CONTENT_FIELD);
-        return content;
-    }
-
-    private void handleChunkCompletion(
-        int chunkIndex,
-        String response,
-        Exception error,
-        int totalChunks,
-        ConcurrentMap<Integer, String> succeededChunks,
-        ConcurrentMap<Integer, String> failedChunks,
-        boolean ignoreFailure,
-        AtomicInteger processedChunks,
-        ActionListener<ChunkResult> progressListener
-    ) {
-        try {
-            if (error != null) {
-                String errorMessage = error.getMessage();
-                failedChunks.put(chunkIndex, errorMessage);
-                if (!ignoreFailure) {
-                    progressListener.onFailure(error);
-                    return;
-                }
-            } else {
-                succeededChunks.put(chunkIndex, response);
-            }
-
-            int processed = processedChunks.incrementAndGet();
-            boolean isLastChunk = processed == totalChunks;
-
-            ChunkResult result = new ChunkResult(
-                chunkIndex,
-                totalChunks,
-                isLastChunk,
-                new HashMap<>(succeededChunks),
-                new HashMap<>(failedChunks)
-            );
-
-            progressListener.onResponse(result);
-
-            if (isLastChunk) {
-                handleFinalStatus(result, ignoreFailure, progressListener);
-            }
-        } catch (Exception e) {
-            LOGGER.error("Error handling chunk completion for chunk {}", chunkIndex, e);
-            if (!ignoreFailure) {
-                progressListener.onFailure(e);
-            }
-        }
-    }
-
-    private void handleFinalStatus(ChunkResult finalResult, boolean ignoreFailure, ActionListener<ChunkResult> progressListener) {
-        if (finalResult.getFailedChunksCount() > 0 && !ignoreFailure) {
-            String errorMessage = String.format(
-                Locale.ROOT,
-                "Failed to process %d out of %d chunks",
-                finalResult.getFailedChunksCount(),
-                finalResult.getTotalChunks()
-            );
-            progressListener.onFailure(new RuntimeException(errorMessage));
-        } else {
-            progressListener.onResponse(finalResult);
-        }
     }
 
 }

--- a/src/main/java/org/opensearch/searchrelevance/ml/MLInputOutputTransformer.java
+++ b/src/main/java/org/opensearch/searchrelevance/ml/MLInputOutputTransformer.java
@@ -1,0 +1,152 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+package org.opensearch.searchrelevance.ml;
+
+import static org.opensearch.searchrelevance.common.MLConstants.INPUT_FORMAT_SEARCH;
+import static org.opensearch.searchrelevance.common.MLConstants.INPUT_FORMAT_SEARCH_WITH_REFERENCE;
+import static org.opensearch.searchrelevance.common.MLConstants.PARAM_MESSAGES_FIELD;
+import static org.opensearch.searchrelevance.common.MLConstants.PROMPT_JSON_MESSAGES_SHELL;
+import static org.opensearch.searchrelevance.common.MLConstants.PROMPT_SEARCH_RELEVANCE;
+import static org.opensearch.searchrelevance.common.MLConstants.RESPONSE_CHOICES_FIELD;
+import static org.opensearch.searchrelevance.common.MLConstants.RESPONSE_CONTENT_FIELD;
+import static org.opensearch.searchrelevance.common.MLConstants.RESPONSE_MESSAGE_FIELD;
+import static org.opensearch.searchrelevance.common.MLConstants.escapeJson;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+
+import org.opensearch.common.xcontent.XContentFactory;
+import org.opensearch.core.common.util.CollectionUtils;
+import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.ml.common.FunctionName;
+import org.opensearch.ml.common.dataset.remote.RemoteInferenceInputDataSet;
+import org.opensearch.ml.common.input.MLInput;
+import org.opensearch.ml.common.output.MLOutput;
+import org.opensearch.ml.common.output.model.ModelTensor;
+import org.opensearch.ml.common.output.model.ModelTensorOutput;
+import org.opensearch.ml.common.output.model.ModelTensors;
+
+import lombok.extern.log4j.Log4j2;
+
+/**
+ * Handles ML input/output transformations for search relevance predictions
+ */
+@Log4j2
+public class MLInputOutputTransformer {
+
+    public List<MLInput> createMLInputs(int tokenLimit, String searchText, String reference, Map<String, String> hits) {
+        List<MLInput> mlInputs = new ArrayList<>();
+        Map<String, String> currentChunk = new HashMap<>();
+
+        for (Map.Entry<String, String> entry : hits.entrySet()) {
+            Map<String, String> tempChunk = new HashMap<>(currentChunk);
+            tempChunk.put(entry.getKey(), entry.getValue());
+
+            String messages = formatMessages(searchText, reference, tempChunk);
+            int totalTokens = TokenizerUtil.countTokens(messages);
+
+            if (totalTokens > tokenLimit) {
+                if (currentChunk.isEmpty()) {
+                    mlInputs.add(handleOversizedEntry(entry, searchText, reference, tokenLimit));
+                } else {
+                    mlInputs.add(createMLInput(searchText, reference, currentChunk));
+                    currentChunk = new HashMap<>();
+                    currentChunk.put(entry.getKey(), entry.getValue());
+                }
+            } else {
+                currentChunk.put(entry.getKey(), entry.getValue());
+            }
+        }
+
+        if (!currentChunk.isEmpty()) {
+            mlInputs.add(createMLInput(searchText, reference, currentChunk));
+        }
+
+        return mlInputs;
+    }
+
+    private MLInput handleOversizedEntry(Map.Entry<String, String> entry, String searchText, String reference, int tokenLimit) {
+        log.warn("Entry with key {} causes total tokens to exceed limit of {}", entry.getKey(), tokenLimit);
+
+        Map<String, String> testChunk = Map.of(entry.getKey(), entry.getValue());
+        String testMessages = formatMessages(searchText, reference, testChunk);
+        int excessTokens = TokenizerUtil.countTokens(testMessages) - tokenLimit;
+
+        int currentTokens = TokenizerUtil.countTokens(entry.getValue());
+        String truncatedValue = TokenizerUtil.truncateString(entry.getValue(), Math.max(1, currentTokens - excessTokens));
+
+        Map<String, String> singleEntryChunk = Map.of(entry.getKey(), truncatedValue);
+        return createMLInput(searchText, reference, singleEntryChunk);
+    }
+
+    public MLInput createMLInput(String searchText, String reference, Map<String, String> hits) {
+        Map<String, String> parameters = new HashMap<>();
+        parameters.put(PARAM_MESSAGES_FIELD, formatMessages(searchText, reference, hits));
+        return MLInput.builder().algorithm(FunctionName.REMOTE).inputDataset(new RemoteInferenceInputDataSet(parameters)).build();
+    }
+
+    public String formatMessages(String searchText, String reference, Map<String, String> hits) {
+        try {
+            String hitsJson = buildHitsJson(hits);
+            String userContent = buildUserContent(searchText, reference, hitsJson);
+            return String.format(Locale.ROOT, PROMPT_JSON_MESSAGES_SHELL, PROMPT_SEARCH_RELEVANCE, escapeJson(userContent));
+        } catch (IOException e) {
+            log.error("Error converting hits to JSON string", e);
+            throw new IllegalArgumentException("Failed to process hits", e);
+        }
+    }
+
+    private String buildHitsJson(Map<String, String> hits) throws IOException {
+        try (XContentBuilder builder = XContentFactory.jsonBuilder()) {
+            builder.startArray();
+            for (Map.Entry<String, String> hit : hits.entrySet()) {
+                builder.startObject();
+                builder.field("id", hit.getKey());
+                builder.field("source", hit.getValue());
+                builder.endObject();
+            }
+            builder.endArray();
+            return builder.toString();
+        }
+    }
+
+    private String buildUserContent(String searchText, String reference, String hitsJson) {
+        if (Objects.isNull(reference) || reference.isEmpty()) {
+            return String.format(Locale.ROOT, INPUT_FORMAT_SEARCH, searchText, hitsJson);
+        } else {
+            return String.format(Locale.ROOT, INPUT_FORMAT_SEARCH_WITH_REFERENCE, searchText, reference, hitsJson);
+        }
+    }
+
+    public String extractResponseContent(MLOutput mlOutput) {
+        if (!(mlOutput instanceof ModelTensorOutput)) {
+            throw new IllegalArgumentException("Expected ModelTensorOutput, but got " + mlOutput.getClass().getSimpleName());
+        }
+
+        ModelTensorOutput modelTensorOutput = (ModelTensorOutput) mlOutput;
+        List<ModelTensors> tensorOutputList = modelTensorOutput.getMlModelOutputs();
+
+        if (CollectionUtils.isEmpty(tensorOutputList) || CollectionUtils.isEmpty(tensorOutputList.get(0).getMlModelTensors())) {
+            throw new IllegalStateException(
+                "Empty model result produced. Expected at least [1] tensor output and [1] model tensor, but got [0]"
+            );
+        }
+
+        ModelTensor tensor = tensorOutputList.get(0).getMlModelTensors().get(0);
+        Map<String, ?> dataMap = tensor.getDataAsMap();
+
+        Map<String, ?> choices = (Map<String, ?>) ((List<?>) dataMap.get(RESPONSE_CHOICES_FIELD)).get(0);
+        Map<String, ?> message = (Map<String, ?>) choices.get(RESPONSE_MESSAGE_FIELD);
+        return (String) message.get(RESPONSE_CONTENT_FIELD);
+    }
+}

--- a/src/main/java/org/opensearch/searchrelevance/model/JudgmentBatchStatus.java
+++ b/src/main/java/org/opensearch/searchrelevance/model/JudgmentBatchStatus.java
@@ -1,0 +1,34 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+package org.opensearch.searchrelevance.model;
+
+/**
+ * Enum representing the aggregate status of a batch of judgment generation tasks
+ * within a query processing during LLM judgment execution.
+ */
+public enum JudgmentBatchStatus {
+    /**
+     * All judgment generation tasks in the batch have completed successfully
+     */
+    SUCCESS,
+
+    /**
+     * Some judgment tasks succeeded while others failed
+     */
+    PARTIAL_SUCCESS,
+
+    /**
+     * All judgment generation tasks in the batch have failed
+     */
+    ALL_FAILED,
+
+    /**
+     * Processing was terminated early due to critical failure (ignoreFailure=false)
+     */
+    TERMINATED
+}

--- a/src/test/java/org/opensearch/searchrelevance/executors/JudgmentDataTransformerTests.java
+++ b/src/test/java/org/opensearch/searchrelevance/executors/JudgmentDataTransformerTests.java
@@ -1,0 +1,187 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+package org.opensearch.searchrelevance.executors;
+
+import java.util.List;
+import java.util.Map;
+
+import org.opensearch.searchrelevance.judgments.JudgmentDataTransformer;
+import org.opensearch.test.OpenSearchTestCase;
+
+public class JudgmentDataTransformerTests extends OpenSearchTestCase {
+
+    private JudgmentDataTransformer transformer;
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        transformer = new JudgmentDataTransformer();
+    }
+
+    public void testCreateJudgmentResultWithRatings() {
+        // Arrange
+        String queryTextWithReference = "laptop||Professional laptop for business";
+        Map<String, String> docIdToScore = Map.of("doc1", "0.9", "doc2", "0.7", "doc3", "0.5");
+
+        // Act
+        Map<String, Object> result = transformer.createJudgmentResult(queryTextWithReference, docIdToScore);
+
+        // Assert
+        assertEquals(queryTextWithReference, result.get("query"));
+
+        List<Map<String, Object>> ratings = (List<Map<String, Object>>) result.get("ratings");
+        assertEquals(3, ratings.size());
+
+        // Verify ratings content
+        Map<String, String> ratingsMap = Map.of(
+            (String) ratings.get(0).get("docId"),
+            (String) ratings.get(0).get("rating"),
+            (String) ratings.get(1).get("docId"),
+            (String) ratings.get(1).get("rating"),
+            (String) ratings.get(2).get("docId"),
+            (String) ratings.get(2).get("rating")
+        );
+
+        assertEquals("0.9", ratingsMap.get("doc1"));
+        assertEquals("0.7", ratingsMap.get("doc2"));
+        assertEquals("0.5", ratingsMap.get("doc3"));
+    }
+
+    public void testCreateJudgmentResultWithEmptyRatings() {
+        // Arrange
+        String queryTextWithReference = "laptop||Professional laptop for business";
+        Map<String, String> docIdToScore = Map.of();
+
+        // Act
+        Map<String, Object> result = transformer.createJudgmentResult(queryTextWithReference, docIdToScore);
+
+        // Assert
+        assertEquals(queryTextWithReference, result.get("query"));
+
+        List<Map<String, Object>> ratings = (List<Map<String, Object>>) result.get("ratings");
+        assertEquals(0, ratings.size());
+    }
+
+    public void testCreateJudgmentResultWithNullRatings() {
+        // Arrange
+        String queryTextWithReference = "laptop||Professional laptop for business";
+        Map<String, String> docIdToScore = null;
+
+        // Act
+        Map<String, Object> result = transformer.createJudgmentResult(queryTextWithReference, docIdToScore);
+
+        // Assert
+        assertEquals(queryTextWithReference, result.get("query"));
+
+        List<Map<String, Object>> ratings = (List<Map<String, Object>>) result.get("ratings");
+        assertEquals(0, ratings.size());
+    }
+
+    public void testCreateJudgmentResultWithQueryOnly() {
+        // Arrange
+        String queryTextWithReference = "laptop";
+        Map<String, String> docIdToScore = Map.of("doc1", "0.8");
+
+        // Act
+        Map<String, Object> result = transformer.createJudgmentResult(queryTextWithReference, docIdToScore);
+
+        // Assert
+        assertEquals(queryTextWithReference, result.get("query"));
+
+        List<Map<String, Object>> ratings = (List<Map<String, Object>>) result.get("ratings");
+        assertEquals(1, ratings.size());
+        assertEquals("doc1", ratings.get(0).get("docId"));
+        assertEquals("0.8", ratings.get(0).get("rating"));
+    }
+
+    public void testCreateJudgmentResultRatingStructure() {
+        // Arrange
+        String queryTextWithReference = "test query";
+        Map<String, String> docIdToScore = Map.of("testDoc", "0.95");
+
+        // Act
+        Map<String, Object> result = transformer.createJudgmentResult(queryTextWithReference, docIdToScore);
+
+        // Assert
+        List<Map<String, Object>> ratings = (List<Map<String, Object>>) result.get("ratings");
+        Map<String, Object> rating = ratings.get(0);
+
+        assertEquals(2, rating.size());
+        assertTrue(rating.containsKey("docId"));
+        assertTrue(rating.containsKey("rating"));
+        assertEquals("testDoc", rating.get("docId"));
+        assertEquals("0.95", rating.get("rating"));
+    }
+
+    public void testCreateJudgmentResultMultipleRatingsOrder() {
+        // Arrange
+        String queryTextWithReference = "test query";
+        Map<String, String> docIdToScore = Map.of("docA", "0.1", "docB", "0.2", "docC", "0.3");
+
+        // Act
+        Map<String, Object> result = transformer.createJudgmentResult(queryTextWithReference, docIdToScore);
+
+        // Assert
+        List<Map<String, Object>> ratings = (List<Map<String, Object>>) result.get("ratings");
+        assertEquals(3, ratings.size());
+
+        // Verify all expected docIds are present
+        List<String> docIds = ratings.stream().map(rating -> (String) rating.get("docId")).toList();
+
+        assertTrue(docIds.contains("docA"));
+        assertTrue(docIds.contains("docB"));
+        assertTrue(docIds.contains("docC"));
+    }
+
+    public void testCreateJudgmentResultWithSpecialCharacters() {
+        // Arrange
+        String queryTextWithReference = "special||query with \"quotes\" and 'apostrophes'";
+        Map<String, String> docIdToScore = Map.of("doc-with-dash", "0.6");
+
+        // Act
+        Map<String, Object> result = transformer.createJudgmentResult(queryTextWithReference, docIdToScore);
+
+        // Assert
+        assertEquals(queryTextWithReference, result.get("query"));
+
+        List<Map<String, Object>> ratings = (List<Map<String, Object>>) result.get("ratings");
+        assertEquals(1, ratings.size());
+        assertEquals("doc-with-dash", ratings.get(0).get("docId"));
+        assertEquals("0.6", ratings.get(0).get("rating"));
+    }
+
+    public void testCreateJudgmentResultWithZeroRating() {
+        // Arrange
+        String queryTextWithReference = "test query";
+        Map<String, String> docIdToScore = Map.of("doc1", "0.0");
+
+        // Act
+        Map<String, Object> result = transformer.createJudgmentResult(queryTextWithReference, docIdToScore);
+
+        // Assert
+        List<Map<String, Object>> ratings = (List<Map<String, Object>>) result.get("ratings");
+        assertEquals(1, ratings.size());
+        assertEquals("doc1", ratings.get(0).get("docId"));
+        assertEquals("0.0", ratings.get(0).get("rating"));
+    }
+
+    public void testCreateJudgmentResultWithMaxRating() {
+        // Arrange
+        String queryTextWithReference = "test query";
+        Map<String, String> docIdToScore = Map.of("doc1", "1.0");
+
+        // Act
+        Map<String, Object> result = transformer.createJudgmentResult(queryTextWithReference, docIdToScore);
+
+        // Assert
+        List<Map<String, Object>> ratings = (List<Map<String, Object>>) result.get("ratings");
+        assertEquals(1, ratings.size());
+        assertEquals("doc1", ratings.get(0).get("docId"));
+        assertEquals("1.0", ratings.get(0).get("rating"));
+    }
+}

--- a/src/test/java/org/opensearch/searchrelevance/executors/JudgmentResponseProcessorTests.java
+++ b/src/test/java/org/opensearch/searchrelevance/executors/JudgmentResponseProcessorTests.java
@@ -1,0 +1,213 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+package org.opensearch.searchrelevance.executors;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+import org.apache.lucene.search.TotalHits;
+import org.opensearch.action.search.SearchResponse;
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.core.common.bytes.BytesArray;
+import org.opensearch.search.SearchHit;
+import org.opensearch.search.SearchHits;
+import org.opensearch.searchrelevance.dao.JudgmentCacheDao;
+import org.opensearch.test.OpenSearchTestCase;
+
+public class JudgmentResponseProcessorTests extends OpenSearchTestCase {
+
+    private JudgmentCacheDao judgmentCacheDao;
+    private JudgmentResponseProcessor processor;
+    private JudgmentTaskContext context;
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        judgmentCacheDao = mock(JudgmentCacheDao.class);
+        processor = new JudgmentResponseProcessor(judgmentCacheDao);
+        context = createMockContext();
+    }
+
+    public void testProcessSearchResponseSuccess() {
+        // Arrange
+        SearchResponse response = createSearchResponse(2);
+        ConcurrentMap<String, SearchHit> allHits = new ConcurrentHashMap<>();
+        String configIndex = "test-index";
+
+        // Act
+        processor.processSearchResponse(response, configIndex, allHits, context);
+
+        // Assert
+        assertEquals(2, allHits.size());
+        verify(context).completeSearchTask(true);
+    }
+
+    public void testProcessSearchResponseNoHits() {
+        // Arrange
+        SearchResponse response = createSearchResponse(0);
+        ConcurrentMap<String, SearchHit> allHits = new ConcurrentHashMap<>();
+        String configIndex = "test-index";
+
+        // Act
+        processor.processSearchResponse(response, configIndex, allHits, context);
+
+        // Assert
+        assertEquals(0, allHits.size());
+        verify(context).completeSearchTask(true);
+    }
+
+    public void testProcessSearchResponseException() {
+        // Arrange
+        SearchResponse response = mock(SearchResponse.class);
+        when(response.getHits()).thenThrow(new RuntimeException("Test exception"));
+        ConcurrentMap<String, SearchHit> allHits = new ConcurrentHashMap<>();
+        String configIndex = "test-index";
+
+        // Act
+        processor.processSearchResponse(response, configIndex, allHits, context);
+
+        // Assert
+        verify(context).completeSearchTask(false);
+    }
+
+    public void testProcessCacheResponseFound() {
+        // Arrange
+        SearchResponse response = createCacheResponse("0.8", "field1,field2");
+        String docId = "doc1";
+        ConcurrentMap<String, Boolean> processedDocs = new ConcurrentHashMap<>();
+
+        // Act
+        processor.processCacheResponse(response, docId, processedDocs, context);
+
+        // Assert
+        verify(context).getDocIdToScore();
+        verify(context).completeCacheTask(true);
+        assertTrue(processedDocs.get(docId));
+    }
+
+    public void testProcessCacheResponseNotFound() {
+        // Arrange
+        SearchResponse response = createSearchResponse(0);
+        String docId = "doc1";
+        ConcurrentMap<String, Boolean> processedDocs = new ConcurrentHashMap<>();
+
+        // Act
+        processor.processCacheResponse(response, docId, processedDocs, context);
+
+        // Assert
+        verify(context).completeCacheTask(true);
+        assertNull(processedDocs.get(docId));
+    }
+
+    public void testHandleSearchFailure() {
+        // Arrange
+        Exception error = new RuntimeException("Search failed");
+        String configIndex = "test-index";
+
+        // Act
+        processor.handleSearchFailure(error, configIndex, context);
+
+        // Assert
+        verify(context).completeSearchTask(false);
+    }
+
+    public void testHandleSearchFailureWithIgnoreFailureFalse() {
+        // Arrange
+        when(context.isIgnoreFailure()).thenReturn(false);
+        Exception error = new RuntimeException("Search failed");
+        String configIndex = "test-index";
+
+        // Act
+        processor.handleSearchFailure(error, configIndex, context);
+
+        // Assert
+        verify(context).completeSearchTask(false);
+        verify(context).failJudgment(error);
+    }
+
+    public void testHandleCacheFailure() {
+        // Arrange
+        Exception error = new RuntimeException("Cache failed");
+        String docId = "doc1";
+
+        // Act
+        processor.handleCacheFailure(error, docId, context);
+
+        // Assert
+        verify(context).completeCacheTask(false);
+    }
+
+    public void testHandleLLMFailureWithIgnoreFailureFalse() {
+        // Arrange
+        Exception error = new RuntimeException("LLM failed");
+        String queryText = "test query";
+        ActionListener<Map<String, String>> listener = mock(ActionListener.class);
+
+        // Act
+        processor.handleLLMFailure(error, queryText, false, listener);
+
+        // Assert
+        verify(listener).onFailure(error);
+        verify(listener, never()).onResponse(any());
+    }
+
+    public void testHandleLLMFailureWithIgnoreFailureTrue() {
+        // Arrange
+        Exception error = new RuntimeException("LLM failed");
+        String queryText = "test query";
+        ActionListener<Map<String, String>> listener = mock(ActionListener.class);
+
+        // Act
+        processor.handleLLMFailure(error, queryText, true, listener);
+
+        // Assert
+        verify(listener).onResponse(Map.of());
+        verify(listener, never()).onFailure(any());
+    }
+
+    private JudgmentTaskContext createMockContext() {
+        JudgmentTaskContext context = mock(JudgmentTaskContext.class);
+        when(context.getDocIdToScore()).thenReturn(new ConcurrentHashMap<>());
+        when(context.isIgnoreFailure()).thenReturn(true);
+        return context;
+    }
+
+    private SearchResponse createSearchResponse(int hitCount) {
+        SearchResponse response = mock(SearchResponse.class);
+
+        SearchHit[] hitArray = new SearchHit[hitCount];
+        for (int i = 0; i < hitCount; i++) {
+            hitArray[i] = new SearchHit(i, "doc" + i, null, null);
+        }
+
+        SearchHits hits = new SearchHits(hitArray, new TotalHits(hitCount, TotalHits.Relation.EQUAL_TO), 0);
+        when(response.getHits()).thenReturn(hits);
+
+        return response;
+    }
+
+    private SearchResponse createCacheResponse(String rating, String contextFields) {
+        SearchResponse response = mock(SearchResponse.class);
+
+        String jsonSource = "{\"rating\":\"" + rating + "\",\"contextFieldsStr\":\"" + contextFields + "\"}";
+        SearchHit hit = new SearchHit(0, "doc1", null, null);
+        hit.sourceRef(new BytesArray(jsonSource));
+
+        SearchHits hits = new SearchHits(new SearchHit[] { hit }, new TotalHits(1, TotalHits.Relation.EQUAL_TO), 0);
+        when(response.getHits()).thenReturn(hits);
+
+        return response;
+    }
+}

--- a/src/test/java/org/opensearch/searchrelevance/executors/JudgmentTaskContextTests.java
+++ b/src/test/java/org/opensearch/searchrelevance/executors/JudgmentTaskContextTests.java
@@ -1,0 +1,361 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+package org.opensearch.searchrelevance.executors;
+
+import static org.mockito.Mockito.mock;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.searchrelevance.model.JudgmentBatchStatus;
+import org.opensearch.searchrelevance.model.SearchConfiguration;
+import org.opensearch.test.OpenSearchTestCase;
+
+public class JudgmentTaskContextTests extends OpenSearchTestCase {
+
+    public void testTaskContextInitialization() {
+        // Arrange
+        String queryTextWithReference = "laptop#Professional laptop for business";
+        String modelId = "test-model-id";
+        List<String> contextFields = List.of("name", "description");
+        List<SearchConfiguration> searchConfigurations = List.of(mock(SearchConfiguration.class));
+        boolean ignoreFailure = true;
+        ActionListener<Map<String, String>> listener = mock(ActionListener.class);
+
+        // Act
+        JudgmentTaskContext context = new JudgmentTaskContext(
+            queryTextWithReference,
+            modelId,
+            contextFields,
+            searchConfigurations,
+            ignoreFailure,
+            listener
+        );
+
+        // Assert
+        assertEquals(queryTextWithReference, context.getQueryTextWithReference());
+        assertEquals(modelId, context.getModelId());
+        assertEquals(contextFields, context.getContextFields());
+        assertEquals(searchConfigurations, context.getSearchConfigurations());
+        assertEquals(ignoreFailure, context.isIgnoreFailure());
+        assertEquals(searchConfigurations.size(), context.getPendingSearchTasks().get());
+        assertEquals(0, context.getPendingCacheTasks().get());
+        assertEquals(0, context.getSuccessfulTasks().get());
+        assertEquals(0, context.getFailedTasks().get());
+        assertNotNull(context.getDocIdToScore());
+        assertTrue(context.getDocIdToScore().isEmpty());
+    }
+
+    public void testCompleteSearchTaskSuccess() {
+        // Arrange
+        JudgmentTaskContext context = createTestContext(2);
+
+        // Act
+        context.completeSearchTask(true);
+
+        // Assert
+        assertEquals(1, context.getSuccessfulTasks().get());
+        assertEquals(0, context.getFailedTasks().get());
+        assertEquals(1, context.getPendingSearchTasks().get());
+        assertFalse(context.isAllTasksCompleted());
+    }
+
+    public void testCompleteSearchTaskFailure() {
+        // Arrange
+        JudgmentTaskContext context = createTestContext(2);
+
+        // Act
+        context.completeSearchTask(false);
+
+        // Assert
+        assertEquals(0, context.getSuccessfulTasks().get());
+        assertEquals(1, context.getFailedTasks().get());
+        assertEquals(1, context.getPendingSearchTasks().get());
+        assertFalse(context.isAllTasksCompleted());
+    }
+
+    public void testCompleteCacheTaskSuccess() {
+        // Arrange
+        JudgmentTaskContext context = createTestContext(1);
+        context.setPendingCacheTasks(3);
+
+        // Act
+        context.completeCacheTask(true);
+
+        // Assert
+        assertEquals(1, context.getSuccessfulTasks().get());
+        assertEquals(0, context.getFailedTasks().get());
+        assertEquals(2, context.getPendingCacheTasks().get());
+        assertFalse(context.isAllTasksCompleted());
+    }
+
+    public void testCompleteCacheTaskFailure() {
+        // Arrange
+        JudgmentTaskContext context = createTestContext(1);
+        context.setPendingCacheTasks(3);
+
+        // Act
+        context.completeCacheTask(false);
+
+        // Assert
+        assertEquals(0, context.getSuccessfulTasks().get());
+        assertEquals(1, context.getFailedTasks().get());
+        assertEquals(2, context.getPendingCacheTasks().get());
+        assertFalse(context.isAllTasksCompleted());
+    }
+
+    public void testIsAllTasksCompleted() {
+        // Arrange
+        JudgmentTaskContext context = createTestContext(2);
+        context.setPendingCacheTasks(2);
+
+        // Act & Assert - initially not completed
+        assertFalse(context.isAllTasksCompleted());
+
+        // Complete search tasks
+        context.completeSearchTask(true);
+        context.completeSearchTask(true);
+        assertFalse(context.isAllTasksCompleted()); // Cache tasks still pending
+
+        // Complete cache tasks
+        context.completeCacheTask(true);
+        context.completeCacheTask(false);
+        assertTrue(context.isAllTasksCompleted()); // All tasks completed
+    }
+
+    public void testCompleteJudgmentSuccess() throws Exception {
+        // Arrange
+        CountDownLatch latch = new CountDownLatch(1);
+        AtomicReference<Map<String, String>> result = new AtomicReference<>();
+
+        ActionListener<Map<String, String>> listener = new ActionListener<Map<String, String>>() {
+            @Override
+            public void onResponse(Map<String, String> response) {
+                result.set(response);
+                latch.countDown();
+            }
+
+            @Override
+            public void onFailure(Exception e) {
+                fail("Should not fail: " + e.getMessage());
+            }
+        };
+
+        JudgmentTaskContext context = new JudgmentTaskContext(
+            "test query",
+            "model-id",
+            List.of("field1"),
+            List.of(mock(SearchConfiguration.class)),
+            false,
+            listener
+        );
+
+        // Add some test data
+        context.getDocIdToScore().put("doc1", "0.8");
+        context.getDocIdToScore().put("doc2", "0.6");
+
+        // Act
+        context.completeJudgment();
+
+        // Assert
+        assertTrue("Judgment should complete within timeout", latch.await(5, TimeUnit.SECONDS));
+        assertNotNull(result.get());
+        assertEquals(context.getDocIdToScore(), result.get());
+    }
+
+    public void testFailJudgment() throws Exception {
+        // Arrange
+        CountDownLatch latch = new CountDownLatch(1);
+        AtomicReference<Exception> error = new AtomicReference<>();
+
+        ActionListener<Map<String, String>> listener = new ActionListener<Map<String, String>>() {
+            @Override
+            public void onResponse(Map<String, String> response) {
+                fail("Should not succeed");
+            }
+
+            @Override
+            public void onFailure(Exception e) {
+                error.set(e);
+                latch.countDown();
+            }
+        };
+
+        JudgmentTaskContext context = new JudgmentTaskContext(
+            "test query",
+            "model-id",
+            List.of("field1"),
+            List.of(mock(SearchConfiguration.class)),
+            false,
+            listener
+        );
+
+        Exception testException = new RuntimeException("Test failure");
+
+        // Act
+        context.failJudgment(testException);
+
+        // Assert
+        assertTrue("Judgment should fail within timeout", latch.await(5, TimeUnit.SECONDS));
+        assertEquals(testException, error.get());
+    }
+
+    public void testGetStatusAllSuccess() {
+        // Arrange
+        JudgmentTaskContext context = createTestContext(2);
+        context.setPendingCacheTasks(2);
+
+        // Complete all tasks successfully
+        context.completeSearchTask(true);
+        context.completeSearchTask(true);
+        context.completeCacheTask(true);
+        context.completeCacheTask(true);
+
+        // Act & Assert
+        assertEquals(JudgmentBatchStatus.SUCCESS, context.getStatus());
+    }
+
+    public void testGetStatusPartialSuccess() {
+        // Arrange
+        JudgmentTaskContext context = createTestContext(2);
+        context.setPendingCacheTasks(2);
+
+        // Complete with mixed results
+        context.completeSearchTask(true);
+        context.completeSearchTask(false);
+        context.completeCacheTask(true);
+        context.completeCacheTask(true);
+
+        // Act & Assert
+        assertEquals(JudgmentBatchStatus.PARTIAL_SUCCESS, context.getStatus());
+    }
+
+    public void testGetStatusAllFailed() {
+        // Arrange
+        JudgmentTaskContext context = createTestContext(2);
+        context.setPendingCacheTasks(2);
+
+        // Complete all tasks with failures
+        context.completeSearchTask(false);
+        context.completeSearchTask(false);
+        context.completeCacheTask(false);
+        context.completeCacheTask(false);
+
+        // Act & Assert
+        assertEquals(JudgmentBatchStatus.ALL_FAILED, context.getStatus());
+    }
+
+    public void testConcurrentTaskCompletions() throws Exception {
+        // Arrange
+        int searchTasks = 50;
+        int cacheTasks = 50;
+        JudgmentTaskContext context = createTestContext(searchTasks);
+        context.setPendingCacheTasks(cacheTasks);
+
+        CountDownLatch startLatch = new CountDownLatch(1);
+        CountDownLatch completionLatch = new CountDownLatch(searchTasks + cacheTasks);
+
+        // Act - simulate concurrent task completions
+        for (int i = 0; i < searchTasks; i++) {
+            final boolean isSuccess = i % 3 != 0; // Every 3rd task fails
+            new Thread(() -> {
+                try {
+                    startLatch.await();
+                    context.completeSearchTask(isSuccess);
+                    completionLatch.countDown();
+                } catch (InterruptedException e) {
+                    fail("Thread interrupted");
+                }
+            }).start();
+        }
+
+        for (int i = 0; i < cacheTasks; i++) {
+            final boolean isSuccess = i % 4 != 0; // Every 4th task fails
+            new Thread(() -> {
+                try {
+                    startLatch.await();
+                    context.completeCacheTask(isSuccess);
+                    completionLatch.countDown();
+                } catch (InterruptedException e) {
+                    fail("Thread interrupted");
+                }
+            }).start();
+        }
+
+        // Start all threads simultaneously
+        startLatch.countDown();
+
+        // Wait for all completions
+        assertTrue("All tasks should complete within timeout", completionLatch.await(10, TimeUnit.SECONDS));
+
+        // Assert
+        assertTrue(context.isAllTasksCompleted());
+        assertEquals(0, context.getPendingSearchTasks().get());
+        assertEquals(0, context.getPendingCacheTasks().get());
+
+        int totalTasks = searchTasks + cacheTasks;
+        int successCount = context.getSuccessfulTasks().get();
+        int failureCount = context.getFailedTasks().get();
+
+        assertEquals(totalTasks, successCount + failureCount);
+        assertTrue("Should have some successes", successCount > 0);
+        assertTrue("Should have some failures", failureCount > 0);
+        assertEquals(JudgmentBatchStatus.PARTIAL_SUCCESS, context.getStatus());
+    }
+
+    public void testDocIdToScoreThreadSafety() throws Exception {
+        // Arrange
+        JudgmentTaskContext context = createTestContext(1);
+        int threadCount = 100;
+        CountDownLatch startLatch = new CountDownLatch(1);
+        CountDownLatch completionLatch = new CountDownLatch(threadCount);
+
+        // Act - concurrent writes to docIdToScore
+        for (int i = 0; i < threadCount; i++) {
+            final int docIndex = i;
+            new Thread(() -> {
+                try {
+                    startLatch.await();
+                    context.getDocIdToScore().put("doc" + docIndex, "0." + docIndex);
+                    completionLatch.countDown();
+                } catch (InterruptedException e) {
+                    fail("Thread interrupted");
+                }
+            }).start();
+        }
+
+        startLatch.countDown();
+        assertTrue("All writes should complete within timeout", completionLatch.await(5, TimeUnit.SECONDS));
+
+        // Assert
+        assertEquals(threadCount, context.getDocIdToScore().size());
+        for (int i = 0; i < threadCount; i++) {
+            assertTrue("Should contain doc" + i, context.getDocIdToScore().containsKey("doc" + i));
+        }
+    }
+
+    private JudgmentTaskContext createTestContext(int searchConfigCount) {
+        List<SearchConfiguration> searchConfigurations = new java.util.ArrayList<>();
+        for (int i = 0; i < searchConfigCount; i++) {
+            searchConfigurations.add(mock(SearchConfiguration.class));
+        }
+
+        return new JudgmentTaskContext(
+            "test query#reference answer",
+            "test-model-id",
+            List.of("name", "description"),
+            searchConfigurations,
+            false,
+            mock(ActionListener.class)
+        );
+    }
+}

--- a/src/test/java/org/opensearch/searchrelevance/ml/ChunkProcessingContextTests.java
+++ b/src/test/java/org/opensearch/searchrelevance/ml/ChunkProcessingContextTests.java
@@ -1,0 +1,279 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+package org.opensearch.searchrelevance.ml;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.test.OpenSearchTestCase;
+
+public class ChunkProcessingContextTests extends OpenSearchTestCase {
+
+    public void testHandleSuccessFirstChunk() throws Exception {
+        // Arrange
+        CountDownLatch latch = new CountDownLatch(1);
+        AtomicReference<ChunkResult> result = new AtomicReference<>();
+
+        ActionListener<ChunkResult> listener = new ActionListener<ChunkResult>() {
+            @Override
+            public void onResponse(ChunkResult chunkResult) {
+                result.set(chunkResult);
+                latch.countDown();
+            }
+
+            @Override
+            public void onFailure(Exception e) {
+                fail("Should not fail: " + e.getMessage());
+            }
+        };
+
+        ChunkProcessingContext context = new ChunkProcessingContext(3, listener);
+
+        // Act
+        context.handleSuccess(0, "response0");
+
+        // Assert
+        assertTrue("Should complete within timeout", latch.await(5, TimeUnit.SECONDS));
+        ChunkResult chunkResult = result.get();
+        assertNotNull(chunkResult);
+        assertEquals(0, chunkResult.getChunkIndex());
+        assertEquals(3, chunkResult.getTotalChunks());
+        assertFalse(chunkResult.isLastChunk());
+        assertEquals(1, chunkResult.getSucceededChunks().size());
+        assertEquals("response0", chunkResult.getSucceededChunks().get(0));
+        assertTrue(chunkResult.getFailedChunks().isEmpty());
+    }
+
+    public void testHandleSuccessLastChunk() throws Exception {
+        // Arrange
+        CountDownLatch latch = new CountDownLatch(1);
+        AtomicReference<ChunkResult> result = new AtomicReference<>();
+
+        ActionListener<ChunkResult> listener = new ActionListener<ChunkResult>() {
+            @Override
+            public void onResponse(ChunkResult chunkResult) {
+                if (chunkResult.isLastChunk()) {
+                    result.set(chunkResult);
+                    latch.countDown();
+                }
+            }
+
+            @Override
+            public void onFailure(Exception e) {
+                fail("Should not fail: " + e.getMessage());
+            }
+        };
+
+        ChunkProcessingContext context = new ChunkProcessingContext(2, listener);
+
+        // Act
+        context.handleSuccess(0, "response0");
+        context.handleSuccess(1, "response1");
+
+        // Assert
+        assertTrue("Should complete within timeout", latch.await(5, TimeUnit.SECONDS));
+        ChunkResult chunkResult = result.get();
+        assertNotNull(chunkResult);
+        assertTrue(chunkResult.isLastChunk());
+        assertEquals(2, chunkResult.getSucceededChunks().size());
+        assertEquals("response0", chunkResult.getSucceededChunks().get(0));
+        assertEquals("response1", chunkResult.getSucceededChunks().get(1));
+    }
+
+    public void testHandleFailure() throws Exception {
+        // Arrange
+        CountDownLatch latch = new CountDownLatch(1);
+        AtomicReference<ChunkResult> result = new AtomicReference<>();
+
+        ActionListener<ChunkResult> listener = new ActionListener<ChunkResult>() {
+            @Override
+            public void onResponse(ChunkResult chunkResult) {
+                result.set(chunkResult);
+                latch.countDown();
+            }
+
+            @Override
+            public void onFailure(Exception e) {
+                fail("Should not fail: " + e.getMessage());
+            }
+        };
+
+        ChunkProcessingContext context = new ChunkProcessingContext(2, listener);
+
+        // Act
+        context.handleFailure(0, new RuntimeException("Test error"));
+
+        // Assert
+        assertTrue("Should complete within timeout", latch.await(5, TimeUnit.SECONDS));
+        ChunkResult chunkResult = result.get();
+        assertNotNull(chunkResult);
+        assertEquals(1, chunkResult.getFailedChunks().size());
+        assertEquals("Test error", chunkResult.getFailedChunks().get(0));
+        assertTrue(chunkResult.getSucceededChunks().isEmpty());
+    }
+
+    public void testMixedSuccessAndFailure() throws Exception {
+        // Arrange
+        CountDownLatch latch = new CountDownLatch(1);
+        AtomicReference<ChunkResult> result = new AtomicReference<>();
+
+        ActionListener<ChunkResult> listener = new ActionListener<ChunkResult>() {
+            @Override
+            public void onResponse(ChunkResult chunkResult) {
+                if (chunkResult.isLastChunk()) {
+                    result.set(chunkResult);
+                    latch.countDown();
+                }
+            }
+
+            @Override
+            public void onFailure(Exception e) {
+                fail("Should not fail: " + e.getMessage());
+            }
+        };
+
+        ChunkProcessingContext context = new ChunkProcessingContext(3, listener);
+
+        // Act
+        context.handleSuccess(0, "response0");
+        context.handleFailure(1, new RuntimeException("Error1"));
+        context.handleSuccess(2, "response2");
+
+        // Assert
+        assertTrue("Should complete within timeout", latch.await(5, TimeUnit.SECONDS));
+        ChunkResult chunkResult = result.get();
+        assertNotNull(chunkResult);
+        assertTrue(chunkResult.isLastChunk());
+        assertEquals(2, chunkResult.getSucceededChunks().size());
+        assertEquals(1, chunkResult.getFailedChunks().size());
+        assertEquals("response0", chunkResult.getSucceededChunks().get(0));
+        assertEquals("response2", chunkResult.getSucceededChunks().get(2));
+        assertEquals("Error1", chunkResult.getFailedChunks().get(1));
+    }
+
+    public void testConcurrentChunkProcessing() throws Exception {
+        // Arrange
+        int totalChunks = 10;
+        CountDownLatch startLatch = new CountDownLatch(1);
+        CountDownLatch completionLatch = new CountDownLatch(1);
+        AtomicReference<ChunkResult> finalResult = new AtomicReference<>();
+
+        ActionListener<ChunkResult> listener = new ActionListener<ChunkResult>() {
+            @Override
+            public void onResponse(ChunkResult chunkResult) {
+                if (chunkResult.isLastChunk()) {
+                    finalResult.set(chunkResult);
+                    completionLatch.countDown();
+                }
+            }
+
+            @Override
+            public void onFailure(Exception e) {
+                fail("Should not fail: " + e.getMessage());
+            }
+        };
+
+        ChunkProcessingContext context = new ChunkProcessingContext(totalChunks, listener);
+
+        // Act - simulate concurrent chunk processing
+        for (int i = 0; i < totalChunks; i++) {
+            final int chunkIndex = i;
+            new Thread(() -> {
+                try {
+                    startLatch.await();
+                    if (chunkIndex % 3 == 0) {
+                        context.handleFailure(chunkIndex, new RuntimeException("Error" + chunkIndex));
+                    } else {
+                        context.handleSuccess(chunkIndex, "response" + chunkIndex);
+                    }
+                } catch (InterruptedException e) {
+                    fail("Thread interrupted");
+                }
+            }).start();
+        }
+
+        // Start all threads
+        startLatch.countDown();
+
+        // Assert
+        assertTrue("Should complete within timeout", completionLatch.await(10, TimeUnit.SECONDS));
+        ChunkResult result = finalResult.get();
+        assertNotNull(result);
+        assertTrue(result.isLastChunk());
+        assertEquals(totalChunks, result.getTotalChunks());
+
+        // Should have some successes and some failures
+        assertTrue("Should have successful chunks", result.getSuccessfulChunksCount() > 0);
+        assertTrue("Should have failed chunks", result.getFailedChunksCount() > 0);
+        assertEquals(totalChunks, result.getSuccessfulChunksCount() + result.getFailedChunksCount());
+    }
+
+    public void testSingleChunkCompletion() throws Exception {
+        // Arrange
+        CountDownLatch latch = new CountDownLatch(1);
+        AtomicReference<ChunkResult> result = new AtomicReference<>();
+
+        ActionListener<ChunkResult> listener = new ActionListener<ChunkResult>() {
+            @Override
+            public void onResponse(ChunkResult chunkResult) {
+                result.set(chunkResult);
+                latch.countDown();
+            }
+
+            @Override
+            public void onFailure(Exception e) {
+                fail("Should not fail: " + e.getMessage());
+            }
+        };
+
+        ChunkProcessingContext context = new ChunkProcessingContext(1, listener);
+
+        // Act
+        context.handleSuccess(0, "single response");
+
+        // Assert
+        assertTrue("Should complete within timeout", latch.await(5, TimeUnit.SECONDS));
+        ChunkResult chunkResult = result.get();
+        assertNotNull(chunkResult);
+        assertTrue(chunkResult.isLastChunk());
+        assertEquals(1, chunkResult.getTotalChunks());
+        assertEquals(1, chunkResult.getSuccessfulChunksCount());
+        assertEquals(0, chunkResult.getFailedChunksCount());
+    }
+
+    public void testExceptionInCompleteChunk() throws Exception {
+        // Arrange
+        CountDownLatch latch = new CountDownLatch(1);
+        AtomicReference<Exception> error = new AtomicReference<>();
+
+        ActionListener<ChunkResult> listener = new ActionListener<ChunkResult>() {
+            @Override
+            public void onResponse(ChunkResult chunkResult) {
+                throw new RuntimeException("Listener exception");
+            }
+
+            @Override
+            public void onFailure(Exception e) {
+                error.set(e);
+                latch.countDown();
+            }
+        };
+
+        ChunkProcessingContext context = new ChunkProcessingContext(1, listener);
+
+        // Act
+        context.handleSuccess(0, "response");
+
+        // Assert
+        assertTrue("Should complete within timeout", latch.await(5, TimeUnit.SECONDS));
+        assertNotNull(error.get());
+        assertTrue(error.get().getMessage().contains("Listener exception"));
+    }
+}


### PR DESCRIPTION
### Description
According to RFC 159, implementing task scheduler methods can significantly improve the efficiency of LLM judgment processing. 

### Potential Issues:
LLM Judgments, current issues starting from class LlmJudgmentsProcessor:
- Sequential processing of multiple queries in generateLLMJudgments()
- Blocking search operations across multiple search configurations
- Sequential LLM prediction calls with actionGet() blocking patterns
- Cache lookups performed sequentially per document

### Key Transformations:

> Sequential processing of multiple queries :white_check_mark:


- LlmJudgmentTaskManager with concurrent processing
  - queries processed in parallel with semaphore-based rate limiting

> Blocking search operations :white_check_mark:


- Search operations are now asynchronous within each task
 - No more sequential blocking across search configurations

> Sequential LLM prediction calls :white_check_mark:


- LLM calls are now concurrent per query via task manager
- Each query processes independently in parallel

> Sequential cache lookups :white_check_mark:


- Cache operations are asynchronous with graceful fallback
- Cache failures don’t block processing

:white_check_mark: Current Architecture is Non-Blocking:
```
LlmJudgmentsProcessor
├── Upfront cache index creation (async, non-blocking)
├── LlmJudgmentTaskManager.scheduleTasksAsync()
│   ├── {querySetSize} concurrent tasks (semaphore-limited to ~24)
│   ├── Each task: processQueryTextWithReference()
│   │   ├── Async cache lookup (with fallback)
│   │   ├── Async search operations
│   │   ├── Async LLM prediction
│   │   └── Async cache update
│   └── CompletableFuture.allOf() coordination
└── Final result aggregation
```

### Performance Impact:
- Before: O(n) sequential processing time
- After: O(1) parallel processing time (limited by slowest operation)

### Throughput Check
| NodeNum  | QuerySet Size | SearchConfiguration Size | Judgment Status|
| ------------- | ------------- | ------------- | ------------- |
| 1  | 10  | 5 | COMPLETED |
| 1  | 25  | 5 | COMPLETED |
| 1  | 150  | 5 | COMPLETED |
| 1  | 250  | 5 | COMPLETED |
| 1  | 250  | 10 | COMPLETED |
| 1  | 250  | 15 | COMPLETED |
| 3  | 250  | 5 | COMPLETED |
| 3  | 250  | 10 | COMPLETED |
| 3 | 250  | 15 | COMPLETED |





### Issues Resolved
- #161 
- #159 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
