### PR TITLE
Remove .gitattributes which force bat with crlf eol

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,0 @@
-*.bat text eol=crlf


### PR DESCRIPTION
### Description
Remove .gitattributes which force bat with crlf eol

### Issues Resolved
Update `i/crlf  w/crlf  attr/text eol=crlf    	gradlew.bat` to be `i/crlf  w/crlf  attr/                 	gradlew.bat` without always forcing a crlf on all system.
https://github.com/opensearch-project/opensearch-build/actions/runs/21887604270/job/63297038337

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
