### PR TITLE
export CI env var as true to skip git diff on depth=1 checkout

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -9,6 +9,8 @@
 
 set -ex
 
+export CI=true
+
 function usage() {
     echo "Usage: $0 [args]"
     echo ""


### PR DESCRIPTION
### Description
export CI env var as true to skip git diff on depth=1 checkout

### Issues Resolved
```
git diff --no-color --minimal refs/remotes/origin/main
fatal: ambiguous argument 'refs/remotes/origin/main': unknown revision or path not in the working tree.
Use '--' to separate paths from revisions, like this:
'git <command> [<revision>...] -- [<file>...]'
```

When depth=1 checkout:

```
2025-11-04 23:51:27 INFO     Executing "git init" in /tmp/tmpzbgxzqbd/user-behavior-insights
2025-11-04 23:51:27 INFO     Executing "git remote add origin https://github.com/opensearch-project/user-behavior-insights.git" in /tmp/tmpzbgxzqbd/user-behavior-insights
2025-11-04 23:51:27 INFO     Executing "git fetch --depth 1 origin tags/3.3.0.0" in /tmp/tmpzbgxzqbd/user-behavior-insights
2025-11-04 23:51:28 INFO     Executing "git checkout FETCH_HEAD" in /tmp/tmpzbgxzqbd/user-behavior-insights
2025-11-04 23:51:28 INFO     Executing "git rev-parse HEAD" in /tmp/tmpzbgxzqbd/user-behavior-insights
2025-11-04 23:51:28 INFO     Checked out https://github.com/opensearch-project/user-behavior-insights.git@tags/3.3.0.0 into /tmp/tmpzbgxzqbd/user-behavior-insights at df39f8abc5ab82a00690b09c2c216be57b7ad16f
2025-11-04 23:51:28 INFO     Executing "bash /tmp/tmpzbgxzqbd/user-behavior-insights/scripts/build.sh -v 3.3.2 -p linux -a x64 -s false -o builds" in /tmp/tmpzbgxzqbd/user-behavior-insights
```

**Both GitHub and Jenkins have set this CI=true by default but this will fail on local builds through build repo, because we are checking out repo with depth=1.**

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
