### PR TITLE
Fix incorrect number in maximum query set size limit to match default value

### DIFF
--- a/src/main/java/org/opensearch/searchrelevance/settings/SearchRelevanceSettings.java
+++ b/src/main/java/org/opensearch/searchrelevance/settings/SearchRelevanceSettings.java
@@ -44,7 +44,7 @@ public class SearchRelevanceSettings {
 
     /**
      * Gates the maximum limit of search relevance query set size
-     * By defaulted, we set the value as 150
+     * The defaultValue is 1,000
      */
     public static final String SEARCH_RELEVANCE_QUERY_SET_MAX_LIMIT_KEY = "plugins.search_relevance.query_set.maximum";
     public static final Setting<Integer> SEARCH_RELEVANCE_QUERY_SET_MAX_LIMIT = Setting.intSetting(


### PR DESCRIPTION
### Description
This PR fixes the incorrect number in the `SEARCH_RELEVANCE_QUERY_SET_MAX_LIMIT` comment to match the current default value of 1,000 for the maximum query set size.

### Issues Resolved
#215 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
