### PR TITLE
[BUG] Fix floating-point precision issues in hybrid optimizer weight generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 * Support for adding description in Search Configuration ([#293](https://github.com/opensearch-project/search-relevance/pull/293))
 
 ### Bug Fixes
+* Fixed floating-point precision issues in Hybrid Optimizer weight generation by switching to step-based iteration and rounding, ensuring clean and consistent weight pairs. ([#308](https://github.com/opensearch-project/search-relevance/pull/308))
 
 ### Infrastructure
 

--- a/src/main/java/org/opensearch/searchrelevance/experiment/ExperimentOptionsForHybridSearch.java
+++ b/src/main/java/org/opensearch/searchrelevance/experiment/ExperimentOptionsForHybridSearch.java
@@ -58,11 +58,14 @@ public class ExperimentOptionsForHybridSearch implements ExperimentOptions {
                             queryWeightForCombination = min + (i * increment);
                         }
 
+                        float w1 = Math.round(queryWeightForCombination * 10) / 10.0f;
+                        float w2 = Math.round((1.0f - w1) * 10) / 10.0f;
+
                         allPossibleParameterCombinations.add(
                             ExperimentVariantHybridSearchDTO.builder()
                                 .normalizationTechnique(normalizationTechnique)
                                 .combinationTechnique(combinationTechnique)
-                                .queryWeightsForCombination(new float[] { queryWeightForCombination, 1.0f - queryWeightForCombination })
+                                .queryWeightsForCombination(new float[] { w1, w2 })
                                 .build()
                         );
                     }

--- a/src/test/java/org/opensearch/searchrelevance/experiment/ExperimentOptionsForHybridSearchTests.java
+++ b/src/test/java/org/opensearch/searchrelevance/experiment/ExperimentOptionsForHybridSearchTests.java
@@ -268,7 +268,62 @@ public class ExperimentOptionsForHybridSearchTests extends OpenSearchTestCase {
             float w1 = combo.getQueryWeightsForCombination()[0];
             float w2 = combo.getQueryWeightsForCombination()[1];
 
-            assertEquals(1.0f, w1 + w2, DELTA_FOR_FLOAT_ASSERTION);
+            assertEquals(1.0f, w1 + w2, 0.0f);
+
+            String w1Str = Float.toString(w1);
+            String w2Str = Float.toString(w2);
+
+            assertFalse("w1 has float drift: " + w1Str, w1Str.matches(".*\\d{2,}E-.*"));
+            assertFalse("w2 has float drift: " + w2Str, w2Str.matches(".*\\d{2,}E-.*"));
+            assertTrue("w1 is not 1-decimal rounded: " + w1Str, w1Str.matches("^-?\\d(\\.\\d)?$"));
+            assertTrue("w2 is not 1-decimal rounded: " + w2Str, w2Str.matches("^-?\\d(\\.\\d)?$"));
+        }
+    }
+
+    public void testGetParameterCombinations_withConstantListOfCorrectValues_weightsAreRoundedToOneDecimal() {
+        // Given
+        Set<String> normalizationTechniques = Set.of("min_max");
+        Set<String> combinationTechniques = Set.of("arithmetic_mean");
+
+        // Use increment that is MOST LIKELY TO EXPOSE FLOAT DRIFT
+        ExperimentOptionsForHybridSearch.WeightsRange weightsRange = ExperimentOptionsForHybridSearch.WeightsRange.builder()
+            .rangeMin(0.0f)
+            .rangeMax(1.0f)
+            .increment(0.1f)
+            .build();
+
+        ExperimentOptionsForHybridSearch options = ExperimentOptionsForHybridSearch.builder()
+            .normalizationTechniques(normalizationTechniques)
+            .combinationTechniques(combinationTechniques)
+            .weightsRange(weightsRange)
+            .build();
+
+        // When
+        List<ExperimentVariantHybridSearchDTO> combinations = options.getParameterCombinations(true);
+
+        // Then
+        float[][] expected = {
+            { 0.0f, 1.0f },
+            { 0.1f, 0.9f },
+            { 0.2f, 0.8f },
+            { 0.3f, 0.7f },
+            { 0.4f, 0.6f },
+            { 0.5f, 0.5f },
+            { 0.6f, 0.4f },
+            { 0.7f, 0.3f },
+            { 0.8f, 0.2f },
+            { 0.9f, 0.1f },
+            { 1.0f, 0.0f } };
+
+        assertEquals(11, combinations.size());
+
+        for (int i = 0; i < 11; i++) {
+            float w1 = combinations.get(i).getQueryWeightsForCombination()[0];
+            float w2 = combinations.get(i).getQueryWeightsForCombination()[1];
+
+            assertEquals(expected[i][0], w1, 0.0f);
+            assertEquals(expected[i][1], w2, 0.0f);
+            assertEquals(1.0f, w1 + w2, 0.0f);
 
             String w1Str = Float.toString(w1);
             String w2Str = Float.toString(w2);

--- a/src/test/java/org/opensearch/searchrelevance/experiment/ExperimentOptionsForHybridSearchTests.java
+++ b/src/test/java/org/opensearch/searchrelevance/experiment/ExperimentOptionsForHybridSearchTests.java
@@ -241,4 +241,42 @@ public class ExperimentOptionsForHybridSearchTests extends OpenSearchTestCase {
             assertTrue("Missing expected weight: " + expected, foundWeight);
         }
     }
+
+    public void testGetParameterCombinations_weightsAreRoundedToOneDecimal() {
+        // Given
+        Set<String> normalizationTechniques = Set.of("min_max");
+        Set<String> combinationTechniques = Set.of("arithmetic_mean");
+
+        // Use increment that is MOST LIKELY TO EXPOSE FLOAT DRIFT
+        ExperimentOptionsForHybridSearch.WeightsRange weightsRange = ExperimentOptionsForHybridSearch.WeightsRange.builder()
+            .rangeMin(0.0f)
+            .rangeMax(1.0f)
+            .increment(0.1f)
+            .build();
+
+        ExperimentOptionsForHybridSearch options = ExperimentOptionsForHybridSearch.builder()
+            .normalizationTechniques(normalizationTechniques)
+            .combinationTechniques(combinationTechniques)
+            .weightsRange(weightsRange)
+            .build();
+
+        // When
+        List<ExperimentVariantHybridSearchDTO> combinations = options.getParameterCombinations(true);
+
+        // Then
+        for (ExperimentVariantHybridSearchDTO combo : combinations) {
+            float w1 = combo.getQueryWeightsForCombination()[0];
+            float w2 = combo.getQueryWeightsForCombination()[1];
+
+            assertEquals(1.0f, w1 + w2, DELTA_FOR_FLOAT_ASSERTION);
+
+            String w1Str = Float.toString(w1);
+            String w2Str = Float.toString(w2);
+
+            assertFalse("w1 has float drift: " + w1Str, w1Str.matches(".*\\d{2,}E-.*"));
+            assertFalse("w2 has float drift: " + w2Str, w2Str.matches(".*\\d{2,}E-.*"));
+            assertTrue("w1 is not 1-decimal rounded: " + w1Str, w1Str.matches("^-?\\d(\\.\\d)?$"));
+            assertTrue("w2 is not 1-decimal rounded: " + w2Str, w2Str.matches("^-?\\d(\\.\\d)?$"));
+        }
+    }
 }


### PR DESCRIPTION
### Description
This change fixes floating-point precision issues in the Hybrid Optimizer Experiment when generating query weight combinations. Previously, weights such as `0.39999998` or `0.60000002` could appear due to cumulative floating-point addition. This caused inconsistent experiment variants and reduced clarity when interpreting results.

This update:
- Uses step-based iteration instead of floating-point accumulation.
- Rounds both weight values to one decimal place.
- Ensures weight pairs cleanly sum to 1.0.
- Adds a regression test to ensure weights do not reintroduce floating drift.

Test fails without code changes:
<img width="1914" height="648" alt="Screenshot 2025-11-07 at 8 02 28 AM" src="https://github.com/user-attachments/assets/d5f5a0de-59e4-4d48-ae22-8ea558c12c7f" />

### Issues Resolved
Closes #298

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).