### PR TITLE
Process cancellations

### DIFF
--- a/src/main/java/org/opensearch/searchrelevance/executors/ExperimentRunningManager.java
+++ b/src/main/java/org/opensearch/searchrelevance/executors/ExperimentRunningManager.java
@@ -44,7 +44,7 @@ import org.opensearch.searchrelevance.model.QuerySet;
 import org.opensearch.searchrelevance.model.ScheduledExperimentResult;
 import org.opensearch.searchrelevance.model.SearchConfiguration;
 import org.opensearch.searchrelevance.model.SearchConfigurationDetails;
-import org.opensearch.searchrelevance.scheduler.ExperimentCancellationToken;
+import org.opensearch.searchrelevance.scheduler.AbstractCancellationToken;
 import org.opensearch.searchrelevance.scheduler.ScheduledExperimentRunnerManager;
 import org.opensearch.searchrelevance.settings.SearchRelevanceSettingsAccessor;
 import org.opensearch.searchrelevance.transport.experiment.PutExperimentRequest;
@@ -108,7 +108,7 @@ public class ExperimentRunningManager {
     public void startExperimentRun(
         String experimentId,
         PutExperimentRequest request,
-        ExperimentCancellationToken cancellationToken,
+        AbstractCancellationToken cancellationToken,
         CountDownLatch actuallyFinished
     ) {
         List<Future<?>> futures = new ArrayList<>();
@@ -130,10 +130,31 @@ public class ExperimentRunningManager {
             });
 
             // register cancellation callback
-            // If the
             cancellationToken.onCancel(() -> {
                 runningFutures.get(request.getScheduledExperimentResultId()).forEach(f -> FutureUtils.cancel(f));
                 runningFutures.remove(request.getScheduledExperimentResultId());
+            });
+        } else {
+            if (runningFutures.containsKey(experimentId)) {
+                handleAsyncFailure(
+                    experimentId,
+                    request,
+                    "There is a running single experiment run with the same experiment id",
+                    new Exception("Cannot run experiment!"),
+                    actuallyFinished
+                );
+                log.error("Cannot run experiment as there is another run with the same experiment id, {}", experimentId);
+                return;
+            }
+            runningFutures.compute(experimentId, (key, existingList) -> {
+                List<Future<?>> list = existingList != null ? existingList : new CopyOnWriteArrayList<>();
+                return list;
+            });
+
+            // register cancellation callback
+            cancellationToken.onCancel(() -> {
+                runningFutures.get(experimentId).forEach(f -> FutureUtils.cancel(f));
+                runningFutures.remove(experimentId);
             });
         }
         // First, get QuerySet asynchronously
@@ -165,7 +186,7 @@ public class ExperimentRunningManager {
         String experimentId,
         PutExperimentRequest request,
         List<String> queryTextWithReferences,
-        ExperimentCancellationToken cancellationToken,
+        AbstractCancellationToken cancellationToken,
         CountDownLatch actuallyFinished
     ) {
         Map<String, SearchConfigurationDetails> searchConfigurations = new HashMap<>();
@@ -193,6 +214,13 @@ public class ExperimentRunningManager {
                         configId,
                         experimentId
                     );
+                }
+            } else {
+                // This should be synchronized.
+                try {
+                    runningFutures.get(experimentId).add(singleSearchConfigurationFuture);
+                } catch (Exception e) {
+                    log.info("Fetching search configuration, {} for single experiment {} cannot be completed", configId, experimentId);
                 }
             }
             configFutures.add(singleSearchConfigurationFuture);
@@ -234,7 +262,7 @@ public class ExperimentRunningManager {
         );
     }
 
