### PR TITLE
Replace match from term query in Delete calls

### DIFF
--- a/src/main/java/org/opensearch/searchrelevance/dao/ExperimentDao.java
+++ b/src/main/java/org/opensearch/searchrelevance/dao/ExperimentDao.java
@@ -135,7 +135,7 @@ public class ExperimentDao {
             return;
         }
 
-        SearchSourceBuilder sourceBuilder = new SearchSourceBuilder().query(QueryBuilders.matchQuery(fieldName, fieldId)).size(size);
+        SearchSourceBuilder sourceBuilder = new SearchSourceBuilder().query(QueryBuilders.termQuery(fieldName, fieldId)).size(size);
         searchRelevanceIndicesManager.listDocsBySearchRequest(sourceBuilder, EXPERIMENT, listener);
     }
 


### PR DESCRIPTION
### Description
Replacing match query to term query in getExperimentById field. Earlier in my testing, due to not creating index mapping seperately, and directly ingesting document led to text field creation of _id. Therfore, the term query was failing. But after doing the testing in a right way I have resolved the issue.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
