### PR TITLE
Revert "[Enhancement] Add description in Search Configuration (#293)"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,6 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 * Added APIs and components to implement running scheduled experiments ([#220](https://github.com/opensearch-project/search-relevance/pull/220))
 
 ### Enhancements
-* Support for adding description in Search Configuration ([#293](https://github.com/opensearch-project/search-relevance/pull/293))
 
 ### Bug Fixes
 

--- a/src/main/java/org/opensearch/searchrelevance/dao/SearchConfigurationDao.java
+++ b/src/main/java/org/opensearch/searchrelevance/dao/SearchConfigurationDao.java
@@ -186,8 +186,7 @@ public class SearchConfigurationDao {
             (String) source.get(SearchConfiguration.TIME_STAMP),
             (String) source.get(SearchConfiguration.INDEX),
             (String) source.get(SearchConfiguration.QUERY),
-            (String) source.get(SearchConfiguration.SEARCH_PIPELINE),
-            (String) source.get(SearchConfiguration.DESCRIPTION)
+            (String) source.get(SearchConfiguration.SEARCH_PIPELINE)
         );
     }
 }

--- a/src/main/java/org/opensearch/searchrelevance/executors/ExperimentRunningManager.java
+++ b/src/main/java/org/opensearch/searchrelevance/executors/ExperimentRunningManager.java
@@ -98,7 +98,7 @@ public class ExperimentRunningManager {
     /**
      * Starts the experiment by setting up cancellation callback for the cancellation token and also retrieves the queryset.
      *
-     * One thing to be careful about is that only at most scheduled run for a given scheduled experiment run id
+     * One thing to be careful about is that only at most scheduled run for a given scheduled experiment run id 
      * should be in the system at all times.
      * @param experimentId - the id of the experiment to be run
      * @param request - required parameters for placing a request to start an experiment
@@ -329,8 +329,7 @@ public class ExperimentRunningManager {
             (String) source.get("timestamp"),
             (String) source.get("index"),
             (String) source.get("query"),
-            (String) source.get("searchPipeline"),
-            (String) source.get("description")
+            (String) source.get("searchPipeline")
         );
     }
 

--- a/src/main/java/org/opensearch/searchrelevance/model/SearchConfiguration.java
+++ b/src/main/java/org/opensearch/searchrelevance/model/SearchConfiguration.java
@@ -18,7 +18,6 @@ import org.opensearch.core.xcontent.XContentBuilder;
 public class SearchConfiguration implements ToXContentObject {
     public static final String ID = "id";
     public static final String NAME = "name";
-    public static final String DESCRIPTION = "description";
     public static final String TIME_STAMP = "timestamp";
     public static final String INDEX = "index";
 
@@ -30,28 +29,18 @@ public class SearchConfiguration implements ToXContentObject {
      */
     private final String id;
     private final String name;
-    private final String description;
     private final String timestamp;
     private final String index;
     private final String query;
     private final String searchPipeline;
 
-    public SearchConfiguration(
-        String id,
-        String name,
-        String timestamp,
-        String index,
-        String query,
-        String searchPipeline,
-        String description
-    ) {
+    public SearchConfiguration(String id, String name, String timestamp, String index, String query, String searchPipeline) {
         this.id = id;
         this.name = name;
         this.timestamp = timestamp;
         this.index = index;
         this.query = query;
         this.searchPipeline = searchPipeline;
-        this.description = description;
     }
 
     @Override
@@ -63,7 +52,6 @@ public class SearchConfiguration implements ToXContentObject {
         xContentBuilder.field(INDEX, this.index.trim());
         xContentBuilder.field(QUERY, this.query.trim());
         xContentBuilder.field(SEARCH_PIPELINE, this.searchPipeline == null ? "" : this.searchPipeline.trim());
-        xContentBuilder.field(DESCRIPTION, this.description == null ? "" : this.description.trim());
         return xContentBuilder.endObject();
     }
 

--- a/src/main/java/org/opensearch/searchrelevance/rest/RestPutSearchConfigurationAction.java
+++ b/src/main/java/org/opensearch/searchrelevance/rest/RestPutSearchConfigurationAction.java
@@ -9,7 +9,6 @@ package org.opensearch.searchrelevance.rest;
 
 import static java.util.Collections.singletonList;
 import static org.opensearch.rest.RestRequest.Method.PUT;
-import static org.opensearch.searchrelevance.common.PluginConstants.DESCRIPTION;
 import static org.opensearch.searchrelevance.common.PluginConstants.INDEX;
 import static org.opensearch.searchrelevance.common.PluginConstants.NAME;
 import static org.opensearch.searchrelevance.common.PluginConstants.QUERY;
@@ -73,28 +72,11 @@ public class RestPutSearchConfigurationAction extends BaseRestHandler {
                 new BytesRestResponse(RestStatus.BAD_REQUEST, "Invalid name: " + nameValidation.getErrorMessage())
             );
         }
-
-        String description = (String) source.get(DESCRIPTION);
-        if (description != null) {
-            TextValidationUtil.ValidationResult descriptionValidation = TextValidationUtil.validateDescription(description);
-            if (!descriptionValidation.isValid()) {
-                return channel -> channel.sendResponse(
-                    new BytesRestResponse(RestStatus.BAD_REQUEST, "Invalid description: " + descriptionValidation.getErrorMessage())
-                );
-            }
-        }
-
         String index = (String) source.get(INDEX);
         String queryBody = (String) source.get(QUERY);
         String searchPipeline = (String) source.getOrDefault(SEARCH_PIPELINE, "");
 
-        PutSearchConfigurationRequest createRequest = new PutSearchConfigurationRequest(
-            name,
-            index,
-            queryBody,
-            searchPipeline,
-            description
-        );
+        PutSearchConfigurationRequest createRequest = new PutSearchConfigurationRequest(name, index, queryBody, searchPipeline);
 
         return channel -> client.execute(PutSearchConfigurationAction.INSTANCE, createRequest, new ActionListener<IndexResponse>() {
             @Override

--- a/src/main/java/org/opensearch/searchrelevance/transport/searchConfiguration/PutSearchConfigurationRequest.java
+++ b/src/main/java/org/opensearch/searchrelevance/transport/searchConfiguration/PutSearchConfigurationRequest.java
@@ -19,14 +19,12 @@ public class PutSearchConfigurationRequest extends ActionRequest {
     private final String index;
     private final String queryBody;
     private final String searchPipeline;
-    private final String description;
 
-    public PutSearchConfigurationRequest(String name, String index, String queryBody, String searchPipeline, String description) {
+    public PutSearchConfigurationRequest(String name, String index, String queryBody, String searchPipeline) {
         this.name = name;
         this.index = index;
         this.queryBody = queryBody;
         this.searchPipeline = searchPipeline;
-        this.description = description;
     }
 
     public PutSearchConfigurationRequest(StreamInput in) throws IOException {
@@ -35,7 +33,6 @@ public class PutSearchConfigurationRequest extends ActionRequest {
         this.index = in.readString();
         this.queryBody = in.readString();
         this.searchPipeline = in.readOptionalString();
-        this.description = in.readOptionalString();
     }
 
     @Override
@@ -45,7 +42,6 @@ public class PutSearchConfigurationRequest extends ActionRequest {
         out.writeString(index);
         out.writeString(queryBody);
         out.writeOptionalString(searchPipeline);
-        out.writeOptionalString(description);
     }
 
     public String getName() {
@@ -62,10 +58,6 @@ public class PutSearchConfigurationRequest extends ActionRequest {
 
     public String getSearchPipeline() {
         return searchPipeline;
-    }
-
-    public String getDescription() {
-        return description;
     }
 
     @Override

--- a/src/main/java/org/opensearch/searchrelevance/transport/searchConfiguration/PutSearchConfigurationTransportAction.java
+++ b/src/main/java/org/opensearch/searchrelevance/transport/searchConfiguration/PutSearchConfigurationTransportAction.java
@@ -55,8 +55,6 @@ public class PutSearchConfigurationTransportAction extends HandledTransportActio
             listener.onFailure(new SearchRelevanceException("Name cannot be null or empty. Request: " + request, RestStatus.BAD_REQUEST));
             return;
         }
-        String description = request.getDescription();
-
         String index = request.getIndex();
         String queryBody = request.getQueryBody();
         String searchPipeline = request.getSearchPipeline();
@@ -64,15 +62,7 @@ public class PutSearchConfigurationTransportAction extends HandledTransportActio
         StepListener<Void> createIndexStep = new StepListener<>();
         searchConfigurationDao.createIndexIfAbsent(createIndexStep);
         createIndexStep.whenComplete(v -> {
-            SearchConfiguration searchConfiguration = new SearchConfiguration(
-                id,
-                name,
-                timestamp,
-                index,
-                queryBody,
-                searchPipeline,
-                description
-            );
+            SearchConfiguration searchConfiguration = new SearchConfiguration(id, name, timestamp, index, queryBody, searchPipeline);
             searchConfigurationDao.putSearchConfiguration(searchConfiguration, listener);
         }, listener::onFailure);
     }

--- a/src/test/java/org/opensearch/searchrelevance/action/searchConfiguration/PutSearchConfigurationActionTests.java
+++ b/src/test/java/org/opensearch/searchrelevance/action/searchConfiguration/PutSearchConfigurationActionTests.java
@@ -17,13 +17,7 @@ import org.opensearch.test.OpenSearchTestCase;
 public class PutSearchConfigurationActionTests extends OpenSearchTestCase {
 
     public void testStreams() throws IOException {
-        PutSearchConfigurationRequest request = new PutSearchConfigurationRequest(
-            "base_line",
-            "sample_id",
-            "{\"match_all\":{}}",
-            "n/a",
-            "sample description"
-        );
+        PutSearchConfigurationRequest request = new PutSearchConfigurationRequest("base_line", "sample_id", "{\"match_all\":{}}", "n/a");
         BytesStreamOutput output = new BytesStreamOutput();
         request.writeTo(output);
         StreamInput in = StreamInput.wrap(output.bytes().toBytesRef().bytes);
@@ -32,17 +26,10 @@ public class PutSearchConfigurationActionTests extends OpenSearchTestCase {
         assertEquals("sample_id", serialized.getIndex());
         assertEquals("{\"match_all\":{}}", serialized.getQueryBody());
         assertEquals("n/a", serialized.getSearchPipeline());
-        assertEquals("sample description", serialized.getDescription());
     }
 
     public void testRequestValidation() {
-        PutSearchConfigurationRequest request = new PutSearchConfigurationRequest(
-            "base_line",
-            "sample_id",
-            "{\"match_all\":{}}",
-            "n/a",
-            "sample description"
-        );
+        PutSearchConfigurationRequest request = new PutSearchConfigurationRequest("base_line", "sample_id", "{\"match_all\":{}}", "n/a");
         assertNull(request.validate());
     }
 }

--- a/src/test/java/org/opensearch/searchrelevance/action/searchConfiguration/SearchConfigurationIT.java
+++ b/src/test/java/org/opensearch/searchrelevance/action/searchConfiguration/SearchConfigurationIT.java
@@ -68,7 +68,6 @@ public class SearchConfigurationIT extends BaseSearchRelevanceIT {
         assertEquals("test_index", source.get("index"));
         assertEquals("{\"query\": {\"match_all\": {}}}", source.get("query"));
         assertEquals("test_pipeline", source.get("searchPipeline"));
-        assertEquals("sample description", source.get("description"));
 
         Response deleteSearchConfigResponse = makeRequest(
             client(),

--- a/src/test/java/org/opensearch/searchrelevance/executors/ExperimentRunningManagerTests.java
+++ b/src/test/java/org/opensearch/searchrelevance/executors/ExperimentRunningManagerTests.java
@@ -187,7 +187,7 @@ public class ExperimentRunningManagerTests extends OpenSearchTestCase {
     }
 
     public void testStartExperimentRunReject() {
-        // Make sure that only at most one experiment run for a given scheduled experiment run id
+        // Make sure that only at most one experiment run for a given scheduled experiment run id 
         // can be scheduled at a given time
         // Also makes sure the entry in the mapping futures is removed when the cancellation token is cancelled.
         PutExperimentRequest request = createExperimentRequest();

--- a/src/test/resources/searchconfig/CreateSearchConfiguration.json
+++ b/src/test/resources/searchconfig/CreateSearchConfiguration.json
@@ -2,6 +2,5 @@
   "name": "test_search_config",
   "index": "test_index",
   "query": "{\"query\": {\"match_all\": {}}}",
-  "searchPipeline": "test_pipeline",
-  "description": "sample description"
+  "searchPipeline": "test_pipeline"
 }


### PR DESCRIPTION
### Description
This reverts commit ba08bdb0aa801bb7040fdb32829d864f760b44a5.

When adding a new field to the index mapping, we should define it explicitly to ensure the field type is deterministic. We also need a mechanism to update existing index mappings. Reverting this https://github.com/opensearch-project/search-relevance/commit/ba08bdb0aa801bb7040fdb32829d864f760b44a5 to prevent accidental release before addressing these two points.

### Issues Resolved
N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
