### PR TITLE
Fixed thread pool starvation in LLM judgment processing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Enhancements
 
 ### Bug Fixes
+* Fixed thread pool starvation in LLM judgment processing ([#387](https://github.com/opensearch-project/search-relevance/pull/387))
 
 ### Infrastructure
 

--- a/src/main/java/org/opensearch/searchrelevance/executors/LlmJudgmentTaskManager.java
+++ b/src/main/java/org/opensearch/searchrelevance/executors/LlmJudgmentTaskManager.java
@@ -7,10 +7,11 @@
  */
 package org.opensearch.searchrelevance.executors;
 
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.Semaphore;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -24,7 +25,16 @@ import org.opensearch.threadpool.ThreadPool;
 import lombok.extern.log4j.Log4j2;
 
 /**
- * Manages concurrent execution of LLM judgment tasks at the query text level
+ * Manages concurrent execution of LLM judgment tasks at the query text level.
+ *
+ * Uses batched submission to prevent thread pool starvation: only one batch of queries
+ * is submitted to the thread pool at a time. Each batch contains at most {@code batchSize}
+ * queries. The next batch is submitted only after the current batch completes.
+ *
+ * This ensures that at most {@code batchSize} threads from the GENERIC pool are occupied
+ * by query processing tasks, leaving the remaining pool capacity available for nested
+ * operations (search, cache lookup, LLM calls) that those tasks depend on.
+ *
  */
 @Log4j2
 public class LlmJudgmentTaskManager {
@@ -34,21 +44,33 @@ public class LlmJudgmentTaskManager {
     private static final int ALLOCATED_PROCESSORS = Runtime.getRuntime().availableProcessors();
 
     private final ThreadPool threadPool;
-    private final Semaphore rateLimiter;
-    private final int maxConcurrentTasks;
+    private final int batchSize;
 
     @Inject
     public LlmJudgmentTaskManager(ThreadPool threadPool) {
         this.threadPool = threadPool;
-        this.maxConcurrentTasks = Math.max(2, Math.min(DEFAULT_MIN_CONCURRENT_THREADS, ALLOCATED_PROCESSORS / PROCESSOR_NUMBER_DIVISOR));
-        this.rateLimiter = new Semaphore(maxConcurrentTasks);
-        log.info(
-            "LlmJudgmentTaskManager initialized with {} max concurrent tasks (processors: {})",
-            maxConcurrentTasks,
-            ALLOCATED_PROCESSORS
-        );
+        this.batchSize = Math.max(2, Math.min(DEFAULT_MIN_CONCURRENT_THREADS, ALLOCATED_PROCESSORS / PROCESSOR_NUMBER_DIVISOR));
+        log.info("LlmJudgmentTaskManager initialized with {} max concurrent tasks (processors: {})", batchSize, ALLOCATED_PROCESSORS);
     }
 
+    /**
+     * Schedules query processing tasks in batches to prevent thread pool starvation.
+     *
+     * Instead of submitting all queries at once (which would exhaust the GENERIC thread pool
+     * when queries exceed pool capacity), this method processes queries in sequential batches.
+     * Each batch submits at most {@code batchSize} tasks to the thread pool concurrently.
+     * The next batch begins only after the current batch completes.
+     *
+     * This approach ensures that:
+     * 1. At most {@code batchSize} GENERIC threads are occupied by query tasks
+     * 2. Remaining GENERIC threads are available for nested operations (search, cache, LLM)
+     * 3. No thread starvation or deadlock regardless of total query count
+     *
+     * @param queryTextsWithCustomInput List of query texts to process
+     * @param queryProcessor Function that processes a single query and returns results
+     * @param ignoreFailure If true, individual query failures don't fail the entire operation
+     * @param listener Callback with the aggregated results from all batches
+     */
     public void scheduleTasksAsync(
         List<String> queryTextsWithCustomInput,
         Function<String, Map<String, Object>> queryProcessor,
@@ -56,18 +78,57 @@ public class LlmJudgmentTaskManager {
         ActionListener<List<Map<String, Object>>> listener
     ) {
         int totalQueries = queryTextsWithCustomInput.size();
-        log.info("Scheduling {} query text tasks for concurrent processing", totalQueries);
+        log.info("Scheduling {} query text tasks for batched processing (batch size: {})", totalQueries, batchSize);
+
+        // Partition queries into batches
+        List<List<String>> batches = partition(queryTextsWithCustomInput, batchSize);
+        List<Map<String, Object>> allResults = Collections.synchronizedList(new ArrayList<>());
+
+        log.info("Created {} batches for {} total queries", batches.size(), totalQueries);
+
+        // Process batches sequentially — each batch runs its queries concurrently
+        processBatch(batches, 0, queryProcessor, ignoreFailure, allResults, totalQueries, listener);
+    }
+
+    /**
+     * Recursively processes batches: runs the current batch concurrently, then proceeds to the next.
+     */
+    private void processBatch(
+        List<List<String>> batches,
+        int batchIndex,
+        Function<String, Map<String, Object>> queryProcessor,
+        boolean ignoreFailure,
+        List<Map<String, Object>> allResults,
+        int totalQueries,
+        ActionListener<List<Map<String, Object>>> listener
+    ) {
+        // Base case: all batches processed
+        if (batchIndex >= batches.size()) {
+            int processedQueries = allResults.size();
+            int successQueries = countSuccessful(allResults);
+            int failureQueries = totalQueries - processedQueries;
+
+            log.info(
+                "Task manager completed - Total: {}, Processed: {}, Success: {}, Failure: {}",
+                totalQueries,
+                processedQueries,
+                successQueries,
+                failureQueries
+            );
+            log.info("Task manager calling listener.onResponse with {} results", allResults.size());
+            listener.onResponse(allResults);
+            return;
+        }
+
+        List<String> batch = batches.get(batchIndex);
+        log.debug("Processing batch {}/{} with {} queries", batchIndex + 1, batches.size(), batch.size());
 
         try {
-            List<CompletableFuture<Map<String, Object>>> futures = queryTextsWithCustomInput.stream()
+            // Submit all queries in this batch concurrently
+            List<CompletableFuture<Map<String, Object>>> futures = batch.stream()
                 .map(queryTextWithCustomInput -> CompletableFuture.supplyAsync(() -> {
                     try {
-                        rateLimiter.acquire();
-                        try {
-                            return queryProcessor.apply(queryTextWithCustomInput);
-                        } finally {
-                            rateLimiter.release();
-                        }
+                        return queryProcessor.apply(queryTextWithCustomInput);
                     } catch (Exception e) {
                         log.warn("Query processing failed, returning empty result for: {}", queryTextWithCustomInput, e);
                         return JudgmentDataTransformer.createJudgmentResult(queryTextWithCustomInput, Map.of());
@@ -75,47 +136,61 @@ public class LlmJudgmentTaskManager {
                 }, threadPool.executor(THREAD_POOL_EXECUTOR_NAME)))
                 .collect(Collectors.toList());
 
+            // When all futures in this batch complete, collect results and proceed to next batch
             CompletableFuture.allOf(futures.toArray(new CompletableFuture[0])).whenComplete((v, ex) -> {
-                List<Map<String, Object>> results = futures.stream().map(future -> {
+                // Collect results from this batch
+                for (CompletableFuture<Map<String, Object>> future : futures) {
                     try {
-                        return future.join();
+                        Map<String, Object> result = future.join();
+                        if (result != null) {
+                            allResults.add(result);
+                        }
                     } catch (Exception e) {
                         log.warn("Individual query future failed, skipping", e);
-                        return null;
                     }
-                }).filter(result -> result != null).collect(Collectors.toList());
-
-                int processedQueries = results.size();
-                int successQueries = (int) results.stream().mapToLong(result -> {
-                    List<Map<String, String>> ratings = (List<Map<String, String>>) result.get("ratings");
-                    return ratings != null && !ratings.isEmpty() ? 1 : 0;
-                }).sum();
-                int failureQueries = totalQueries - processedQueries;
-
-                if (results.isEmpty() && ex != null) {
-                    log.error("Task manager failed - Total: {}, Processed: 0, Success: 0, Failure: {}", totalQueries, totalQueries, ex);
-                    listener.onFailure(
-                        new SearchRelevanceException("All query text judgments failed", ex, RestStatus.INTERNAL_SERVER_ERROR)
-                    );
-                } else {
-                    log.info(
-                        "Task manager completed - Total: {}, Processed: {}, Success: {}, Failure: {}",
-                        totalQueries,
-                        processedQueries,
-                        successQueries,
-                        failureQueries
-                    );
-                    log.info("Task manager calling listener.onResponse with {} results", results.size());
-                    listener.onResponse(results);
                 }
+
+                log.debug(
+                    "Batch {}/{} completed. Cumulative results: {}/{}",
+                    batchIndex + 1,
+                    batches.size(),
+                    allResults.size(),
+                    totalQueries
+                );
+
+                // Process next batch
+                processBatch(batches, batchIndex + 1, queryProcessor, ignoreFailure, allResults, totalQueries, listener);
             });
         } catch (Exception e) {
-            log.error("Failed to schedule tasks - Total: {}", totalQueries, e);
+            log.error("Failed to schedule batch {}/{}", batchIndex + 1, batches.size(), e);
             if (!ignoreFailure) {
                 listener.onFailure(new SearchRelevanceException("Failed to schedule judgment tasks", e, RestStatus.INTERNAL_SERVER_ERROR));
             } else {
-                listener.onResponse(List.of());
+                // Skip failed batch, continue with next
+                processBatch(batches, batchIndex + 1, queryProcessor, ignoreFailure, allResults, totalQueries, listener);
             }
         }
+    }
+
+    /**
+     * Partitions a list into sublists of at most the given size.
+     */
+    private static <T> List<List<T>> partition(List<T> list, int size) {
+        List<List<T>> partitions = new ArrayList<>();
+        for (int i = 0; i < list.size(); i += size) {
+            partitions.add(list.subList(i, Math.min(i + size, list.size())));
+        }
+        return partitions;
+    }
+
+    /**
+     * Counts queries with non-empty ratings (successful LLM judgments).
+     */
+    @SuppressWarnings("unchecked")
+    private static int countSuccessful(List<Map<String, Object>> results) {
+        return (int) results.stream().mapToLong(result -> {
+            List<Map<String, String>> ratings = (List<Map<String, String>>) result.get("ratings");
+            return ratings != null && !ratings.isEmpty() ? 1 : 0;
+        }).sum();
     }
 }

--- a/src/test/java/org/opensearch/searchrelevance/executors/LlmJudgmentTaskManagerThreadStarvationTests.java
+++ b/src/test/java/org/opensearch/searchrelevance/executors/LlmJudgmentTaskManagerThreadStarvationTests.java
@@ -1,0 +1,243 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+package org.opensearch.searchrelevance.executors;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.test.OpenSearchTestCase;
+import org.opensearch.threadpool.TestThreadPool;
+import org.opensearch.threadpool.ThreadPool;
+
+/**
+ * Tests that verify the batched submission fix in {@link LlmJudgmentTaskManager} prevents
+ * thread pool starvation when processing large numbers of queries.
+ *
+ * Original implementation submitted ALL queries as CompletableFuture.supplyAsync() to the
+ * GENERIC thread pool at once. Each query's processor blocks (via .join() or .actionGet()) waiting
+ * for sub-operations (search, cache lookup, LLM calls) whose callbacks also need GENERIC pool
+ * threads. When the number of queries exceeded available threads, all threads became blocked
+ * waiting for callbacks that could never execute — classic thread starvation / deadlock.
+ *
+ * Fix uses batched submission: only {@code batchSize} queries are submitted concurrently.
+ * The next batch starts only after the current one completes. This ensures that at most
+ * {@code batchSize} GENERIC threads are occupied by query tasks, leaving remaining pool
+ * capacity for the nested operations those tasks depend on.
+ *
+ * @see <a href="https://github.com/opensearch-project/search-relevance/issues/386">GitHub issue #386</a>
+ */
+public class LlmJudgmentTaskManagerThreadStarvationTests extends OpenSearchTestCase {
+
+    /**
+     * Calculates the number of queries needed to guarantee GENERIC pool saturation on any machine.
+     *
+     * The GENERIC pool max threads = max(128, 4 * availableProcessors) (from OpenSearch ThreadPool).
+     * To reliably trigger thread starvation with the old unbounded submission, we need more queries
+     * than the pool can hold. Using 2x the pool max ensures saturation regardless of machine size:
+     *
+     * - 2-core CI:     max(128, 8) = 128  → test uses 256 queries
+     * - 12-core laptop: max(128, 48) = 128 → test uses 256 queries
+     * - 32-core server: max(128, 128) = 128 → test uses 256 queries
+     * - 96-core server: max(128, 384) = 384 → test uses 768 queries
+     * - 128-core:       max(128, 512) = 512 → test uses 1024 queries
+     */
+    private static int calculateQueryCountForSaturation() {
+        int processors = Runtime.getRuntime().availableProcessors();
+        int genericPoolMax = Math.max(128, 4 * processors);
+        return genericPoolMax * 2;
+    }
+
+    /**
+     * Verifies that batched submission prevents thread pool starvation when processing
+     * a large number of queries with nested blocking operations on the same GENERIC pool.
+     *
+     * Submits enough queries to exceed the GENERIC pool max (calculated dynamically based on
+     * machine processors) where each query performs 3 nested blocking operations that submit
+     * work to the GENERIC pool and block waiting for results. This mirrors the production
+     * pattern in processQueryTextAsync():
+     * - processSearchConfigurationsAsync() → CompletableFuture.allOf(...).join()
+     * - deduplicateFromCache() → CompletableFuture.allOf(...).join()
+     * - processWithLLM() → PlainActionFuture.actionGet()
+     *
+     * With batched submission, all queries should complete successfully because only
+     * batchSize threads are occupied at a time, leaving pool capacity for inner operations.
+     */
+    public void testThreadPoolStarvationWithNestedBlockingOnSamePool() throws Exception {
+        TestThreadPool threadPool = new TestThreadPool("starvation-test");
+
+        try {
+            LlmJudgmentTaskManager taskManager = new LlmJudgmentTaskManager(threadPool);
+
+            int numQueries = calculateQueryCountForSaturation();
+            List<String> queries = IntStream.range(0, numQueries).mapToObj(i -> "query_" + i).collect(Collectors.toList());
+
+            logger.info(
+                "Running starvation test with {} queries (processors: {}, estimated GENERIC pool max: {})",
+                numQueries,
+                Runtime.getRuntime().availableProcessors(),
+                Math.max(128, 4 * Runtime.getRuntime().availableProcessors())
+            );
+
+            CountDownLatch completionLatch = new CountDownLatch(1);
+            AtomicReference<List<Map<String, Object>>> resultRef = new AtomicReference<>();
+            AtomicReference<Exception> errorRef = new AtomicReference<>();
+            AtomicInteger starvationTimeouts = new AtomicInteger(0);
+
+            taskManager.scheduleTasksAsync(queries, queryText -> {
+                // Simulate 3 nested blocking operations on the GENERIC pool
+                for (int step = 0; step < 3; step++) {
+                    CompletableFuture<String> innerWork = CompletableFuture.supplyAsync(() -> {
+                        try {
+                            Thread.sleep(5);
+                        } catch (InterruptedException e) {
+                            Thread.currentThread().interrupt();
+                        }
+                        return "inner_result";
+                    }, threadPool.executor(ThreadPool.Names.GENERIC));
+
+                    try {
+                        innerWork.get(3, TimeUnit.SECONDS);
+                    } catch (TimeoutException e) {
+                        starvationTimeouts.incrementAndGet();
+                        return Map.of("query", (Object) queryText, "ratings", List.of());
+                    } catch (Exception e) {
+                        return Map.of("query", (Object) queryText, "ratings", List.of());
+                    }
+                }
+
+                return Map.of("query", (Object) queryText, "ratings", List.of(Map.of("docId", "doc1", "rating", "0.8")));
+            }, true, ActionListener.wrap(results -> {
+                resultRef.set(results);
+                completionLatch.countDown();
+            }, error -> {
+                errorRef.set(error);
+                completionLatch.countDown();
+            }));
+
+            boolean completed = completionLatch.await(180, TimeUnit.SECONDS);
+
+            if (!completed) {
+                fail(
+                    "DEADLOCK DETECTED: LlmJudgmentTaskManager.scheduleTasksAsync() did not complete "
+                        + "within 180 seconds with "
+                        + numQueries
+                        + " queries."
+                );
+            }
+
+            if (errorRef.get() != null) {
+                fail("Unexpected error: " + errorRef.get().getMessage());
+            }
+
+            assertNotNull("Results should not be null", resultRef.get());
+            List<Map<String, Object>> results = resultRef.get();
+
+            long successfulQueries = results.stream().filter(r -> {
+                List<?> ratings = (List<?>) r.get("ratings");
+                return ratings != null && !ratings.isEmpty();
+            }).count();
+
+            long failedQueries = results.size() - successfulQueries;
+
+            logger.info(
+                "Thread starvation test results: total={}, successful={}, failed={}, starvationTimeouts={}",
+                numQueries,
+                successfulQueries,
+                failedQueries,
+                starvationTimeouts.get()
+            );
+
+            // With batched submission, all queries should succeed with zero starvation timeouts
+            assertEquals(
+                "All "
+                    + numQueries
+                    + " queries should succeed with batched submission. "
+                    + "Starvation timeouts: "
+                    + starvationTimeouts.get()
+                    + ", failed: "
+                    + failedQueries,
+                0,
+                starvationTimeouts.get()
+            );
+            assertEquals("All queries should produce results", numQueries, results.size());
+            assertEquals("All queries should have non-empty ratings", (long) numQueries, successfulQueries);
+
+        } finally {
+            ThreadPool.terminate(threadPool, 60, TimeUnit.SECONDS);
+        }
+    }
+
+    /**
+     * Verifies that a small number of queries (well within thread pool capacity)
+     * completes successfully. This serves as a basic sanity check for the batched
+     * submission logic with minimal load.
+     */
+    public void testSmallQuerySetSucceedsWithoutStarvation() throws Exception {
+        TestThreadPool threadPool = new TestThreadPool("small-set-test");
+
+        try {
+            LlmJudgmentTaskManager taskManager = new LlmJudgmentTaskManager(threadPool);
+
+            int numQueries = 3;
+            List<String> queries = IntStream.range(0, numQueries).mapToObj(i -> "query_" + i).collect(Collectors.toList());
+
+            CountDownLatch completionLatch = new CountDownLatch(1);
+            AtomicReference<List<Map<String, Object>>> resultRef = new AtomicReference<>();
+            AtomicReference<Exception> errorRef = new AtomicReference<>();
+
+            taskManager.scheduleTasksAsync(queries, queryText -> {
+                CompletableFuture<String> innerWork = CompletableFuture.supplyAsync(() -> {
+                    try {
+                        Thread.sleep(10);
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                    }
+                    return "inner_result";
+                }, threadPool.executor(ThreadPool.Names.GENERIC));
+
+                try {
+                    innerWork.get(5, TimeUnit.SECONDS);
+                } catch (Exception e) {
+                    return Map.of("query", (Object) queryText, "ratings", List.of());
+                }
+
+                return Map.of("query", (Object) queryText, "ratings", List.of(Map.of("docId", "doc1", "rating", "0.8")));
+            }, false, ActionListener.wrap(results -> {
+                resultRef.set(results);
+                completionLatch.countDown();
+            }, error -> {
+                errorRef.set(error);
+                completionLatch.countDown();
+            }));
+
+            boolean completed = completionLatch.await(30, TimeUnit.SECONDS);
+            assertTrue("Small query set should complete without deadlock", completed);
+            assertNull("Should not have errors with small query set", errorRef.get());
+            assertNotNull("Should have results", resultRef.get());
+
+            long successfulQueries = resultRef.get().stream().filter(r -> {
+                List<?> ratings = (List<?>) r.get("ratings");
+                return ratings != null && !ratings.isEmpty();
+            }).count();
+
+            assertEquals("All queries in small set should succeed", numQueries, successfulQueries);
+
+        } finally {
+            ThreadPool.terminate(threadPool, 30, TimeUnit.SECONDS);
+        }
+    }
+}


### PR DESCRIPTION
### Description
Currently `LlmJudgmentTaskManager.scheduleTasksAsync()` submits __all N queries simultaneously__ as `CompletableFuture.supplyAsync()` to the OpenSearch GENERIC thread pool. Each submitted task immediately acquires a thread from the pool and then blocks inside that thread — first on `Semaphore.acquire()` (waiting for a concurrency permit), then on nested blocking operations (`.join()` and `.actionGet()`) that themselves require GENERIC pool threads to complete.

The execution chain that causes starvation:

1. __All N tasks submitted at once__ — `queryTextsWithCustomInput.stream().map(q -> CompletableFuture.supplyAsync(..., GENERIC)).collect()` eagerly submits all queries to the GENERIC pool

2. __Each task blocks inside the pool thread__ — the Semaphore gates execution *inside* the lambda, so all N tasks hold pool threads while only `maxConcurrentTasks` do actual work; the rest block on `semaphore.acquire()`

3. __Working tasks need the same pool for sub-operations__ — `processQueryTextAsync()` performs three nested blocking calls:

   - `processSearchConfigurationsAsync()` → `CompletableFuture.allOf(...).join()` (blocks GENERIC thread waiting for search callbacks on GENERIC)
   - `deduplicateFromCache()` → `CompletableFuture.allOf(...).join()` (blocks GENERIC thread waiting for cache callbacks on GENERIC)
   - `processWithLLM()` → `PlainActionFuture.actionGet()` (blocks GENERIC thread waiting for ML predict callback on GENERIC)

4. __Thread starvation__ — when N exceeds the GENERIC pool max (`max(128, 4 * processors)`), all pool threads are occupied by outer tasks. The inner operations' callbacks cannot execute because no threads are available. Tasks waiting on the semaphore hold threads hostage without doing any work.

This manifests as ~40-60% of queries returning empty ratings when query sets exceed ~5,000 queries, with the failure rate scaling proportionally to how much the query count exceeds pool capacity.

--------

To fix this we replace unbounded submission with batched sequential processing:

- Partition queries into batches of `batchSize` (same formula as the old `maxConcurrentTasks`: `max(2, min(24, processors/2))`)
- Submit one batch at a time to the GENERIC pool via `CompletableFuture.supplyAsync()`
- Only start the next batch after the current batch completes
- Remove the `Semaphore` — batching makes it unnecessary since at most `batchSize` tasks are in the pool at once

This ensures that at most `batchSize` GENERIC threads are occupied by query processing tasks at any time, leaving the remaining pool capacity (128+ threads) available for the nested search/cache/LLM callbacks that those tasks depend on.


### Issues Resolved
https://github.com/opensearch-project/search-relevance/issues/386

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
