### PR TITLE
Replace autocut to dependabot to skip changelog update check

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -14,4 +14,4 @@ jobs:
 
       - uses: dangoslen/changelog-enforcer@v3
         with:
-          skipLabels: 'autocut, skip-changelog'
+          skipLabels: 'dependabot, skip-changelog'


### PR DESCRIPTION
### Description
Replace autocut to dependabot to skip changelog update check

### Issues Resolved
N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
