### PR TITLE
double retries due to transmission errors

### DIFF
--- a/src/test/java/org/opensearch/searchrelevance/experiment/BaseExperimentIT.java
+++ b/src/test/java/org/opensearch/searchrelevance/experiment/BaseExperimentIT.java
@@ -68,7 +68,7 @@ public abstract class BaseExperimentIT extends BaseSearchRelevanceIT {
     );
 
     protected static final String BASE_INDEX_NAME_ESCI = "ecommerce";
-    protected static final int MAX_POLL_RETRIES = 60;
+    protected static final int MAX_POLL_RETRIES = 120;
 
     protected String createJudgment() throws IOException, URISyntaxException, InterruptedException {
         String importJudgmentBody = Files.readString(Path.of(classLoader.getResource("data_esci/ImportJudgment.json").toURI()));


### PR DESCRIPTION
### Description
There is a transmission errors for integration tests. 
```
Suite: Test class org.opensearch.searchrelevance.experiment.HybridOptimizerExperimentIT
Aug 06, 2025 8:07:48 PM org.opensearch.client.RestClient logResponse
WARNING: request [GET http://localhost:9200/.plugins-search-relevance-experiment/_doc/c5e9bcc4-b899-4b60-a44f-7e2b7c7a6f80] returned 1 warnings: [299 OpenSearch-3.2.0-c01ff891fa2d028f79dc20d122ccf16622246856 "this request accesses system indices: [.plugins-search-relevance-experiment], but in a future major version, direct access to system indices will be prevented by default"]
REPRODUCE WITH: ./gradlew ':integTestRemote' --tests 'org.opensearch.searchrelevance.experiment.HybridOptimizerExperimentIT.testHybridOptimizerExperiment_whenHybridQueries_thenSuccessful' -Dtests.seed=66AB2D6B8B8F450E -Dtests.security.manager=false -Dtests.locale=en-ZM -Dtests.timezone=America/Aruba -Druntime.java=24
org.junit.ComparisonFailure: Experiment status must be COMPLETED expected:<[COMPLETED]> but was:<[PROCESSING]>
        at __randomizedtesting.SeedInfo.seed([66AB2D6B8B8F450E:8455121003CE6DE4]:0)
        at org.junit.Assert.assertEquals(Assert.java:117)
        at org.opensearch.searchrelevance.experiment.BaseExperimentIT.pollExperimentUntilCompleted(BaseExperimentIT.java:230)
        at org.opensearch.searchrelevance.experiment.HybridOptimizerExperimentIT.testHybridOptimizerExperiment_whenHybridQueries_thenSuccessful(HybridOptimizerExperimentIT.java:61)
NOTE: leaving temporary files on disk at: /tmp/tmpjlas_w1b/search-relevance/build/testrun/integTestRemote/temp/org.opensearch.searchrelevance.experiment.HybridOptimizerExperimentIT_66AB2D6B8B8F450E-001
NOTE: test params are: codec=Asserting(Lucene101): {}, docValues:{}, maxPointsInLeafNode=1692, maxMBSortInHeap=7.13941304509219, sim=Asserting(RandomSimilarity(queryNorm=true): {}), locale=en-ZM, timezone=America/Aruba
NOTE: Linux 6.1.140-154.222.amzn2023.aarch64 aarch64/Eclipse Adoptium 24.0.1 (64-bit)/cpus=4,threads=1,free=261785944,total=536870912
NOTE: All tests run in this JVM: [BaseSearchRelevanceIT, CalculateJudgmentsIT, JudgmentsIT, QuerySetIT, SearchConfigurationIT, HybridOptimizerExperimentIT]

8 tests completed, 1 failed
```

## Root Cause:
The current implementation polls for experiment status up to 60 times before timing out. During integration testing, this limit appears insufficient as the experiment status remains in PROCESSING state beyond the maximum retry attempts.

## Proposed Solution:
Increase the maximum retry attempts from 60 to 120 to allow more time for the experiment to complete processing.

### Issues Resolved
#168 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
