### PR TITLE
bug fix on rest APIs error status for creations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 * Added tasks scheduling and management mechanism for hybrid optimizer experiments ([#139](https://github.com/opensearch-project/search-relevance/pull/139))
 
 ### Bug Fixes
+* Bug fix on rest APIs error status for creations ([#176](https://github.com/opensearch-project/search-relevance/pull/176))
 
 ### Infrastructure
 * Added end to end integration tests for experiments ([#154](https://github.com/opensearch-project/search-relevance/pull/154))

--- a/src/main/java/org/opensearch/searchrelevance/exception/SearchRelevanceException.java
+++ b/src/main/java/org/opensearch/searchrelevance/exception/SearchRelevanceException.java
@@ -46,4 +46,9 @@ public class SearchRelevanceException extends OpenSearchException {
         super(message, cause);
         this.restStatus = restStatus;
     }
+
+    @Override
+    public RestStatus status() {
+        return restStatus;
+    }
 }

--- a/src/main/java/org/opensearch/searchrelevance/rest/RestCreateQuerySetAction.java
+++ b/src/main/java/org/opensearch/searchrelevance/rest/RestCreateQuerySetAction.java
@@ -22,6 +22,7 @@ import java.util.Map;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.opensearch.ExceptionsHelper;
 import org.opensearch.action.index.IndexResponse;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.rest.RestStatus;
@@ -111,7 +112,7 @@ public class RestCreateQuerySetAction extends BaseRestHandler {
             @Override
             public void onFailure(Exception e) {
                 try {
-                    channel.sendResponse(new BytesRestResponse(channel, RestStatus.INTERNAL_SERVER_ERROR, e));
+                    channel.sendResponse(new BytesRestResponse(channel, ExceptionsHelper.status(e), e));
                 } catch (IOException ex) {
                     LOGGER.error("Failed to send error response", ex);
                 }

--- a/src/main/java/org/opensearch/searchrelevance/rest/RestPutExperimentAction.java
+++ b/src/main/java/org/opensearch/searchrelevance/rest/RestPutExperimentAction.java
@@ -20,6 +20,7 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 
+import org.opensearch.ExceptionsHelper;
 import org.opensearch.action.index.IndexResponse;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.rest.RestStatus;
@@ -145,7 +146,7 @@ public class RestPutExperimentAction extends BaseRestHandler {
             @Override
             public void onFailure(Exception e) {
                 try {
-                    channel.sendResponse(new BytesRestResponse(channel, RestStatus.INTERNAL_SERVER_ERROR, e));
+                    channel.sendResponse(new BytesRestResponse(channel, ExceptionsHelper.status(e), e));
                 } catch (IOException ex) {
                     log.error("Failed to send error response", ex);
                 }

--- a/src/main/java/org/opensearch/searchrelevance/rest/RestPutJudgmentAction.java
+++ b/src/main/java/org/opensearch/searchrelevance/rest/RestPutJudgmentAction.java
@@ -31,6 +31,7 @@ import java.util.Optional;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.opensearch.ExceptionsHelper;
 import org.opensearch.action.index.IndexResponse;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.rest.RestStatus;
@@ -165,7 +166,7 @@ public class RestPutJudgmentAction extends BaseRestHandler {
             @Override
             public void onFailure(Exception e) {
                 try {
-                    channel.sendResponse(new BytesRestResponse(channel, RestStatus.INTERNAL_SERVER_ERROR, e));
+                    channel.sendResponse(new BytesRestResponse(channel, ExceptionsHelper.status(e), e));
                 } catch (IOException ex) {
                     LOGGER.error("Failed to send error response", ex);
                 }

--- a/src/main/java/org/opensearch/searchrelevance/rest/RestPutQuerySetAction.java
+++ b/src/main/java/org/opensearch/searchrelevance/rest/RestPutQuerySetAction.java
@@ -24,6 +24,7 @@ import java.util.stream.Collectors;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.opensearch.ExceptionsHelper;
 import org.opensearch.action.index.IndexResponse;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.rest.RestStatus;
@@ -121,7 +122,7 @@ public class RestPutQuerySetAction extends BaseRestHandler {
             @Override
             public void onFailure(Exception e) {
                 try {
-                    channel.sendResponse(new BytesRestResponse(channel, RestStatus.INTERNAL_SERVER_ERROR, e));
+                    channel.sendResponse(new BytesRestResponse(channel, ExceptionsHelper.status(e), e));
                 } catch (IOException ex) {
                     LOGGER.error("Failed to send error response", ex);
                 }

--- a/src/main/java/org/opensearch/searchrelevance/rest/RestPutSearchConfigurationAction.java
+++ b/src/main/java/org/opensearch/searchrelevance/rest/RestPutSearchConfigurationAction.java
@@ -21,6 +21,7 @@ import java.util.Map;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.opensearch.ExceptionsHelper;
 import org.opensearch.action.index.IndexResponse;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.rest.RestStatus;
@@ -95,7 +96,7 @@ public class RestPutSearchConfigurationAction extends BaseRestHandler {
             @Override
             public void onFailure(Exception e) {
                 try {
-                    channel.sendResponse(new BytesRestResponse(channel, RestStatus.INTERNAL_SERVER_ERROR, e));
+                    channel.sendResponse(new BytesRestResponse(channel, ExceptionsHelper.status(e), e));
                 } catch (IOException ex) {
                     LOGGER.error("Failed to send error response", ex);
                 }

--- a/src/test/java/org/opensearch/searchrelevance/rest/RestDeleteQuerySetActionTests.java
+++ b/src/test/java/org/opensearch/searchrelevance/rest/RestDeleteQuerySetActionTests.java
@@ -135,6 +135,6 @@ public class RestDeleteQuerySetActionTests extends SearchRelevanceRestTestCase {
 
         // Verify the exception details
         assertEquals("id cannot be null", exception.getMessage());
-        assertEquals(RestStatus.INTERNAL_SERVER_ERROR, exception.status());
+        assertEquals(RestStatus.BAD_REQUEST, exception.status());
     }
 }

--- a/src/test/java/org/opensearch/searchrelevance/rest/RestDeleteSearchConfigurationActionTests.java
+++ b/src/test/java/org/opensearch/searchrelevance/rest/RestDeleteSearchConfigurationActionTests.java
@@ -135,6 +135,6 @@ public class RestDeleteSearchConfigurationActionTests extends SearchRelevanceRes
 
         // Verify the exception details
         assertEquals("id cannot be null", exception.getMessage());
-        assertEquals(RestStatus.INTERNAL_SERVER_ERROR, exception.status());
+        assertEquals(RestStatus.BAD_REQUEST, exception.status());
     }
 }

--- a/src/test/java/org/opensearch/searchrelevance/rest/RestPutJudgmentActionTests.java
+++ b/src/test/java/org/opensearch/searchrelevance/rest/RestPutJudgmentActionTests.java
@@ -230,7 +230,7 @@ public class RestPutJudgmentActionTests extends SearchRelevanceRestTestCase {
             () -> restPutJudgmentAction.handleRequest(request, channel, client)
         );
         assertEquals("modelId is required for LLM_JUDGMENT", exception.getMessage());
-        assertEquals(RestStatus.INTERNAL_SERVER_ERROR, exception.status());
+        assertEquals(RestStatus.BAD_REQUEST, exception.status());
     }
 
     public void testPutJudgment_Failure() throws Exception {


### PR DESCRIPTION
### Description
We are seeing a 500 Server Error when creating a Query Set Comparison experiment when the same Search Configuration is provided twice as a parameter. 

**REQUEST**
```
POST /api/relevancy/experiments HTTP/1.1
Host: opense-clust-ibvwxkd20qqp-bb13c7635827b15a.elb.us-east-1.amazonaws.com:8443
Content-Length: 198
osd-version: 3.1.0
Accept-Language: en-US,en;q=0.9
User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/137.0.0.0 Safari/537.36
Content-Type: application/json
osd-xsrf: osd-fetch
Accept: */*
Origin: http://opense-clust-ibvwxkd20qqp-bb13c7635827b15a.elb.us-east-1.amazonaws.com:8443/
Referer: http://opense-clust-ibvwxkd20qqp-bb13c7635827b15a.elb.us-east-1.amazonaws.com:8443/app/searchRelevance?security_tenant=__user__
Accept-Encoding: gzip, deflate, br
Cookie: security_authentication=Fe26.2**6ad81cd2d7a5755106d96924ed902da2cf39477b01fd5d6eb1657cb706447de7*4wo5Na2F6YCxXnKekxAmow*gJtWhLa-YfDPltPrwPtuMlACMBtI355HDDbjsWHi1dfRt9frmYOOY32S6G0MsAxr51QYlbv9LM2tqu93PlAirH9TV3P2NMwK0fw1ws9H63IxmaQclGkWMXNuCdSWGEnGZcH9QoLc4S0aOlN3qEYQwSPlP2XvDRy8EYRKSrdR-RTCEAt3cqYqJc1aFD6JUjYjUVl-qCsSUgEEPwXTzOjQqhXzZ3lnTK5pJ8Hdggnv0qoJzcSF5eqPz981V_P8GOTm**b56cf590b2e2d808821501619ed24c43f97001e83142d6ab55e14e25676b83b5*bGJh9xnY4Ak3a6nTvJuT59cR9BcoqZQwjkw0MooZSh8
Connection: keep-alive

{"querySetId":"e4b3ae23-1a16-481f-9f72-4d5b149e3e17","size":10,"searchConfigurationList":["2230d89e-37cd-4faa-a357-a1c9c42763bb","2230d89e-37cd-4faa-a357-a1c9c42763bb"],"type":"PAIRWISE_COMPARISON"}
```

**RESPONSE**
```
HTTP/1.1 500 Internal Server Error
osd-name: ip-10-0-5-62.ec2.internal
content-type: application/json; charset=utf-8
cache-control: private, no-cache, no-store, must-revalidate
set-cookie: security_authentication=Fe26.2**c098ff0fe491917fd4608f061f9541021a60051a117dcb52507267cc842bd71b*LE2XU_zgBwThrrcXSyG-tg*yujc2xT3Bw_Cy-ahR4y_uW_Wk4X_ZpiRLgwreQfYPSIB1a2J4PXdh3ewgsL4j2mFQyjcSy6dmdaqkPhBfmQzy7ITAtdD-FoMFbMfcg9xYiUHUZnP8YysPOUwubU7Wz1-o0cNphPdt5thxlJuBVRpqbr1quBFrilLp034DFGS4hb0Z6_3exUQS6hSrR528qjbfYtVwiVhvJ1V97BJbTMY71azr5PqcnshqMuYvyK0WFgaYaOmaQQ0V1GV9BqgFpkR**c3ee5a6e5e5f9f4d1efba8e1be7468f92549c15e4d6b8558a5f0e6011a485fc6*cLotXdV7PijXaLWpuPMUVrKVcmY52C3YYImyHWZVh9M; HttpOnly; Path=/
content-length: 407
Date: Wed, 02 Jul 2025 22:37:04 GMT
Connection: keep-alive
Keep-Alive: timeout=120

{"statusCode":500,"error":"Internal Server Error","message":"[search_relevance_exception] PAIRWISE_COMPARISON requires distinct search configurations","attributes":{"error":{"root_cause":[{"type":"search_relevance_exception","reason":"PAIRWISE_COMPARISON requires distinct search configurations"}],"type":"search_relevance_exception","reason":"PAIRWISE_COMPARISON requires distinct search configurations"}}}
```


### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
