### PR TITLE
Remove @Inject from JudgmentCacheDao, JudgmentDao and QuerySetDao classes

### DIFF
--- a/src/main/java/org/opensearch/searchrelevance/dao/JudgmentCacheDao.java
+++ b/src/main/java/org/opensearch/searchrelevance/dao/JudgmentCacheDao.java
@@ -20,7 +20,6 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.opensearch.action.StepListener;
 import org.opensearch.action.search.SearchResponse;
-import org.opensearch.common.inject.Inject;
 import org.opensearch.common.xcontent.XContentFactory;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.rest.RestStatus;
@@ -38,7 +37,6 @@ public class JudgmentCacheDao {
     private static final Logger LOGGER = LogManager.getLogger(JudgmentCacheDao.class);
     private final SearchRelevanceIndicesManager searchRelevanceIndicesManager;
 
-    @Inject
     public JudgmentCacheDao(SearchRelevanceIndicesManager searchRelevanceIndicesManager) {
         this.searchRelevanceIndicesManager = searchRelevanceIndicesManager;
     }

--- a/src/main/java/org/opensearch/searchrelevance/dao/JudgmentDao.java
+++ b/src/main/java/org/opensearch/searchrelevance/dao/JudgmentDao.java
@@ -14,7 +14,6 @@ import java.io.IOException;
 import org.opensearch.action.StepListener;
 import org.opensearch.action.delete.DeleteResponse;
 import org.opensearch.action.search.SearchResponse;
-import org.opensearch.common.inject.Inject;
 import org.opensearch.common.xcontent.XContentFactory;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.rest.RestStatus;
@@ -28,7 +27,6 @@ import org.opensearch.searchrelevance.model.Judgment;
 public class JudgmentDao {
     private final SearchRelevanceIndicesManager searchRelevanceIndicesManager;
 
-    @Inject
     public JudgmentDao(SearchRelevanceIndicesManager searchRelevanceIndicesManager) {
         this.searchRelevanceIndicesManager = searchRelevanceIndicesManager;
     }

--- a/src/main/java/org/opensearch/searchrelevance/dao/QuerySetDao.java
+++ b/src/main/java/org/opensearch/searchrelevance/dao/QuerySetDao.java
@@ -21,7 +21,6 @@ import org.apache.logging.log4j.Logger;
 import org.opensearch.action.StepListener;
 import org.opensearch.action.delete.DeleteResponse;
 import org.opensearch.action.search.SearchResponse;
-import org.opensearch.common.inject.Inject;
 import org.opensearch.common.xcontent.XContentFactory;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.rest.RestStatus;
@@ -42,7 +41,6 @@ public class QuerySetDao {
     private static final Logger LOGGER = LogManager.getLogger(QuerySetDao.class);
     private final SearchRelevanceIndicesManager searchRelevanceIndicesManager;
 
-    @Inject
     public QuerySetDao(SearchRelevanceIndicesManager searchRelevanceIndicesManager) {
         this.searchRelevanceIndicesManager = searchRelevanceIndicesManager;
     }


### PR DESCRIPTION
All Dao classes are initialized in createComponents method of the SearchRelevancePlugin class. Few of them have @Inject and few of them do not. Technically, we are not injecting any dependency in the dao classes, instead we are passing them by constructor. Therefore, @Inject is not required.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
