### PR TITLE
add queryText and referenceAnswer text validation from manual input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Bug Fixes
 * Bug fix on rest APIs error status for creations ([#176](https://github.com/opensearch-project/search-relevance/pull/176))
 * Fixed pipeline parameter being ignored in pairwise metrics processing for hybrid search queries ([#187](https://github.com/opensearch-project/search-relevance/pull/187))
+* Added queryText and referenceAnswer text validation from manual input ([#177](https://github.com/opensearch-project/search-relevance/pull/177))
 
 ### Infrastructure
 * Added end to end integration tests for experiments ([#154](https://github.com/opensearch-project/search-relevance/pull/154))

--- a/src/main/java/org/opensearch/searchrelevance/rest/RestPutJudgmentAction.java
+++ b/src/main/java/org/opensearch/searchrelevance/rest/RestPutJudgmentAction.java
@@ -82,7 +82,7 @@ public class RestPutJudgmentAction extends BaseRestHandler {
         Map<String, Object> source = parser.map();
 
         String name = (String) source.get(NAME);
-        TextValidationUtil.ValidationResult nameValidation = TextValidationUtil.validateText(name);
+        TextValidationUtil.ValidationResult nameValidation = TextValidationUtil.validateName(name);
         if (!nameValidation.isValid()) {
             return channel -> channel.sendResponse(
                 new BytesRestResponse(RestStatus.BAD_REQUEST, "Invalid name: " + nameValidation.getErrorMessage())
@@ -90,7 +90,7 @@ public class RestPutJudgmentAction extends BaseRestHandler {
         }
         String description = (String) source.get(DESCRIPTION);
         if (description != null) {
-            TextValidationUtil.ValidationResult descriptionValidation = TextValidationUtil.validateText(description);
+            TextValidationUtil.ValidationResult descriptionValidation = TextValidationUtil.validateDescription(description);
             if (!descriptionValidation.isValid()) {
                 return channel -> channel.sendResponse(
                     new BytesRestResponse(RestStatus.BAD_REQUEST, "Invalid description: " + descriptionValidation.getErrorMessage())

--- a/src/main/java/org/opensearch/searchrelevance/rest/RestPutSearchConfigurationAction.java
+++ b/src/main/java/org/opensearch/searchrelevance/rest/RestPutSearchConfigurationAction.java
@@ -66,7 +66,7 @@ public class RestPutSearchConfigurationAction extends BaseRestHandler {
         Map<String, Object> source = parser.map();
 
         String name = (String) source.get(NAME);
-        TextValidationUtil.ValidationResult nameValidation = TextValidationUtil.validateText(name);
+        TextValidationUtil.ValidationResult nameValidation = TextValidationUtil.validateName(name);
         if (!nameValidation.isValid()) {
             return channel -> channel.sendResponse(
                 new BytesRestResponse(RestStatus.BAD_REQUEST, "Invalid name: " + nameValidation.getErrorMessage())

--- a/src/main/java/org/opensearch/searchrelevance/utils/TextValidationUtil.java
+++ b/src/main/java/org/opensearch/searchrelevance/utils/TextValidationUtil.java
@@ -8,7 +8,9 @@
 package org.opensearch.searchrelevance.utils;
 
 public class TextValidationUtil {
-    private static final int MAX_TEXT_LENGTH = 2000;
+    private static final int DEFAULT_MAX_TEXT_LENGTH = 2000;
+    private static final int MAX_NAME_LENGTH = 50;
+    private static final int MAX_DESCRIPTION_LENGTH = 250;
     // Characters that could break JSON or cause security issues
     private static final String DANGEROUS_CHARS_PATTERN = "[\"\\\\<>]+";  // Excludes quotes, backslashes, and HTML tags
 
@@ -30,7 +32,24 @@ public class TextValidationUtil {
         }
     }
 
+    /**
+     * Validates text with default maximum length (2000 characters)
+     *
+     * @param text The text to validate
+     * @return ValidationResult indicating if the text is valid
+     */
     public static ValidationResult validateText(String text) {
+        return validateText(text, DEFAULT_MAX_TEXT_LENGTH);
+    }
+
+    /**
+     * Validates text with a specified maximum length
+     *
+     * @param text The text to validate
+     * @param maxLength The maximum allowed length
+     * @return ValidationResult indicating if the text is valid
+     */
+    public static ValidationResult validateText(String text, int maxLength) {
         if (text == null) {
             return new ValidationResult(false, "Text cannot be null");
         }
@@ -39,8 +58,8 @@ public class TextValidationUtil {
             return new ValidationResult(false, "Text cannot be empty");
         }
 
-        if (text.length() > MAX_TEXT_LENGTH) {
-            return new ValidationResult(false, "Text exceeds maximum length of " + MAX_TEXT_LENGTH + " characters");
+        if (text.length() > maxLength) {
+            return new ValidationResult(false, "Text exceeds maximum length of " + maxLength + " characters");
         }
 
         if (text.matches(".*" + DANGEROUS_CHARS_PATTERN + ".*")) {
@@ -48,6 +67,26 @@ public class TextValidationUtil {
         }
 
         return new ValidationResult(true, null);
+    }
+
+    /**
+     * Validates name field with maximum length of 50 characters
+     *
+     * @param name The name to validate
+     * @return ValidationResult indicating if the name is valid
+     */
+    public static ValidationResult validateName(String name) {
+        return validateText(name, MAX_NAME_LENGTH);
+    }
+
+    /**
+     * Validates description field with maximum length of 250 characters
+     *
+     * @param description The description to validate
+     * @return ValidationResult indicating if the description is valid
+     */
+    public static ValidationResult validateDescription(String description) {
+        return validateText(description, MAX_DESCRIPTION_LENGTH);
     }
 
 }

--- a/src/test/java/org/opensearch/searchrelevance/util/TextValidationUtilTests.java
+++ b/src/test/java/org/opensearch/searchrelevance/util/TextValidationUtilTests.java
@@ -9,31 +9,31 @@ package org.opensearch.searchrelevance.util;
 
 import java.util.List;
 
+import org.opensearch.searchrelevance.plugin.SearchRelevanceRestTestCase;
 import org.opensearch.searchrelevance.utils.TextValidationUtil;
-import org.opensearch.test.OpenSearchTestCase;
 
-class TextValidationUtilTest extends OpenSearchTestCase {
+public class TextValidationUtilTests extends SearchRelevanceRestTestCase {
 
-    void testNullText() {
+    public void testNullText() {
         TextValidationUtil.ValidationResult result = TextValidationUtil.validateText(null);
         assertFalse(result.isValid());
         assertEquals("Text cannot be null", result.getErrorMessage());
     }
 
-    void testEmptyText() {
+    public void testEmptyText() {
         TextValidationUtil.ValidationResult result = TextValidationUtil.validateText("");
         assertFalse(result.isValid());
         assertEquals("Text cannot be empty", result.getErrorMessage());
     }
 
-    void testTextTooLong() {
-        String longText = "a".repeat(1001);
+    public void testTextTooLong() {
+        String longText = "a".repeat(2001);
         TextValidationUtil.ValidationResult result = TextValidationUtil.validateText(longText);
         assertFalse(result.isValid());
-        assertEquals("Text exceeds maximum length of 1000 characters", result.getErrorMessage());
+        assertEquals("Text exceeds maximum length of 2000 characters", result.getErrorMessage());
     }
 
-    void testValidText() {
+    public void testValidText() {
         List<String> inputs = List.of(
             "Hello, World!",
             "Test_123",
@@ -60,7 +60,7 @@ class TextValidationUtilTest extends OpenSearchTestCase {
         }
     }
 
-    void testInvalidCharacters() {
+    public void testInvalidCharacters() {
         List<String> inputs = List.of(
             "Invalid\"quote",
             "Invalid\\backslash",
@@ -72,17 +72,49 @@ class TextValidationUtilTest extends OpenSearchTestCase {
         for (String input : inputs) {
             TextValidationUtil.ValidationResult result = TextValidationUtil.validateText(input);
             assertFalse(result.isValid());
-            assertEquals(
-                "Text contains invalid characters. Only letters, numbers, and basic punctuation allowed",
-                result.getErrorMessage()
-            );
+            assertEquals("Text contains invalid characters (quotes, backslashes, or HTML tags are not allowed)", result.getErrorMessage());
         }
     }
 
-    void testMaximumLengthText() {
-        String maxLengthText = "a".repeat(1000);
+    public void testMaximumLengthText() {
+        String maxLengthText = "a".repeat(2000);
         TextValidationUtil.ValidationResult result = TextValidationUtil.validateText(maxLengthText);
         assertTrue(result.isValid());
         assertNull(result.getErrorMessage());
+    }
+
+    public void testValidateWithCustomLength() {
+        String text = "a".repeat(100);
+        TextValidationUtil.ValidationResult result = TextValidationUtil.validateText(text, 50);
+        assertFalse(result.isValid());
+        assertEquals("Text exceeds maximum length of 50 characters", result.getErrorMessage());
+
+        result = TextValidationUtil.validateText(text, 200);
+        assertTrue(result.isValid());
+        assertNull(result.getErrorMessage());
+    }
+
+    public void testValidateName() {
+        String validName = "a".repeat(50);
+        TextValidationUtil.ValidationResult result = TextValidationUtil.validateName(validName);
+        assertTrue(result.isValid());
+        assertNull(result.getErrorMessage());
+
+        String invalidName = "a".repeat(51);
+        result = TextValidationUtil.validateName(invalidName);
+        assertFalse(result.isValid());
+        assertEquals("Text exceeds maximum length of 50 characters", result.getErrorMessage());
+    }
+
+    public void testValidateDescription() {
+        String validDesc = "a".repeat(250);
+        TextValidationUtil.ValidationResult result = TextValidationUtil.validateDescription(validDesc);
+        assertTrue(result.isValid());
+        assertNull(result.getErrorMessage());
+
+        String invalidDesc = "a".repeat(251);
+        result = TextValidationUtil.validateDescription(invalidDesc);
+        assertFalse(result.isValid());
+        assertEquals("Text exceeds maximum length of 250 characters", result.getErrorMessage());
     }
 }


### PR DESCRIPTION
### Description
- Add text validation for queryText and referenceAnswer when creating query set with manual input. The validation includes json parsing validation and a length check:
  - name validation max 50 characters (aligned with frontend check)
  - description validation max 250 characters (aligned with frontend check)
  - queryText and referenceAnswer validation max 2000 characters
 

### Issues Resolved
- https://github.com/opensearch-project/search-relevance/issues/186

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