-    private boolean checkIfCancelled(ExperimentCancellationToken cancellationToken) {
+    private boolean checkIfCancelled(AbstractCancellationToken cancellationToken) {
         if (cancellationToken != null && cancellationToken.isCancelled()) {
             return true;
         }
@@ -247,7 +275,7 @@ public class ExperimentRunningManager {
         List<String> queryTextWithReferences,
         AtomicBoolean hasFailure,
         String configId,
-        ExperimentCancellationToken cancellationToken,
+        AbstractCancellationToken cancellationToken,
         CountDownLatch actuallyFinished
     ) {
         CompletableFuture<Entry<String, Object>> future = new CompletableFuture<>();
@@ -382,7 +410,7 @@ public class ExperimentRunningManager {
         AtomicInteger pendingQueries,
         AtomicBoolean hasFailure,
         List<String> judgmentList,
-        ExperimentCancellationToken cancellationToken,
+        AbstractCancellationToken cancellationToken,
         CountDownLatch actuallyFinished
     ) {
         int completedQueries = 0;
@@ -492,7 +520,7 @@ public class ExperimentRunningManager {
         PutExperimentRequest request,
         AtomicBoolean hasFailure,
         List<String> judgmentList,
-        ExperimentCancellationToken cancellationToken,
+        AbstractCancellationToken cancellationToken,
         CountDownLatch actuallyFinished
     ) {
         if (hasFailure.get() || checkIfCancelled(cancellationToken)) {

--- a/src/main/java/org/opensearch/searchrelevance/executors/ExperimentTaskManager.java
+++ b/src/main/java/org/opensearch/searchrelevance/executors/ExperimentTaskManager.java
@@ -36,7 +36,7 @@ import org.opensearch.searchrelevance.experiment.QuerySourceUtil;
 import org.opensearch.searchrelevance.model.ExperimentType;
 import org.opensearch.searchrelevance.model.ExperimentVariant;
 import org.opensearch.searchrelevance.model.builder.SearchRequestBuilder;
-import org.opensearch.searchrelevance.scheduler.ExperimentCancellationToken;
+import org.opensearch.searchrelevance.scheduler.AbstractCancellationToken;
 import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.transport.client.Client;
 
@@ -112,7 +112,7 @@ public class ExperimentTaskManager {
         AtomicBoolean hasFailure,
         String scheduledRunId,
         Map<String, List<Future<?>>> runningFutures,
-        ExperimentCancellationToken cancellationToken
+        AbstractCancellationToken cancellationToken
     ) {
         // Create a CompletableFuture to track the overall completion
         CompletableFuture<Map<String, Object>> resultFuture = new CompletableFuture<>();
@@ -190,7 +190,7 @@ public class ExperimentTaskManager {
         Map<String, String> docIdToScores,
         ExperimentTaskContext taskContext,
         String scheduledRunId,
-        ExperimentCancellationToken cancellationToken,
+        AbstractCancellationToken cancellationToken,
         Map<String, List<Future<?>>> runningFutures
     ) {
         if (experimentType == ExperimentType.POINTWISE_EVALUATION) {
@@ -237,7 +237,7 @@ public class ExperimentTaskManager {
         return (String) variant.getParameters().get("searchPipeline");
     }
 
-    private boolean checkIfCancelled(ExperimentCancellationToken cancellationToken) {
+    private boolean checkIfCancelled(AbstractCancellationToken cancellationToken) {
         if (cancellationToken != null && cancellationToken.isCancelled()) {
             return true;
         }

--- a/src/main/java/org/opensearch/searchrelevance/executors/PointwiseTaskParameters.java
+++ b/src/main/java/org/opensearch/searchrelevance/executors/PointwiseTaskParameters.java
@@ -11,7 +11,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.opensearch.searchrelevance.model.ExperimentVariant;
-import org.opensearch.searchrelevance.scheduler.ExperimentCancellationToken;
+import org.opensearch.searchrelevance.scheduler.AbstractCancellationToken;
 
 import lombok.Getter;
 import lombok.experimental.SuperBuilder;
@@ -45,7 +45,7 @@ public class PointwiseTaskParameters extends VariantTaskParameters {
         Map<String, String> docIdToScores,
         ExperimentTaskContext taskContext,
         String searchPipeline,
-        ExperimentCancellationToken cancellationToken
+        AbstractCancellationToken cancellationToken
     ) {
         return PointwiseTaskParameters.builder()
             .experimentId(experimentId)

--- a/src/main/java/org/opensearch/searchrelevance/executors/VariantTaskParameters.java
+++ b/src/main/java/org/opensearch/searchrelevance/executors/VariantTaskParameters.java
@@ -12,7 +12,7 @@ import java.util.Map;
 import java.util.concurrent.Future;
 
 import org.opensearch.searchrelevance.model.ExperimentVariant;
-import org.opensearch.searchrelevance.scheduler.ExperimentCancellationToken;
+import org.opensearch.searchrelevance.scheduler.AbstractCancellationToken;
 
 import lombok.Getter;
 import lombok.experimental.SuperBuilder;
@@ -34,6 +34,6 @@ public class VariantTaskParameters {
     private final Map<String, String> docIdToScores;
     private final ExperimentTaskContext taskContext;
     private final String scheduledRunId;
-    private ExperimentCancellationToken cancellationToken;
+    private final AbstractCancellationToken cancellationToken;
     Map<String, List<Future<?>>> runningFutures;
 }

--- a/src/main/java/org/opensearch/searchrelevance/experiment/HybridOptimizerExperimentProcessor.java
+++ b/src/main/java/org/opensearch/searchrelevance/experiment/HybridOptimizerExperimentProcessor.java
@@ -32,7 +32,7 @@ import org.opensearch.searchrelevance.model.AsyncStatus;
 import org.opensearch.searchrelevance.model.ExperimentType;
 import org.opensearch.searchrelevance.model.ExperimentVariant;
 import org.opensearch.searchrelevance.model.SearchConfigurationDetails;
-import org.opensearch.searchrelevance.scheduler.ExperimentCancellationToken;
+import org.opensearch.searchrelevance.scheduler.AbstractCancellationToken;
 import org.opensearch.searchrelevance.utils.TimeUtils;
 
 import com.google.common.annotations.VisibleForTesting;
@@ -70,7 +70,7 @@ public class HybridOptimizerExperimentProcessor {
         List<String> judgmentList,
         int size,
         String scheduledRunId,
-        ExperimentCancellationToken cancellationToken,
+        AbstractCancellationToken cancellationToken,
         Map<String, List<Future<?>>> runningFutures,
         ActionListener<Map<String, Object>> listener
     ) {
@@ -204,7 +204,7 @@ public class HybridOptimizerExperimentProcessor {
         }
     }
 
-    private boolean checkIfCancelled(ExperimentCancellationToken cancellationToken) {
+    private boolean checkIfCancelled(AbstractCancellationToken cancellationToken) {
         if (cancellationToken != null && cancellationToken.isCancelled()) {
             return true;
         }
@@ -225,7 +225,7 @@ public class HybridOptimizerExperimentProcessor {
         Map<String, String> docIdToScores,
         AtomicBoolean hasFailure,
         String scheduledRunId,
-        ExperimentCancellationToken cancellationToken,
+        AbstractCancellationToken cancellationToken,
         Map<String, List<Future<?>>> runningFutures,
         ActionListener<Map<String, Object>> finalListener
     ) {

--- a/src/main/java/org/opensearch/searchrelevance/experiment/PointwiseExperimentProcessor.java
+++ b/src/main/java/org/opensearch/searchrelevance/experiment/PointwiseExperimentProcessor.java
@@ -34,7 +34,7 @@ import org.opensearch.searchrelevance.model.AsyncStatus;
 import org.opensearch.searchrelevance.model.ExperimentType;
 import org.opensearch.searchrelevance.model.ExperimentVariant;
 import org.opensearch.searchrelevance.model.SearchConfigurationDetails;
-import org.opensearch.searchrelevance.scheduler.ExperimentCancellationToken;
+import org.opensearch.searchrelevance.scheduler.AbstractCancellationToken;
 import org.opensearch.searchrelevance.utils.TimeUtils;
 
 import lombok.extern.log4j.Log4j2;
@@ -77,7 +77,7 @@ public class PointwiseExperimentProcessor {
         int size,
         AtomicBoolean hasFailure,
         String scheduledRunId,
-        ExperimentCancellationToken cancellationToken,
+        AbstractCancellationToken cancellationToken,
         ActionListener<Map<String, Object>> listener
     ) {
         log.info(
@@ -195,7 +195,7 @@ public class PointwiseExperimentProcessor {
         Map<String, String> docIdToScores,
         AtomicBoolean hasFailure,
         String scheduledRunId,
-        ExperimentCancellationToken cancellationToken,
+        AbstractCancellationToken cancellationToken,
         ActionListener<Map<String, Object>> listener
     ) {
         // Create simple variants

--- a/src/main/java/org/opensearch/searchrelevance/plugin/SearchRelevancePlugin.java
+++ b/src/main/java/org/opensearch/searchrelevance/plugin/SearchRelevancePlugin.java
@@ -10,6 +10,7 @@ package org.opensearch.searchrelevance.plugin;
 import static org.opensearch.searchrelevance.common.PluginConstants.EXPERIMENT_INDEX;
 import static org.opensearch.searchrelevance.common.PluginConstants.JUDGMENT_CACHE_INDEX;
 import static org.opensearch.searchrelevance.common.PluginConstants.SCHEDULED_JOBS_INDEX;
+import static org.opensearch.searchrelevance.settings.SearchRelevanceSettings.SEARCH_RELEVANCE_EXPERIMENTS_TIMEOUT;
 import static org.opensearch.searchrelevance.settings.SearchRelevanceSettings.SEARCH_RELEVANCE_QUERY_SET_MAX_LIMIT;
 import static org.opensearch.searchrelevance.settings.SearchRelevanceSettings.SEARCH_RELEVANCE_SCHEDULED_EXPERIMENTS_ENABLED;
 import static org.opensearch.searchrelevance.settings.SearchRelevanceSettings.SEARCH_RELEVANCE_SCHEDULED_EXPERIMENTS_MINIMUM_INTERVAL;
@@ -385,7 +386,8 @@ public class SearchRelevancePlugin extends Plugin
             SEARCH_RELEVANCE_QUERY_SET_MAX_LIMIT,
             SEARCH_RELEVANCE_SCHEDULED_EXPERIMENTS_ENABLED,
             SEARCH_RELEVANCE_SCHEDULED_EXPERIMENTS_TIMEOUT,
-            SEARCH_RELEVANCE_SCHEDULED_EXPERIMENTS_MINIMUM_INTERVAL
+            SEARCH_RELEVANCE_SCHEDULED_EXPERIMENTS_MINIMUM_INTERVAL,
+            SEARCH_RELEVANCE_EXPERIMENTS_TIMEOUT
         );
     }
 

--- a/src/main/java/org/opensearch/searchrelevance/scheduler/AbstractCancellationToken.java
+++ b/src/main/java/org/opensearch/searchrelevance/scheduler/AbstractCancellationToken.java
@@ -1,0 +1,36 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+package org.opensearch.searchrelevance.scheduler;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+public abstract class AbstractCancellationToken {
+
+    private final AtomicBoolean cancelled = new AtomicBoolean(false);
+    // cancellationCallbacks should be short running and completed syncronously quickly.
+    private final List<Runnable> cancellationCallbacks = new CopyOnWriteArrayList<>();
+
+    public boolean isCancelled() {
+        return cancelled.get();
+    }
+
+    public void cancel() {
+        if (cancelled.compareAndSet(false, true)) {
+            cancellationCallbacks.forEach(Runnable::run);
+        }
+    }
+
+    public void onCancel(Runnable callback) {
+        cancellationCallbacks.add(callback);
+        if (isCancelled()) {
+            callback.run();
+        }
+    }
+}

--- a/src/main/java/org/opensearch/searchrelevance/scheduler/ExperimentCancellationToken.java
+++ b/src/main/java/org/opensearch/searchrelevance/scheduler/ExperimentCancellationToken.java
@@ -7,41 +7,14 @@
  */
 package org.opensearch.searchrelevance.scheduler;
 
-import java.util.List;
-import java.util.concurrent.CopyOnWriteArrayList;
-import java.util.concurrent.atomic.AtomicBoolean;
+public class ExperimentCancellationToken extends AbstractCancellationToken {
+    private final String experimentId;
 
-/**
- * Token for signaling whether a scheduled experiment has been cancelled
- */
-public class ExperimentCancellationToken {
-    private final AtomicBoolean cancelled = new AtomicBoolean(false);
-    // cancellationCallbacks should be short running and completed syncronously quickly.
-    private final List<Runnable> cancellationCallbacks = new CopyOnWriteArrayList<>();
-    private final String scheduledExperimentResultId;
-
-    public ExperimentCancellationToken(String scheduledExperimentResultId) {
-        this.scheduledExperimentResultId = scheduledExperimentResultId;
+    public ExperimentCancellationToken(String experimentId) {
+        this.experimentId = experimentId;
     }
 
-    public String getScheduledExperimentResultId() {
-        return scheduledExperimentResultId;
-    }
-
-    public boolean isCancelled() {
-        return cancelled.get();
-    }
-
-    public void cancel() {
-        if (cancelled.compareAndSet(false, true)) {
-            cancellationCallbacks.forEach(Runnable::run);
-        }
-    }
-
-    public void onCancel(Runnable callback) {
-        cancellationCallbacks.add(callback);
-        if (isCancelled()) {
-            callback.run();
-        }
+    public String getExperimentResultId() {
+        return experimentId;
     }
 }

--- a/src/main/java/org/opensearch/searchrelevance/scheduler/ScheduledExperimentCancellationToken.java
+++ b/src/main/java/org/opensearch/searchrelevance/scheduler/ScheduledExperimentCancellationToken.java
@@ -1,0 +1,23 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+package org.opensearch.searchrelevance.scheduler;
+
+/**
+ * Token for signaling whether a scheduled experiment has been cancelled
+ */
+public class ScheduledExperimentCancellationToken extends AbstractCancellationToken {
+    private final String scheduledExperimentResultId;
+
+    public ScheduledExperimentCancellationToken(String scheduledExperimentResultId) {
+        this.scheduledExperimentResultId = scheduledExperimentResultId;
+    }
+
+    public String getScheduledExperimentResultId() {
+        return scheduledExperimentResultId;
+    }
+}

--- a/src/main/java/org/opensearch/searchrelevance/scheduler/ScheduledExperimentRunnerManager.java
+++ b/src/main/java/org/opensearch/searchrelevance/scheduler/ScheduledExperimentRunnerManager.java
@@ -70,7 +70,7 @@ public class ScheduledExperimentRunnerManager {
     public void runScheduledExperiment(
         SearchRelevanceJobParameters parameter,
         String scheduledExperimentResultId,
-        ExperimentCancellationToken cancellationToken,
+        AbstractCancellationToken cancellationToken,
         CountDownLatch actuallyFinished
     ) {
         String experimentId = parameter.getExperimentId();
@@ -157,7 +157,7 @@ public class ScheduledExperimentRunnerManager {
         }
     }
 
-    private boolean checkIfCancelled(ExperimentCancellationToken cancellationToken) {
+    private boolean checkIfCancelled(AbstractCancellationToken cancellationToken) {
         if (cancellationToken != null && cancellationToken.isCancelled()) {
             return true;
         }
@@ -231,7 +231,7 @@ public class ScheduledExperimentRunnerManager {
      * @param scheduledExperimentResultId Id of scheduled experiment result
      * @param cancellationToken The token to indicate whether this scheduled experiment run has been cancelled
      */
-    public void cleanupResources(String experimentId, String scheduledExperimentResultId, ExperimentCancellationToken cancellationToken) {
+    public void cleanupResources(String experimentId, String scheduledExperimentResultId, AbstractCancellationToken cancellationToken) {
         log.info("Cleaning up all resources for {}", experimentId);
         ScheduledExperimentResult finalExperiment = new ScheduledExperimentResult(
             scheduledExperimentResultId,

--- a/src/main/java/org/opensearch/searchrelevance/scheduler/SearchRelevanceJobRunner.java
+++ b/src/main/java/org/opensearch/searchrelevance/scheduler/SearchRelevanceJobRunner.java
@@ -68,7 +68,7 @@ public enum SearchRelevanceJobRunner implements ScheduledJobRunner {
         String scheduledExperimentResultId = UUID.randomUUID().toString();
         SearchRelevanceJobParameters parameter = (SearchRelevanceJobParameters) jobParameter;
 
-        ExperimentCancellationToken cancellationToken = new ExperimentCancellationToken(scheduledExperimentResultId);
+        ScheduledExperimentCancellationToken cancellationToken = new ScheduledExperimentCancellationToken(scheduledExperimentResultId);
         CountDownLatch actuallyFinished = new CountDownLatch(1);
 
         Runnable jobRunTask = () -> {

--- a/src/main/java/org/opensearch/searchrelevance/settings/SearchRelevanceSettings.java
+++ b/src/main/java/org/opensearch/searchrelevance/settings/SearchRelevanceSettings.java
@@ -91,4 +91,15 @@ public class SearchRelevanceSettings {
         Setting.Property.NodeScope,
         Setting.Property.Dynamic
     );
+
+    /**
+     * When a search evaluation is to be run, there will be an amount of
+     * time to wait before automatically cancelling that experiment.
+     */
+    public static final Setting<TimeValue> SEARCH_RELEVANCE_EXPERIMENTS_TIMEOUT = Setting.positiveTimeSetting(
+        "plugins.search_relevance.experiments_timeout",
+        TimeValue.timeValueMinutes(60),
+        Setting.Property.NodeScope,
+        Setting.Property.Dynamic
+    );
 }

--- a/src/main/java/org/opensearch/searchrelevance/settings/SearchRelevanceSettingsAccessor.java
+++ b/src/main/java/org/opensearch/searchrelevance/settings/SearchRelevanceSettingsAccessor.java
@@ -31,6 +31,8 @@ public class SearchRelevanceSettingsAccessor {
     private volatile TimeValue scheduledExperimentsTimeout;
     @Getter
     private volatile TimeValue scheduledExperimentsMinimumInterval;
+    @Getter
+    private volatile TimeValue experimentsTimeout;
 
     /**
      * Constructor, registers callbacks to update settings
@@ -45,6 +47,7 @@ public class SearchRelevanceSettingsAccessor {
         isScheduledExperimentsEnabled = SearchRelevanceSettings.SEARCH_RELEVANCE_SCHEDULED_EXPERIMENTS_ENABLED.get(settings);
         scheduledExperimentsTimeout = SearchRelevanceSettings.SEARCH_RELEVANCE_SCHEDULED_EXPERIMENTS_TIMEOUT.get(settings);
         scheduledExperimentsMinimumInterval = SearchRelevanceSettings.SEARCH_RELEVANCE_SCHEDULED_EXPERIMENTS_MINIMUM_INTERVAL.get(settings);
+        experimentsTimeout = SearchRelevanceSettings.SEARCH_RELEVANCE_EXPERIMENTS_TIMEOUT.get(settings);
         registerSettingsCallbacks(clusterService);
     }
 
@@ -79,6 +82,11 @@ public class SearchRelevanceSettingsAccessor {
         clusterService.getClusterSettings()
             .addSettingsUpdateConsumer(SearchRelevanceSettings.SEARCH_RELEVANCE_SCHEDULED_EXPERIMENTS_MINIMUM_INTERVAL, value -> {
                 scheduledExperimentsMinimumInterval = value;
+            });
+
+        clusterService.getClusterSettings()
+            .addSettingsUpdateConsumer(SearchRelevanceSettings.SEARCH_RELEVANCE_EXPERIMENTS_TIMEOUT, value -> {
+                experimentsTimeout = value;
             });
     }
 }

--- a/src/main/java/org/opensearch/searchrelevance/transport/experiment/PutExperimentTransportAction.java
+++ b/src/main/java/org/opensearch/searchrelevance/transport/experiment/PutExperimentTransportAction.java
@@ -9,6 +9,10 @@ package org.opensearch.searchrelevance.transport.experiment;
 
 import java.util.ArrayList;
 import java.util.UUID;
+import java.util.concurrent.CancellationException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.CountDownLatch;
 
 import org.opensearch.action.index.IndexResponse;
 import org.opensearch.action.support.ActionFilters;
@@ -28,7 +32,10 @@ import org.opensearch.searchrelevance.experiment.PointwiseExperimentProcessor;
 import org.opensearch.searchrelevance.metrics.MetricsHelper;
 import org.opensearch.searchrelevance.model.AsyncStatus;
 import org.opensearch.searchrelevance.model.Experiment;
+import org.opensearch.searchrelevance.scheduler.AbstractCancellationToken;
+import org.opensearch.searchrelevance.scheduler.ExperimentCancellationToken;
 import org.opensearch.searchrelevance.settings.SearchRelevanceSettingsAccessor;
+import org.opensearch.searchrelevance.utils.ConcurrencyUtil;
 import org.opensearch.searchrelevance.utils.TimeUtils;
 import org.opensearch.tasks.Task;
 import org.opensearch.threadpool.ThreadPool;
@@ -49,6 +56,8 @@ public class PutExperimentTransportAction extends HandledTransportAction<PutExpe
     private final HybridOptimizerExperimentProcessor hybridOptimizerExperimentProcessor;
     private final PointwiseExperimentProcessor pointwiseExperimentProcessor;
     private final ExperimentRunningManager experimentRunningManager;
+    private final ThreadPool threadPool;
+    private final SearchRelevanceSettingsAccessor settingsAccessor;
 
     @Inject
     public PutExperimentTransportAction(
@@ -72,6 +81,8 @@ public class PutExperimentTransportAction extends HandledTransportAction<PutExpe
         this.hybridOptimizerExperimentProcessor = new HybridOptimizerExperimentProcessor(judgmentDao, experimentTaskManager);
         this.pointwiseExperimentProcessor = new PointwiseExperimentProcessor(judgmentDao, experimentTaskManager);
         this.experimentRunningManager = experimentRunningManager;
+        this.threadPool = threadPool;
+        this.settingsAccessor = settingsAccessor;
     }
 
     @Override
@@ -100,8 +111,61 @@ public class PutExperimentTransportAction extends HandledTransportAction<PutExpe
                 // Return response immediately
                 listener.onResponse((IndexResponse) response);
 
-                // Start experiment with async processing
-                experimentRunningManager.startExperimentRun(id, request, null, null);
+                ExperimentCancellationToken cancellationToken = new ExperimentCancellationToken(id);
+                CountDownLatch actuallyFinished = new CountDownLatch(1);
+                Runnable experimentRunTask = () -> {
+                    // Start experiment with async processing
+                    experimentRunningManager.startExperimentRun(id, request, cancellationToken, actuallyFinished);
+                    log.info("Experiment {} is finished.", id);
+                };
+
+                Runnable timeoutJobWithCleanup = () -> {
+                    CompletableFuture<Void> searchEvaluationTask = null;
+                    try {
+                        // Schedule the experiment to run then also schedule a timeout to cancel experiment after some time.
+                        long timeoutAmount = settingsAccessor.getExperimentsTimeout().getSeconds();
+                        CompletableFuture<Void> originalExperimentStart;
+                        try {
+                            originalExperimentStart = CompletableFuture.runAsync(experimentRunTask, threadPool.generic());
+                            searchEvaluationTask = ConcurrencyUtil.withTimeout(
+                                originalExperimentStart,
+                                timeoutAmount,
+                                cancellationToken,
+                                actuallyFinished,
+                                threadPool
+                            );
+                        } catch (Exception e) {
+                            actuallyFinished.countDown();
+                            log.error("Experiment never started " + e.getMessage());
+                        }
+
+                        // Wait until all asynchronous operations or timeout complete before cleanup
+                        searchEvaluationTask.join();
+                    } catch (CancellationException e) {
+                        log.error("Timeout for experiment has occured!");
+                    } catch (CompletionException e) {
+                        log.error("Experiment has timed out. Moving onto cleanup");
+                    } finally {
+                        // All threads except this current running one should be released if we got to this point.
+                        // This is if join somehow failed, but the thread should be waiting at the join call and only
+                        // be released when the actuallyFinished latch is counted down.
+                        while (actuallyFinished.getCount() > 0) {
+                            actuallyFinished.countDown();
+                        }
+                        if (cancellationToken.isCancelled()) {
+                            log.info("Search evaluation task has concluded through cancellation.");
+                        } else {
+                            log.info("Search evaluation task has concluded without cancellation");
+                        }
+                        cleanupResources(id, request, cancellationToken);
+                        // This will clean up the future map in ExperimentRunningManager
+                        cancellationToken.cancel();
+                    }
+                };
+
+                // The logic of the experiment run should not block this calling thread, so it will be scheduled
+                // into a threadpool.
+                threadPool.generic().execute(timeoutJobWithCleanup);
             }, e -> {
                 log.error("Failed to create initial experiment", e);
                 listener.onFailure(
@@ -112,6 +176,36 @@ public class PutExperimentTransportAction extends HandledTransportAction<PutExpe
         } catch (Exception e) {
             log.error("Failed to process experiment request", e);
             listener.onFailure(new SearchRelevanceException("Failed to process experiment request", e, RestStatus.INTERNAL_SERVER_ERROR));
+        }
+    }
+
+    /**
+     *
+     * @param experimentId Id of experiment that is scheduled to run
+     * @param cancellationToken The token to indicate whether this scheduled experiment run has been cancelled
+     */
+    public void cleanupResources(String experimentId, PutExperimentRequest request, AbstractCancellationToken cancellationToken) {
+        log.info("Cleaning up all resources for {}", experimentId);
+        Experiment finalExperiment = new Experiment(
+            experimentId,
+            TimeUtils.getTimestamp(),
+            request.getType(),
+            AsyncStatus.TIMEOUT,
+            request.getQuerySetId(),
+            request.getSearchConfigurationList(),
+            request.getJudgmentList(),
+            request.getSize(),
+            null
+        );
+
+        if (cancellationToken.isCancelled()) {
+            experimentDao.updateExperiment(
+                finalExperiment,
+                ActionListener.wrap(
+                    response -> log.info("Updated experiment {} status to TIMEOUT", experimentId),
+                    e -> log.error("Failed to update error status for experiment: {}", experimentId, e)
+                )
+            );
         }
     }
 }

--- a/src/main/java/org/opensearch/searchrelevance/utils/ConcurrencyUtil.java
+++ b/src/main/java/org/opensearch/searchrelevance/utils/ConcurrencyUtil.java
@@ -16,7 +16,7 @@ import java.util.concurrent.TimeoutException;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.opensearch.common.util.concurrent.FutureUtils;
-import org.opensearch.searchrelevance.scheduler.ExperimentCancellationToken;
+import org.opensearch.searchrelevance.scheduler.AbstractCancellationToken;
 import org.opensearch.searchrelevance.scheduler.SearchRelevanceJobRunner;
 import org.opensearch.threadpool.ThreadPool;
 
@@ -30,7 +30,7 @@ public class ConcurrencyUtil {
     public static <T> CompletableFuture<T> withTimeout(
         CompletableFuture<T> future,
         long timeoutSeconds,
-        ExperimentCancellationToken cancellationToken,
+        AbstractCancellationToken cancellationToken,
         CountDownLatch actuallyFinished,
         ThreadPool threadPool
     ) {

--- a/src/test/java/org/opensearch/searchrelevance/executors/ExperimentRunningManagerTests.java
+++ b/src/test/java/org/opensearch/searchrelevance/executors/ExperimentRunningManagerTests.java
@@ -43,7 +43,7 @@ import org.opensearch.searchrelevance.experiment.PointwiseExperimentProcessor;
 import org.opensearch.searchrelevance.metrics.MetricsHelper;
 import org.opensearch.searchrelevance.model.ExperimentType;
 import org.opensearch.searchrelevance.model.ScheduledExperimentResult;
-import org.opensearch.searchrelevance.scheduler.ExperimentCancellationToken;
+import org.opensearch.searchrelevance.scheduler.ScheduledExperimentCancellationToken;
 import org.opensearch.searchrelevance.settings.SearchRelevanceSettingsAccessor;
 import org.opensearch.searchrelevance.transport.experiment.PutExperimentRequest;
 import org.opensearch.test.OpenSearchTestCase;
@@ -106,7 +106,7 @@ public class ExperimentRunningManagerTests extends OpenSearchTestCase {
         CountDownLatch actuallyFinished = new CountDownLatch(1);
         PutExperimentRequest request = createExperimentRequest();
 
-        ExperimentCancellationToken cancellationToken = new ExperimentCancellationToken("scheduled-experiment-result-id");
+        ScheduledExperimentCancellationToken cancellationToken = new ScheduledExperimentCancellationToken("scheduled-experiment-result-id");
         cancellationToken.cancel();
         experimentRunningManager.fetchSearchConfigurationsAsync(
             "experimentId",
@@ -123,7 +123,7 @@ public class ExperimentRunningManagerTests extends OpenSearchTestCase {
         CountDownLatch actuallyFinished = new CountDownLatch(1);
         PutExperimentRequest request = createExperimentRequest();
 
-        ExperimentCancellationToken cancellationToken = new ExperimentCancellationToken("scheduled-experiment-result-id");
+        ScheduledExperimentCancellationToken cancellationToken = new ScheduledExperimentCancellationToken("scheduled-experiment-result-id");
         SearchResponse searchConfigResponse = mock(SearchResponse.class);
         doAnswer(invocation -> {
             ActionListener<SearchResponse> listener = invocation.getArgument(1);
@@ -147,7 +147,7 @@ public class ExperimentRunningManagerTests extends OpenSearchTestCase {
         PutExperimentRequest request = createExperimentRequest();
         CountDownLatch actuallyFinished = new CountDownLatch(1);
 
-        ExperimentCancellationToken cancellationToken = new ExperimentCancellationToken("scheduled-experiment-result-id");
+        ScheduledExperimentCancellationToken cancellationToken = new ScheduledExperimentCancellationToken("scheduled-experiment-result-id");
         cancellationToken.cancel();
         experimentRunningManager.executeExperimentEvaluation(
             "experimentId",
@@ -171,7 +171,7 @@ public class ExperimentRunningManagerTests extends OpenSearchTestCase {
     public void testConcurrentFutureMapUpdates() {
         PutExperimentRequest request = createExperimentRequest();
         Map<String, List<Future<?>>> runningFutures = new ConcurrentHashMap<>();
-        ExperimentCancellationToken cancellationToken = new ExperimentCancellationToken("scheduled-experiment-result-id");
+        ScheduledExperimentCancellationToken cancellationToken = new ScheduledExperimentCancellationToken("scheduled-experiment-result-id");
         runningFutures.compute(request.getScheduledExperimentResultId(), (key, existingList) -> {
             List<Future<?>> list = existingList != null ? existingList : new CopyOnWriteArrayList<>();
             return list;
@@ -195,7 +195,9 @@ public class ExperimentRunningManagerTests extends OpenSearchTestCase {
 
         doAnswer(invocation -> { return null; }).when(querySetDao).getQuerySet(any(String.class), any(ActionListener.class));
 
-        ExperimentCancellationToken cancellationToken1 = new ExperimentCancellationToken("scheduled-experiment-result-id");
+        ScheduledExperimentCancellationToken cancellationToken1 = new ScheduledExperimentCancellationToken(
+            "scheduled-experiment-result-id"
+        );
         experimentRunningManager.startExperimentRun("experimentId", request, cancellationToken1, actuallyFinished1);
 
         assertEquals(1, actuallyFinished1.getCount());
@@ -204,7 +206,9 @@ public class ExperimentRunningManagerTests extends OpenSearchTestCase {
 
         // Try running a second experiment and make sure that it does not run successfully
         CountDownLatch actuallyFinished2 = new CountDownLatch(1);
-        ExperimentCancellationToken cancellationToken2 = new ExperimentCancellationToken("scheduled-experiment-result-id");
+        ScheduledExperimentCancellationToken cancellationToken2 = new ScheduledExperimentCancellationToken(
+            "scheduled-experiment-result-id"
+        );
 
         experimentRunningManager.startExperimentRun("experimentId", request, cancellationToken2, actuallyFinished2);
 

--- a/src/test/java/org/opensearch/searchrelevance/executors/ExperimentTaskManagerTests.java
+++ b/src/test/java/org/opensearch/searchrelevance/executors/ExperimentTaskManagerTests.java
@@ -31,7 +31,7 @@ import org.opensearch.searchrelevance.dao.ExperimentVariantDao;
 import org.opensearch.searchrelevance.model.AsyncStatus;
 import org.opensearch.searchrelevance.model.ExperimentType;
 import org.opensearch.searchrelevance.model.ExperimentVariant;
-import org.opensearch.searchrelevance.scheduler.ExperimentCancellationToken;
+import org.opensearch.searchrelevance.scheduler.ScheduledExperimentCancellationToken;
 import org.opensearch.test.OpenSearchTestCase;
 import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.transport.client.Client;
@@ -304,7 +304,7 @@ public class ExperimentTaskManagerTests extends OpenSearchTestCase {
         Map<String, Object> initialConfigMap = new HashMap<>();
         initialConfigMap.put("existing-key", "existing-value");
         String scheduledExperimentResultId = "scheduled-experiment-result";
-        ExperimentCancellationToken cancellationToken = new ExperimentCancellationToken(scheduledExperimentResultId);
+        ScheduledExperimentCancellationToken cancellationToken = new ScheduledExperimentCancellationToken(scheduledExperimentResultId);
         cancellationToken.cancel();
 
         CompletableFuture<Map<String, Object>> future = taskManager.scheduleTasksAsync(

--- a/src/test/java/org/opensearch/searchrelevance/experiment/HybridOptimizerExperimentProcessorTests.java
+++ b/src/test/java/org/opensearch/searchrelevance/experiment/HybridOptimizerExperimentProcessorTests.java
@@ -30,7 +30,7 @@ import org.opensearch.core.action.ActionListener;
 import org.opensearch.searchrelevance.dao.JudgmentDao;
 import org.opensearch.searchrelevance.executors.ExperimentTaskManager;
 import org.opensearch.searchrelevance.model.SearchConfigurationDetails;
-import org.opensearch.searchrelevance.scheduler.ExperimentCancellationToken;
+import org.opensearch.searchrelevance.scheduler.ScheduledExperimentCancellationToken;
 import org.opensearch.test.OpenSearchTestCase;
 
 import lombok.SneakyThrows;
@@ -95,7 +95,7 @@ public class HybridOptimizerExperimentProcessorTests extends OpenSearchTestCase 
             judgmentList,
             10,
             "run1",
-            new ExperimentCancellationToken(experimentId),
+            new ScheduledExperimentCancellationToken(experimentId),
             new ConcurrentHashMap<>(),
             listener
         );
@@ -145,7 +145,7 @@ public class HybridOptimizerExperimentProcessorTests extends OpenSearchTestCase 
             judgmentList,
             10,
             "run2",
-            new ExperimentCancellationToken(experimentId),
+            new ScheduledExperimentCancellationToken(experimentId),
             new ConcurrentHashMap<>(),
             listener
         );
@@ -177,7 +177,7 @@ public class HybridOptimizerExperimentProcessorTests extends OpenSearchTestCase 
             }
         };
 
-        ExperimentCancellationToken cancellationToken = new ExperimentCancellationToken(experimentId);
+        ScheduledExperimentCancellationToken cancellationToken = new ScheduledExperimentCancellationToken(experimentId);
         cancellationToken.cancel();
         processor.processSearchConfigurationsAsync(
             experimentId,

--- a/src/test/java/org/opensearch/searchrelevance/scheduler/ExperimentCancellationTokenTests.java
+++ b/src/test/java/org/opensearch/searchrelevance/scheduler/ExperimentCancellationTokenTests.java
@@ -17,7 +17,7 @@ import org.opensearch.test.OpenSearchTestCase;
 public class ExperimentCancellationTokenTests extends OpenSearchTestCase {
     public void testCancellationToken() {
         String scheduledExperimentResultId = "test-experiment-result-id";
-        ExperimentCancellationToken token = new ExperimentCancellationToken(scheduledExperimentResultId);
+        ScheduledExperimentCancellationToken token = new ScheduledExperimentCancellationToken(scheduledExperimentResultId);
 
         // Verify initial state
         assertEquals(scheduledExperimentResultId, token.getScheduledExperimentResultId());

--- a/src/test/java/org/opensearch/searchrelevance/scheduler/ScheduledExperimentRunnerManagerTests.java
+++ b/src/test/java/org/opensearch/searchrelevance/scheduler/ScheduledExperimentRunnerManagerTests.java
@@ -51,7 +51,7 @@ public class ScheduledExperimentRunnerManagerTests extends OpenSearchTestCase {
 
     public void testRunScheduledExperimentSuccess() {
         CountDownLatch actuallyFinished = new CountDownLatch(1);
-        ExperimentCancellationToken cancellationToken = new ExperimentCancellationToken(scheduledExperimentId);
+        ScheduledExperimentCancellationToken cancellationToken = new ScheduledExperimentCancellationToken(scheduledExperimentId);
         doAnswer(invocation -> {
             ActionListener<SearchResponse> listener = invocation.getArgument(1);
             actuallyFinished.countDown();
@@ -65,7 +65,7 @@ public class ScheduledExperimentRunnerManagerTests extends OpenSearchTestCase {
 
     public void testRunScheduledExperimentError() {
         CountDownLatch actuallyFinished = new CountDownLatch(1);
-        ExperimentCancellationToken cancellationToken = new ExperimentCancellationToken(scheduledExperimentId);
+        ScheduledExperimentCancellationToken cancellationToken = new ScheduledExperimentCancellationToken(scheduledExperimentId);
         doAnswer(invocation -> {
             ActionListener<SearchResponse> listener = invocation.getArgument(1);
             listener.onFailure(new Exception("Experiment not found!"));
@@ -79,7 +79,7 @@ public class ScheduledExperimentRunnerManagerTests extends OpenSearchTestCase {
 
     public void testRunScheduledExperimentCancelledBeforeExperimentSearch() {
         CountDownLatch actuallyFinished = new CountDownLatch(1);
-        ExperimentCancellationToken cancellationToken = new ExperimentCancellationToken(scheduledExperimentId);
+        ScheduledExperimentCancellationToken cancellationToken = new ScheduledExperimentCancellationToken(scheduledExperimentId);
         cancellationToken.cancel();
         SearchResponse searchResponse = mock(SearchResponse.class);
         doAnswer(invocation -> {

--- a/src/test/java/org/opensearch/searchrelevance/scheduler/SearchRelevanceJobRunnerTests.java
+++ b/src/test/java/org/opensearch/searchrelevance/scheduler/SearchRelevanceJobRunnerTests.java
@@ -128,7 +128,7 @@ public class SearchRelevanceJobRunnerTests extends OpenSearchTestCase {
             .runScheduledExperiment(
                 any(SearchRelevanceJobParameters.class),
                 any(String.class),
-                any(ExperimentCancellationToken.class),
+                any(ScheduledExperimentCancellationToken.class),
                 any(CountDownLatch.class)
             );
         doAnswer(invocation -> {
@@ -144,12 +144,12 @@ public class SearchRelevanceJobRunnerTests extends OpenSearchTestCase {
         verify(manager, times(1)).runScheduledExperiment(
             any(SearchRelevanceJobParameters.class),
             any(String.class),
-            any(ExperimentCancellationToken.class),
+            any(ScheduledExperimentCancellationToken.class),
             any(CountDownLatch.class)
         );
 
         // Verify that the cleanup stage was actually reached.
-        verify(manager, times(1)).cleanupResources(any(String.class), any(String.class), any(ExperimentCancellationToken.class));
+        verify(manager, times(1)).cleanupResources(any(String.class), any(String.class), any(ScheduledExperimentCancellationToken.class));
         verify(lockService, times(1)).release(any(), any());
     }
 
@@ -158,7 +158,7 @@ public class SearchRelevanceJobRunnerTests extends OpenSearchTestCase {
             .runScheduledExperiment(
                 any(SearchRelevanceJobParameters.class),
                 any(String.class),
-                any(ExperimentCancellationToken.class),
+                any(ScheduledExperimentCancellationToken.class),
                 any(CountDownLatch.class)
             );
         doAnswer(invocation -> {
@@ -174,12 +174,12 @@ public class SearchRelevanceJobRunnerTests extends OpenSearchTestCase {
         verify(manager, times(1)).runScheduledExperiment(
             any(SearchRelevanceJobParameters.class),
             any(String.class),
-            any(ExperimentCancellationToken.class),
+            any(ScheduledExperimentCancellationToken.class),
             any(CountDownLatch.class)
         );
 
         // Verify that the cleanup stage was actually reached.
-        verify(manager, times(1)).cleanupResources(any(String.class), any(String.class), any(ExperimentCancellationToken.class));
+        verify(manager, times(1)).cleanupResources(any(String.class), any(String.class), any(ScheduledExperimentCancellationToken.class));
         verify(lockService, times(1)).release(any(), any());
     }
 
@@ -192,7 +192,7 @@ public class SearchRelevanceJobRunnerTests extends OpenSearchTestCase {
             .runScheduledExperiment(
                 any(SearchRelevanceJobParameters.class),
                 any(String.class),
-                any(ExperimentCancellationToken.class),
+                any(ScheduledExperimentCancellationToken.class),
                 any(CountDownLatch.class)
             );
         doAnswer(invocation -> {
@@ -204,6 +204,6 @@ public class SearchRelevanceJobRunnerTests extends OpenSearchTestCase {
         searchRelevanceJobRunner.runJob(jobParameters, jobExecutionContext);
 
         // Verify that the cleanup stage was actually reached.
-        verify(manager, times(1)).cleanupResources(any(String.class), any(String.class), any(ExperimentCancellationToken.class));
+        verify(manager, times(1)).cleanupResources(any(String.class), any(String.class), any(ScheduledExperimentCancellationToken.class));
     }
 }


### PR DESCRIPTION
### Description
Cancels long-running experiment and judgment processes using a timeout specified by the user. A compromise for the cancellation api in rfc #332 could be to let users specify a timeout ahead of time for cancelling the experiments. Could be a solution for issue #265 

### Issues Resolved


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
