### PR TITLE
Fixed demo script for hybrid optimizer, added pipeline definition as part of the hybrid query

### DIFF
--- a/src/test/scripts/demo_hybrid_optimizer.sh
+++ b/src/test/scripts/demo_hybrid_optimizer.sh
@@ -357,7 +357,7 @@ exe curl -s -X PUT "http://localhost:9200/_plugins/_search_relevance/search_conf
 -H "Content-type: application/json" \
 -d"{
       \"name\": \"hybrid_query\",
-      \"query\": \"{\\\"query\\\":{\\\"hybrid\\\":{\\\"queries\\\":[{\\\"multi_match\\\":{\\\"query\\\":\\\"%SearchText%\\\",\\\"fields\\\":[\\\"id\\\",\\\"title\\\",\\\"category\\\",\\\"bullets\\\",\\\"description\\\",\\\"attrs.Brand\\\",\\\"attrs.Color\\\"]}},{\\\"neural\\\":{\\\"title_embedding\\\":{\\\"query_text\\\":\\\"%SearchText%\\\",\\\"k\\\":100,\\\"model_id\\\":\\\"${model_id}\\\"}}}]}},\\\"size\\\":10}\",
+      \"query\": \"{\\\"query\\\":{\\\"hybrid\\\":{\\\"queries\\\":[{\\\"multi_match\\\":{\\\"query\\\":\\\"%SearchText%\\\",\\\"fields\\\":[\\\"id\\\",\\\"title\\\",\\\"category\\\",\\\"bullets\\\",\\\"description\\\",\\\"attrs.Brand\\\",\\\"attrs.Color\\\"]}},{\\\"neural\\\":{\\\"title_embedding\\\":{\\\"query_text\\\":\\\"%SearchText%\\\",\\\"k\\\":100,\\\"model_id\\\":\\\"${model_id}\\\"}}}]}},\\\"size\\\":10,\\\"search_pipeline\\\":{\\\"description\\\":\\\"Post processor for hybrid search\\\",\\\"phase_results_processors\\\":[{\\\"normalization-processor\\\":{\\\"normalization\\\":{\\\"technique\\\":\\\"min_max\\\"},\\\"combination\\\":{\\\"technique\\\":\\\"arithmetic_mean\\\",\\\"parameters\\\":{}}}}]}}\",
       \"index\": \"ecommerce\"
 }"
 


### PR DESCRIPTION
### Description
Current version of `demo_hybrid_optimizer.sh` does not have a pipeline attached to the hybrid query, this leads to incorrect results. With this change I'm adding pipeline to the query, so query became autonomous. Alternative way is to create pipeline separately and attach only pipeline reference to search configuration. 

This approach applicable to any type of hybrid query, without attached search pipeline search hits are not properly normalized.

Here is result that is returned by the fixed hybrid query when it's compared to the baseline

<img width="3454" height="1824" alt="image" src="https://github.com/user-attachments/assets/90d3cbef-9727-4bc4-8b79-5fca81e5f122" />

<img width="2650" height="1616" alt="image" src="https://github.com/user-attachments/assets/0134508c-d595-4b11-9aac-504099755694" />

### Issues Resolved
https://github.com/opensearch-project/search-relevance/issues/170

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
