### PR TITLE
Add polling for test results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Add retry endpoint for failed LLM judgments, existingJudgments parameter for rating reuse, and remove broken global cache ([#525](https://github.com/opensearch-project/search-relevance/issues/525))
 
 ### Bug Fixes
+- Replaced long thread sleep with polling ([#340](https://github.com/opensearch-project/search-relevance/pull/340))
 - Exclude vector fields (`knn_vector`, `rank_features`, `sparse_vector`) from LLM judgment prompts when `contextFields` is not specified ([#565](https://github.com/opensearch-project/search-relevance/pull/565))
 - Return correct delete REST status codes and honor querySetSize for sampling ([#542](https://github.com/opensearch-project/search-relevance/pull/542))
 - Fix transport-thread blocking in experiment run and query set sampling, and notify listener on protected-index creation failure ([#559](https://github.com/opensearch-project/search-relevance/pull/559))

--- a/src/test/java/org/opensearch/searchrelevance/action/scheduledJob/ScheduledJobsIT.java
+++ b/src/test/java/org/opensearch/searchrelevance/action/scheduledJob/ScheduledJobsIT.java
@@ -23,6 +23,7 @@ import org.apache.hc.core5.http.HttpHeaders;
 import org.apache.hc.core5.http.message.BasicHeader;
 import org.opensearch.client.Response;
 import org.opensearch.client.ResponseException;
+import org.opensearch.common.unit.TimeValue;
 import org.opensearch.rest.RestRequest;
 import org.opensearch.searchrelevance.experiment.BaseExperimentIT;
 import org.opensearch.test.OpenSearchIntegTestCase;
@@ -41,6 +42,9 @@ public class ScheduledJobsIT extends BaseExperimentIT {
     String experimentId;
 
     public static final int CRON_JOB_COMPLETION_MS = 65000;
+    public static final int CRON_JOB_POLL_INTERVAL_MS = 5000;
+    public static final int SCHEDULED_RESULT_COMPLETION_MS = 10000;
+    public static final int SCHEDULED_RESULT_POLL_INTERVAL_MS = 1000;
 
     public void setUpEnvironment() throws Exception {
         // Arrange
@@ -85,61 +89,77 @@ public class ScheduledJobsIT extends BaseExperimentIT {
         assertNotNull(scheduledExperimentSource.get("schedule"));
         assertEquals(experimentId, scheduledExperimentSource.get("id"));
 
-        // Here we have to wait until at last one
-        Thread.sleep(CRON_JOB_COMPLETION_MS);
-
-        // Make sure that the last updated time is not the same as the time the job was placed into the scheduler
         String getScheduledExperimentJobRunByIdUrl = String.join("/", SCHEDULED_JOBS_INDEX, "_doc", experimentId);
-        Response getScheduledExperimentJobRunResponse = makeRequest(
-            client(),
-            RestRequest.Method.GET.name(),
-            getScheduledExperimentJobRunByIdUrl,
-            null,
-            null,
-            ImmutableList.of(new BasicHeader(HttpHeaders.USER_AGENT, DEFAULT_USER_AGENT))
-        );
-        Map<String, Object> getScheduledExperimentJobRunResponseJson = entityAsMap(getScheduledExperimentJobRunResponse);
-        assertNotNull(getScheduledExperimentJobRunResponseJson);
-        assertEquals(experimentId, getScheduledExperimentJobRunResponseJson.get("_id").toString());
-        Map<String, Object> scheduledExperimentJobRunSource = (Map<String, Object>) getScheduledExperimentJobRunResponseJson.get("_source");
-        assertNotNull(scheduledExperimentJobRunSource);
-        assertNotEquals(scheduledExperimentJobRunSource.get("enabledTime"), scheduledExperimentJobRunSource.get("lastUpdateTime"));
 
-        // Read the scheduled experiment results that have been run
+        // Wait until the scheduled job updates its metadata after the first run.
+        assertBusyWithFixedSleepTime(() -> {
+            Response getScheduledExperimentJobRunResponse;
+            try {
+                getScheduledExperimentJobRunResponse = makeRequest(
+                    client(),
+                    RestRequest.Method.GET.name(),
+                    getScheduledExperimentJobRunByIdUrl,
+                    null,
+                    null,
+                    ImmutableList.of(new BasicHeader(HttpHeaders.USER_AGENT, DEFAULT_USER_AGENT))
+                );
+            } catch (ResponseException e) {
+                assertNotEquals(404, e.getResponse().getStatusLine().getStatusCode());
+                throw e;
+            }
+            Map<String, Object> getScheduledExperimentJobRunResponseJson = entityAsMap(getScheduledExperimentJobRunResponse);
+            assertNotNull(getScheduledExperimentJobRunResponseJson);
+            assertEquals(experimentId, getScheduledExperimentJobRunResponseJson.get("_id").toString());
+            Map<String, Object> scheduledExperimentJobRunSource = (Map<String, Object>) getScheduledExperimentJobRunResponseJson.get(
+                "_source"
+            );
+            assertNotNull(scheduledExperimentJobRunSource);
+            assertNotEquals(scheduledExperimentJobRunSource.get("enabledTime"), scheduledExperimentJobRunSource.get("lastUpdateTime"));
+        }, TimeValue.timeValueMillis(CRON_JOB_COMPLETION_MS), TimeValue.timeValueMillis(CRON_JOB_POLL_INTERVAL_MS));
+
         String getScheduledExperimentResultsUrl = String.join("/", SCHEDULED_EXPERIMENT_HISTORY_INDEX, "_search");
-        Response getScheduledExperimentResultsResponse = makeRequest(
-            client(),
-            RestRequest.Method.POST.name(),
-            getScheduledExperimentResultsUrl,
-            null,
-            null,
-            ImmutableList.of(new BasicHeader(HttpHeaders.USER_AGENT, DEFAULT_USER_AGENT))
-        );
-        Map<String, Object> getScheduledExperimentResultListJson = entityAsMap(getScheduledExperimentResultsResponse);
 
-        assertNotNull(getScheduledExperimentResultListJson);
-        List<Object> listOfScheduledExperimentResults = (List<Object>) (((Map<String, Object>) (getScheduledExperimentResultListJson.get(
-            "hits"
-        ))).get("hits"));
-        assertTrue(listOfScheduledExperimentResults.size() > 0);
+        // Wait until the scheduled experiment result completes.
+        assertBusyWithFixedSleepTime(() -> {
+            Response getScheduledExperimentResultsResponse;
+            try {
+                getScheduledExperimentResultsResponse = makeRequest(
+                    client(),
+                    RestRequest.Method.POST.name(),
+                    getScheduledExperimentResultsUrl,
+                    null,
+                    null,
+                    ImmutableList.of(new BasicHeader(HttpHeaders.USER_AGENT, DEFAULT_USER_AGENT))
+                );
+            } catch (ResponseException e) {
+                assertNotEquals(404, e.getResponse().getStatusLine().getStatusCode());
+                throw e;
+            }
+            Map<String, Object> getScheduledExperimentResultListJson = entityAsMap(getScheduledExperimentResultsResponse);
 
-        Map<String, Object> getSingleScheduledExperimentResultJson = (Map<String, Object>) (listOfScheduledExperimentResults.get(0));
+            assertNotNull(getScheduledExperimentResultListJson);
+            List<Object> listOfScheduledExperimentResults = (List<Object>) (((Map<String, Object>) (getScheduledExperimentResultListJson
+                .get("hits"))).get("hits"));
+            assertTrue(listOfScheduledExperimentResults.size() > 0);
 
-        Map<String, Object> experimentSource = (Map<String, Object>) (getSingleScheduledExperimentResultJson.get("_source"));
+            Map<String, Object> getSingleScheduledExperimentResultJson = (Map<String, Object>) (listOfScheduledExperimentResults.get(0));
 
-        assertNotNull(experimentSource);
-        assertEquals("COMPLETED", experimentSource.get("status"));
+            Map<String, Object> experimentSource = (Map<String, Object>) (getSingleScheduledExperimentResultJson.get("_source"));
 
-        List<Map<String, Object>> results = (List<Map<String, Object>>) experimentSource.get("results");
-        assertNotNull(results);
+            assertNotNull(experimentSource);
+            assertEquals("COMPLETED", experimentSource.get("status"));
 
-        // convert list of actual results to map of query text and evaluation id
-        Map<String, Object> resultsMap = new HashMap<>();
-        results.forEach(result -> {
-            assertEquals(searchConfigurationId, result.get("searchConfigurationId"));
-            resultsMap.put((String) result.get("queryText"), result.get("evaluationId"));
-        });
-        assertEquals(results.size(), resultsMap.size());
+            List<Map<String, Object>> results = (List<Map<String, Object>>) experimentSource.get("results");
+            assertNotNull(results);
+
+            // convert list of actual results to map of query text and evaluation id
+            Map<String, Object> resultsMap = new HashMap<>();
+            results.forEach(result -> {
+                assertEquals(searchConfigurationId, result.get("searchConfigurationId"));
+                resultsMap.put((String) result.get("queryText"), result.get("evaluationId"));
+            });
+            assertEquals(results.size(), resultsMap.size());
+        }, TimeValue.timeValueMillis(SCHEDULED_RESULT_COMPLETION_MS), TimeValue.timeValueMillis(SCHEDULED_RESULT_POLL_INTERVAL_MS));
 
         Response deleteScheduledExperimentResponse = makeRequest(
             client(),

--- a/src/test/java/org/opensearch/searchrelevance/action/scheduledJob/ScheduledJobsIT.java
+++ b/src/test/java/org/opensearch/searchrelevance/action/scheduledJob/ScheduledJobsIT.java
@@ -23,6 +23,7 @@ import org.apache.hc.core5.http.HttpHeaders;
 import org.apache.hc.core5.http.message.BasicHeader;
 import org.opensearch.client.Response;
 import org.opensearch.client.ResponseException;
+import org.opensearch.common.unit.TimeValue;
 import org.opensearch.rest.RestRequest;
 import org.opensearch.searchrelevance.experiment.BaseExperimentIT;
 import org.opensearch.test.OpenSearchIntegTestCase;
@@ -41,6 +42,7 @@ public class ScheduledJobsIT extends BaseExperimentIT {
     String experimentId;
 
     public static final int CRON_JOB_COMPLETION_MS = 65000;
+    public static final int SLEEP_TIME = 5000;
 
     public void setUpEnvironment() throws Exception {
         // Arrange
@@ -85,61 +87,77 @@ public class ScheduledJobsIT extends BaseExperimentIT {
         assertNotNull(scheduledExperimentSource.get("schedule"));
         assertEquals(experimentId, scheduledExperimentSource.get("id"));
 
-        // Here we have to wait until at last one
-        Thread.sleep(CRON_JOB_COMPLETION_MS);
-
-        // Make sure that the last updated time is not the same as the time the job was placed into the scheduler
         String getScheduledExperimentJobRunByIdUrl = String.join("/", SCHEDULED_JOBS_INDEX, "_doc", experimentId);
-        Response getScheduledExperimentJobRunResponse = makeRequest(
-            client(),
-            RestRequest.Method.GET.name(),
-            getScheduledExperimentJobRunByIdUrl,
-            null,
-            null,
-            ImmutableList.of(new BasicHeader(HttpHeaders.USER_AGENT, DEFAULT_USER_AGENT))
-        );
-        Map<String, Object> getScheduledExperimentJobRunResponseJson = entityAsMap(getScheduledExperimentJobRunResponse);
-        assertNotNull(getScheduledExperimentJobRunResponseJson);
-        assertEquals(experimentId, getScheduledExperimentJobRunResponseJson.get("_id").toString());
-        Map<String, Object> scheduledExperimentJobRunSource = (Map<String, Object>) getScheduledExperimentJobRunResponseJson.get("_source");
-        assertNotNull(scheduledExperimentJobRunSource);
-        assertNotEquals(scheduledExperimentJobRunSource.get("enabledTime"), scheduledExperimentJobRunSource.get("lastUpdateTime"));
 
-        // Read the scheduled experiment results that have been run
+        // Wait until the scheduled job updates its metadata after the first run.
+        assertBusyWithFixedSleepTime(() -> {
+            Response getScheduledExperimentJobRunResponse;
+            try {
+                getScheduledExperimentJobRunResponse = makeRequest(
+                    client(),
+                    RestRequest.Method.GET.name(),
+                    getScheduledExperimentJobRunByIdUrl,
+                    null,
+                    null,
+                    ImmutableList.of(new BasicHeader(HttpHeaders.USER_AGENT, DEFAULT_USER_AGENT))
+                );
+            } catch (ResponseException e) {
+                assertNotEquals(404, e.getResponse().getStatusLine().getStatusCode());
+                throw e;
+            }
+            Map<String, Object> getScheduledExperimentJobRunResponseJson = entityAsMap(getScheduledExperimentJobRunResponse);
+            assertNotNull(getScheduledExperimentJobRunResponseJson);
+            assertEquals(experimentId, getScheduledExperimentJobRunResponseJson.get("_id").toString());
+            Map<String, Object> scheduledExperimentJobRunSource = (Map<String, Object>) getScheduledExperimentJobRunResponseJson.get(
+                "_source"
+            );
+            assertNotNull(scheduledExperimentJobRunSource);
+            assertNotEquals(scheduledExperimentJobRunSource.get("enabledTime"), scheduledExperimentJobRunSource.get("lastUpdateTime"));
+        }, TimeValue.timeValueMillis(CRON_JOB_COMPLETION_MS), TimeValue.timeValueMillis(SLEEP_TIME));
+
         String getScheduledExperimentResultsUrl = String.join("/", SCHEDULED_EXPERIMENT_HISTORY_INDEX, "_search");
-        Response getScheduledExperimentResultsResponse = makeRequest(
-            client(),
-            RestRequest.Method.POST.name(),
-            getScheduledExperimentResultsUrl,
-            null,
-            null,
-            ImmutableList.of(new BasicHeader(HttpHeaders.USER_AGENT, DEFAULT_USER_AGENT))
-        );
-        Map<String, Object> getScheduledExperimentResultListJson = entityAsMap(getScheduledExperimentResultsResponse);
 
-        assertNotNull(getScheduledExperimentResultListJson);
-        List<Object> listOfScheduledExperimentResults = (List<Object>) (((Map<String, Object>) (getScheduledExperimentResultListJson.get(
-            "hits"
-        ))).get("hits"));
-        assertTrue(listOfScheduledExperimentResults.size() > 0);
+        // Wait until the scheduled experiment result completes.
+        assertBusyWithFixedSleepTime(() -> {
+            Response getScheduledExperimentResultsResponse;
+            try {
+                getScheduledExperimentResultsResponse = makeRequest(
+                    client(),
+                    RestRequest.Method.POST.name(),
+                    getScheduledExperimentResultsUrl,
+                    null,
+                    null,
+                    ImmutableList.of(new BasicHeader(HttpHeaders.USER_AGENT, DEFAULT_USER_AGENT))
+                );
+            } catch (ResponseException e) {
+                assertNotEquals(404, e.getResponse().getStatusLine().getStatusCode());
+                throw e;
+            }
+            Map<String, Object> getScheduledExperimentResultListJson = entityAsMap(getScheduledExperimentResultsResponse);
 
-        Map<String, Object> getSingleScheduledExperimentResultJson = (Map<String, Object>) (listOfScheduledExperimentResults.get(0));
+            assertNotNull(getScheduledExperimentResultListJson);
+            List<Object> listOfScheduledExperimentResults = (List<Object>) (((Map<String, Object>) (getScheduledExperimentResultListJson
+                .get("hits"))).get("hits"));
+            assertTrue(listOfScheduledExperimentResults.size() > 0);
 
-        Map<String, Object> experimentSource = (Map<String, Object>) (getSingleScheduledExperimentResultJson.get("_source"));
+            Map<String, Object> getSingleScheduledExperimentResultJson = (Map<String, Object>) (listOfScheduledExperimentResults.get(0));
 
-        assertNotNull(experimentSource);
-        assertEquals("COMPLETED", experimentSource.get("status"));
+            Map<String, Object> experimentSource = (Map<String, Object>) (getSingleScheduledExperimentResultJson.get("_source"));
 
-        List<Map<String, Object>> results = (List<Map<String, Object>>) experimentSource.get("results");
-        assertNotNull(results);
+            assertNotNull(experimentSource);
+            assertEquals("COMPLETED", experimentSource.get("status"));
 
-        // convert list of actual results to map of query text and evaluation id
-        Map<String, Object> resultsMap = new HashMap<>();
-        results.forEach(result -> {
-            assertEquals(searchConfigurationId, result.get("searchConfigurationId"));
-            resultsMap.put((String) result.get("queryText"), result.get("evaluationId"));
-        });
-        assertEquals(results.size(), resultsMap.size());
+            List<Map<String, Object>> results = (List<Map<String, Object>>) experimentSource.get("results");
+            assertNotNull(results);
+
+            // convert list of actual results to map of query text and evaluation id
+            Map<String, Object> resultsMap = new HashMap<>();
+            results.forEach(result -> {
+                assertEquals(searchConfigurationId, result.get("searchConfigurationId"));
+                resultsMap.put((String) result.get("queryText"), result.get("evaluationId"));
+            });
+            assertEquals(results.size(), resultsMap.size());
+        }, TimeValue.timeValueMillis(CRON_JOB_COMPLETION_MS), TimeValue.timeValueMillis(SLEEP_TIME));
 
         Response deleteScheduledExperimentResponse = makeRequest(
             client(),


### PR DESCRIPTION
### Description
Rather than waiting for the scheduled results to appear by sleeping the thread, the new code polls periodically for results. 

### Issues Resolved
Resolved #326 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
