### PR TITLE
Revert dashboard fields changes of PR#190 to MetricsHelper.

### DIFF
--- a/src/main/java/org/opensearch/searchrelevance/metrics/MetricsHelper.java
+++ b/src/main/java/org/opensearch/searchrelevance/metrics/MetricsHelper.java
@@ -184,8 +184,7 @@ public class MetricsHelper {
         int size,
         List<String> judgmentIds,
         ActionListener<Map<String, Object>> listener,
-        List<ExperimentVariant> experimentVariants,
-        String experimentId
+        List<ExperimentVariant> experimentVariants
     ) {
         if (indexAndQueries.isEmpty() || judgmentIds.isEmpty()) {
             listener.onFailure(new IllegalArgumentException("Missing required parameters"));
@@ -236,8 +235,7 @@ public class MetricsHelper {
                                     docIdToRatings,
                                     configToEvalIds,
                                     listener,
-                                    experimentVariants,
-                                    experimentId
+                                    experimentVariants
                                 );
                             }
                         } catch (Exception e) {
@@ -261,8 +259,7 @@ public class MetricsHelper {
                                     docIdToRatings,
                                     configToEvalIds,
                                     listener,
-                                    experimentVariants,
-                                    experimentId
+                                    experimentVariants
                                 );
                             }
                         }
@@ -283,8 +280,7 @@ public class MetricsHelper {
         Map<String, String> docIdToScores,
         Map<String, Object> configToEvalIds,
         ActionListener<Map<String, Object>> listener,
-        List<ExperimentVariant> experimentVariants,
-        String experimentId
+        List<ExperimentVariant> experimentVariants
     ) {
         AtomicBoolean hasFailure = new AtomicBoolean(false);
         AtomicInteger pendingConfigurations = getNumberOfExperimentRuns(indexAndQueries, experimentVariants);
@@ -315,8 +311,7 @@ public class MetricsHelper {
                     query,
                     searchPipeline,
                     hasFailure,
-                    pendingConfigurations,
-                    experimentId
+                    pendingConfigurations
                 );
             } else {
                 processSearchConfigurationWithHybridExperimentOptions(
@@ -331,8 +326,7 @@ public class MetricsHelper {
                     query,
                     hasFailure,
                     pendingConfigurations,
-                    experimentVariants,
-                    experimentId
+                    experimentVariants
                 );
             }
         }
@@ -365,8 +359,7 @@ public class MetricsHelper {
         String query,
         String searchPipeline,
         AtomicBoolean hasFailure,
-        AtomicInteger pendingConfigurations,
-        String experimentId
+        AtomicInteger pendingConfigurations
     ) {
         SearchRequest searchRequest = buildSearchRequest(index, query, queryText, searchPipeline, size);
         final String evaluationId = UUID.randomUUID().toString();
@@ -403,10 +396,7 @@ public class MetricsHelper {
                         queryText,
                         judgmentIds,
                         docIds,
-                        metrics,
-                        experimentId,
-                        null,
-                        null
+                        metrics
                     );
 
                     evaluationResultDao.putEvaluationResult(evaluationResult, ActionListener.wrap(success -> {
@@ -445,8 +435,7 @@ public class MetricsHelper {
         String query,
         AtomicBoolean hasFailure,
         AtomicInteger pendingConfigurations,
-        List<ExperimentVariant> experimentVariants,
-        String experimentId
+        List<ExperimentVariant> experimentVariants
     ) {
         if (Objects.isNull(experimentVariants) || experimentVariants.isEmpty()) {
             throw new IllegalArgumentException("experiment variant for hybrid search cannot be empty");
@@ -499,22 +488,19 @@ public class MetricsHelper {
                             queryText,
                             judgmentIds,
                             docIds,
-                            metrics,
-                            experimentId,
-                            experimentVariant.getId(),
-                            experimentVariant.getTextualParameters()
+                            metrics
                         );
 
                         evaluationResultDao.putEvaluationResult(evaluationResult, ActionListener.wrap(success -> {
-                                                    ExperimentVariant experimentVariantResult = new ExperimentVariant(
-                            experimentVariant.getId(),
-                            TimeUtils.getTimestamp(),
-                            experimentVariant.getType(),
-                            AsyncStatus.COMPLETED,
-                            experimentId,
-                            experimentVariant.getParameters(),
-                            Map.of("evaluationResultId", evaluationId)
-                        );
+                            ExperimentVariant experimentVariantResult = new ExperimentVariant(
+                                experimentVariant.getId(),
+                                TimeUtils.getTimestamp(),
+                                experimentVariant.getType(),
+                                AsyncStatus.COMPLETED,
+                                experimentVariant.getExperimentId(),
+                                experimentVariant.getParameters(),
+                                Map.of("evaluationResultId", evaluationId)
+                            );
                             StepListener<IndexResponse> voidStepListener = new StepListener<>();
                             experimentVariantDao.updateExperimentVariant(experimentVariantResult, voidStepListener);
                             voidStepListener.whenComplete(indexResponse -> {
@@ -561,7 +547,7 @@ public class MetricsHelper {
                         TimeUtils.getTimestamp(),
                         experimentVariant.getType(),
                         AsyncStatus.ERROR,
-                        experimentId,
+                        experimentVariant.getExperimentId(),
                         experimentVariant.getParameters(),
                         Map.of("evaluationResultId", evaluationId)
                     );

--- a/src/main/java/org/opensearch/searchrelevance/model/EvaluationResult.java
+++ b/src/main/java/org/opensearch/searchrelevance/model/EvaluationResult.java
@@ -68,6 +68,18 @@ public class EvaluationResult implements ToXContentObject {
         this.experimentVariantParameters = experimentVariantParameters;
     }
 
+    public EvaluationResult(
+        String id,
+        String timestamp,
+        String searchConfigurationId,
+        String searchText,
+        List<String> judgmentIds,
+        List<String> documentIds,
+        List<Map<String, Object>> metrics
+    ) {
+        this(id, timestamp, searchConfigurationId, searchText, judgmentIds, documentIds, metrics, null, null, null);
+    }
+
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         XContentBuilder xContentBuilder = builder.startObject();


### PR DESCRIPTION
### Description
The following PR: https://github.com/opensearch-project/search-relevance/pull/174 changes the signature in MetricsHelper which later was added in a test causing a compilation error.

This PR undoes the changes in MetricsHelper fixing the compilation issue. Removing the changes from MetricsHelper is not a problem because this code is no longer used for metrics calculations.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
