### PR TITLE
[Part 2] Data integrity support in delete queryset, judgement and searchconfig

### DIFF
--- a/src/main/java/org/opensearch/searchrelevance/dao/ExperimentDao.java
+++ b/src/main/java/org/opensearch/searchrelevance/dao/ExperimentDao.java
@@ -119,20 +119,24 @@ public class ExperimentDao {
     }
 
     /**
-     * Get experiment by fieldId
+     * Get experiment by fieldId (async version)
      * @param fieldId - id on which experiment is to be retrieved
      * @param fieldName - field on which experiment is to be retrieved
+     * @param listener - action listener for async operation
      */
-    public SearchResponse getExperimentByFieldId(String fieldId, String fieldName) {
+    public void getExperimentByFieldId(String fieldId, String fieldName, int size, ActionListener<SearchResponse> listener) {
         if (fieldId == null || fieldId.isEmpty()) {
-            throw new SearchRelevanceException("fieldId cannot be null or empty", RestStatus.BAD_REQUEST);
+            listener.onFailure(new SearchRelevanceException("fieldId cannot be null or empty", RestStatus.BAD_REQUEST));
+            return;
         }
 
         if (fieldName == null || fieldName.isEmpty()) {
-            throw new SearchRelevanceException("fieldName cannot be null or empty", RestStatus.BAD_REQUEST);
+            listener.onFailure(new SearchRelevanceException("fieldName cannot be null or empty", RestStatus.BAD_REQUEST));
+            return;
         }
-        SearchSourceBuilder sourceBuilder = new SearchSourceBuilder().query(QueryBuilders.termQuery(fieldName, fieldId)).size(1);
-        return searchRelevanceIndicesManager.getDocByQuerySync(EXPERIMENT, sourceBuilder);
+
+        SearchSourceBuilder sourceBuilder = new SearchSourceBuilder().query(QueryBuilders.matchQuery(fieldName, fieldId)).size(size);
+        searchRelevanceIndicesManager.listDocsBySearchRequest(sourceBuilder, EXPERIMENT, listener);
     }
 
     /**

--- a/src/main/java/org/opensearch/searchrelevance/indices/SearchRelevanceIndicesManager.java
+++ b/src/main/java/org/opensearch/searchrelevance/indices/SearchRelevanceIndicesManager.java
@@ -341,13 +341,6 @@ public class SearchRelevanceIndicesManager {
         return null;
     }
 
-    public SearchResponse getDocByQuerySync(final SearchRelevanceIndices index, final SearchSourceBuilder searchSourceBuilder) {
-        SearchRequest searchRequest = new SearchRequest(index.getIndexName());
-        searchRequest.source(searchSourceBuilder);
-
-        return client.search(searchRequest).actionGet();
-    }
-
     /**
      * List docs by search request
      * @param searchSourceBuilder - search source builder to be executed

--- a/src/main/java/org/opensearch/searchrelevance/transport/judgment/DeleteJudgmentTransportAction.java
+++ b/src/main/java/org/opensearch/searchrelevance/transport/judgment/DeleteJudgmentTransportAction.java
@@ -9,6 +9,10 @@ package org.opensearch.searchrelevance.transport.judgment;
 
 import static org.opensearch.searchrelevance.common.PluginConstants.JUDGMENT_LIST;
 
+import java.util.Arrays;
+import java.util.List;
+import java.util.Locale;
+
 import org.opensearch.action.delete.DeleteResponse;
 import org.opensearch.action.search.SearchResponse;
 import org.opensearch.action.support.ActionFilters;
@@ -17,6 +21,7 @@ import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.inject.Inject;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.rest.RestStatus;
+import org.opensearch.search.SearchHit;
 import org.opensearch.searchrelevance.dao.ExperimentDao;
 import org.opensearch.searchrelevance.dao.JudgmentDao;
 import org.opensearch.searchrelevance.exception.SearchRelevanceException;
@@ -54,14 +59,31 @@ public class DeleteJudgmentTransportAction extends HandledTransportAction<OpenSe
                 listener.onFailure(new SearchRelevanceException("judgmentId cannot be null or empty", RestStatus.BAD_REQUEST));
                 return;
             }
-            SearchResponse experiments = experimentDao.getExperimentByFieldId(judgmentId, JUDGMENT_LIST);
-            if (experiments != null && experiments.getHits().getTotalHits().value() > 0) {
-                listener.onFailure(
-                    new SearchRelevanceException("judgment cannot be deleted as it is currently used by a experiment", RestStatus.CONFLICT)
-                );
-                return;
-            }
-            judgmentDao.deleteJudgment(judgmentId, listener);
+            experimentDao.getExperimentByFieldId(judgmentId, JUDGMENT_LIST, 3, new ActionListener<>() {
+                @Override
+                public void onResponse(SearchResponse experiments) {
+                    if (experiments != null && experiments.getHits().getTotalHits().value() > 0) {
+                        List<String> ids = Arrays.stream(experiments.getHits().getHits()).map(SearchHit::getId).toList();
+                        listener.onFailure(
+                            new SearchRelevanceException(
+                                String.format(
+                                    Locale.ROOT,
+                                    "judgement cannot be deleted as it is currently used by experiments with ids %s",
+                                    String.join(", ", ids)
+                                ),
+                                RestStatus.CONFLICT
+                            )
+                        );
+                        return;
+                    }
+                    judgmentDao.deleteJudgment(judgmentId, listener);
+                }
+
+                @Override
+                public void onFailure(Exception e) {
+                    listener.onFailure(e);
+                }
+            });
         } catch (Exception e) {
             listener.onFailure(e);
         }

--- a/src/main/java/org/opensearch/searchrelevance/transport/searchConfiguration/DeleteSearchConfigurationTransportAction.java
+++ b/src/main/java/org/opensearch/searchrelevance/transport/searchConfiguration/DeleteSearchConfigurationTransportAction.java
@@ -9,6 +9,10 @@ package org.opensearch.searchrelevance.transport.searchConfiguration;
 
 import static org.opensearch.searchrelevance.common.PluginConstants.SEARCH_CONFIGURATION_LIST;
 
+import java.util.Arrays;
+import java.util.List;
+import java.util.Locale;
+
 import org.opensearch.action.delete.DeleteResponse;
 import org.opensearch.action.search.SearchResponse;
 import org.opensearch.action.support.ActionFilters;
@@ -17,6 +21,7 @@ import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.inject.Inject;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.rest.RestStatus;
+import org.opensearch.search.SearchHit;
 import org.opensearch.searchrelevance.dao.ExperimentDao;
 import org.opensearch.searchrelevance.dao.SearchConfigurationDao;
 import org.opensearch.searchrelevance.exception.SearchRelevanceException;
@@ -54,17 +59,31 @@ public class DeleteSearchConfigurationTransportAction extends HandledTransportAc
                 listener.onFailure(new SearchRelevanceException("searchConfigurationId cannot be null or empty", RestStatus.BAD_REQUEST));
                 return;
             }
-            SearchResponse experiments = experimentDao.getExperimentByFieldId(searchConfigurationId, SEARCH_CONFIGURATION_LIST);
-            if (experiments != null && experiments.getHits().getTotalHits().value() > 0) {
-                listener.onFailure(
-                    new SearchRelevanceException(
-                        "search configuration cannot be deleted as it is currently used by a experiment",
-                        RestStatus.CONFLICT
-                    )
-                );
-                return;
-            }
-            searchConfigurationDao.deleteSearchConfiguration(searchConfigurationId, listener);
+            experimentDao.getExperimentByFieldId(searchConfigurationId, SEARCH_CONFIGURATION_LIST, 3, new ActionListener<>() {
+                @Override
+                public void onResponse(SearchResponse experiments) {
+                    if (experiments != null && experiments.getHits().getTotalHits().value() > 0) {
+                        List<String> ids = Arrays.stream(experiments.getHits().getHits()).map(SearchHit::getId).toList();
+                        listener.onFailure(
+                            new SearchRelevanceException(
+                                String.format(
+                                    Locale.ROOT,
+                                    "search configuration cannot be deleted as it is currently used by experiments with ids %s",
+                                    String.join(", ", ids)
+                                ),
+                                RestStatus.CONFLICT
+                            )
+                        );
+                        return;
+                    }
+                    searchConfigurationDao.deleteSearchConfiguration(searchConfigurationId, listener);
+                }
+
+                @Override
+                public void onFailure(Exception e) {
+                    listener.onFailure(e);
+                }
+            });
         } catch (Exception e) {
             listener.onFailure(e);
         }

--- a/src/test/java/org/opensearch/searchrelevance/transport/judgment/DeleteJudgmentTransportActionTests.java
+++ b/src/test/java/org/opensearch/searchrelevance/transport/judgment/DeleteJudgmentTransportActionTests.java
@@ -14,6 +14,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.opensearch.searchrelevance.common.PluginConstants.JUDGMENT_LIST;
 
 import org.apache.lucene.search.TotalHits;
 import org.junit.Before;
@@ -61,7 +62,11 @@ public class DeleteJudgmentTransportActionTests extends OpenSearchTestCase {
         OpenSearchDocRequest request = new OpenSearchDocRequest(judgmentId);
 
         SearchResponse mockSearchResponse = createSearchResponseWithHitCount(0);
-        when(experimentDao.getExperimentByFieldId(eq(judgmentId), any())).thenReturn(mockSearchResponse);
+        doAnswer(invocation -> {
+            ActionListener<SearchResponse> listener = invocation.getArgument(3);
+            listener.onResponse(mockSearchResponse);
+            return null;
+        }).when(experimentDao).getExperimentByFieldId(eq(judgmentId), eq(JUDGMENT_LIST), eq(3), any(ActionListener.class));
 
         DeleteResponse mockDeleteResponse = mock(DeleteResponse.class);
         when(mockDeleteResponse.status()).thenReturn(RestStatus.OK);
@@ -75,7 +80,7 @@ public class DeleteJudgmentTransportActionTests extends OpenSearchTestCase {
         ActionListener<DeleteResponse> responseListener = mock(ActionListener.class);
         transportAction.doExecute(null, request, responseListener);
 
-        verify(experimentDao).getExperimentByFieldId(eq(judgmentId), any());
+        verify(experimentDao).getExperimentByFieldId(eq(judgmentId), eq(JUDGMENT_LIST), eq(3), any(ActionListener.class));
         verify(judgmentDao).deleteJudgment(eq(judgmentId), any(ActionListener.class));
     }
 
@@ -101,7 +106,11 @@ public class DeleteJudgmentTransportActionTests extends OpenSearchTestCase {
         OpenSearchDocRequest request = new OpenSearchDocRequest(judgmentId);
 
         SearchResponse mockSearchResponse = createSearchResponseWithHitCount(1);
-        when(experimentDao.getExperimentByFieldId(eq(judgmentId), any())).thenReturn(mockSearchResponse);
+        doAnswer(invocation -> {
+            ActionListener<SearchResponse> listener = invocation.getArgument(3);
+            listener.onResponse(mockSearchResponse);
+            return null;
+        }).when(experimentDao).getExperimentByFieldId(eq(judgmentId), eq(JUDGMENT_LIST), eq(3), any(ActionListener.class));
 
         ActionListener<DeleteResponse> responseListener = mock(ActionListener.class);
         transportAction.doExecute(null, request, responseListener);
@@ -111,7 +120,7 @@ public class DeleteJudgmentTransportActionTests extends OpenSearchTestCase {
 
         Exception exception = exceptionCaptor.getValue();
         assertTrue(exception instanceof SearchRelevanceException);
-        assertTrue(exception.getMessage().contains("judgment cannot be deleted as it is currently used by a experiment"));
+        assertTrue(exception.getMessage().contains("judgement cannot be deleted as it is currently used by experiments with ids"));
         assertEquals(RestStatus.CONFLICT, ((SearchRelevanceException) exception).status());
 
         verify(judgmentDao, never()).deleteJudgment(any(), any(ActionListener.class));
@@ -121,7 +130,11 @@ public class DeleteJudgmentTransportActionTests extends OpenSearchTestCase {
         String judgmentId = "test-judgment-id";
         OpenSearchDocRequest request = new OpenSearchDocRequest(judgmentId);
 
-        when(experimentDao.getExperimentByFieldId(eq(judgmentId), any())).thenReturn(null);
+        doAnswer(invocation -> {
+            ActionListener<SearchResponse> listener = invocation.getArgument(3);
+            listener.onResponse(null);
+            return null;
+        }).when(experimentDao).getExperimentByFieldId(eq(judgmentId), eq(JUDGMENT_LIST), eq(3), any(ActionListener.class));
 
         DeleteResponse mockDeleteResponse = mock(DeleteResponse.class);
         when(mockDeleteResponse.status()).thenReturn(RestStatus.OK);
@@ -135,7 +148,7 @@ public class DeleteJudgmentTransportActionTests extends OpenSearchTestCase {
         ActionListener<DeleteResponse> responseListener = mock(ActionListener.class);
         transportAction.doExecute(null, request, responseListener);
 
-        verify(experimentDao).getExperimentByFieldId(eq(judgmentId), any());
+        verify(experimentDao).getExperimentByFieldId(eq(judgmentId), eq(JUDGMENT_LIST), eq(3), any(ActionListener.class));
         verify(judgmentDao).deleteJudgment(eq(judgmentId), any(ActionListener.class));
     }
 


### PR DESCRIPTION
### Description
This is part 2 of Data integrity support. This PR adds data integrity during deletion of querysets, judgement and search configuration that if they are binded to an experiment then it will throw an exception.

### Issues Resolved
[238](https://github.com/opensearch-project/search-relevance/issues/238)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
