### PR TITLE
Upgrade gradle to 8.14 and JDK 23->24

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -16,7 +16,7 @@ jobs:
     needs: Get-CI-Image-Tag
     strategy:
       matrix:
-        java: [21, 23]
+        java: [21, 24]
         os: [ubuntu-latest]
 
     name: Gradle Check Linux
@@ -54,7 +54,7 @@ jobs:
   Check-search-relevance-windows:
     strategy:
       matrix:
-        java: [21, 23]
+        java: [21, 24]
         os: [windows-latest]
 
     name: Gradle Check Windows
@@ -77,7 +77,7 @@ jobs:
     needs: Get-CI-Image-Tag
     strategy:
       matrix:
-        java: [21, 23]
+        java: [21, 24]
         os: [ubuntu-latest]
 
     name: Pre-commit Linux
@@ -116,7 +116,7 @@ jobs:
     needs: Precommit-search-relevance-linux
     strategy:
       matrix:
-        java: [21, 23]
+        java: [21, 24]
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/test_security.yml
+++ b/.github/workflows/test_security.yml
@@ -20,7 +20,7 @@ jobs:
   integ-test-with-security-linux:
     strategy:
       matrix:
-        java: [21, 23]
+        java: [21, 24]
 
     name: Run Integration Tests on Linux
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Infrastructure
 * Added end to end integration tests for experiments ([#154](https://github.com/opensearch-project/search-relevance/pull/154))
 * Enabled tasks scheduling for llm judgments ([#166](https://github.com/opensearch-project/search-relevance/pull/166))
+* Upgrade gradle to 8.14 and higher JDK version to 24 ([#188](https://github.com/opensearch-project/search-relevance/pull/188))
 
 ### Documentation
 

--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -43,7 +43,7 @@ sdk install java 21.0.2-open
 sdk use java 21.0.2-open
 ``````
 
-JDK versions 21 and 23 were tested and are fully supported for local development.
+JDK versions 21 and 24 were tested and are fully supported for local development.
 
 ## Use an Editor
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,14 +1,8 @@
-#
-# SPDX-License-Identifier: Apache-2.0
-#
-# The OpenSearch Contributors require contributions made to
-# this file be licensed under the Apache-2.0 license or a
-# compatible open source license.
-#
-
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.2-all.zip
+distributionSha256Sum=efe9a3d147d948d7528a9887fa35abcf24ca1a43ad06439996490f77569b02d1
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14-all.zip
+networkTimeout=10000
+validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionSha256Sum=2ab88d6de2c23e6adae7363ae6e29cbdd2a709e992929b48b6530fd0c7133bd6

--- a/src/main/plugin-metadata/plugin-security.policy
+++ b/src/main/plugin-metadata/plugin-security.policy
@@ -4,4 +4,5 @@ grant {
     permission java.lang.RuntimePermission "accessDeclaredMembers";
     permission java.lang.reflect.ReflectPermission "suppressAccessChecks";
     permission java.lang.RuntimePermission "setContextClassLoader";
+    permission java.net.NetPermission "accessUnixDomainSocket";
 };

--- a/src/main/plugin-metadata/plugin-security.policy
+++ b/src/main/plugin-metadata/plugin-security.policy
@@ -4,5 +4,4 @@ grant {
     permission java.lang.RuntimePermission "accessDeclaredMembers";
     permission java.lang.reflect.ReflectPermission "suppressAccessChecks";
     permission java.lang.RuntimePermission "setContextClassLoader";
-    permission java.net.NetPermission "accessUnixDomainSocket";
 };


### PR DESCRIPTION
### Description
Updated gradle and java version to 24. 

Request for all plugins from infra team, prereq for 3.2 release. Follow path of other plugins (e.g. https://github.com/opensearch-project/k-NN/pull/2792)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
