### PR TITLE
Fix codeowners file syntax

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-@fen-qin @heemin32 @martin-gaievski @epugh @wrigleyDan
+* @fen-qin @heemin32 @martin-gaievski @epugh @wrigleyDan


### PR DESCRIPTION
### Description
Following https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#example-of-a-codeowners-file this PR fixes codeowners file syntax

Even though the setting is enabled, the codeowners are not added automatically
<img width="618" height="71" alt="image" src="https://github.com/user-attachments/assets/38d98543-b3bf-4c70-9af2-585006ef5e70" />


### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
