### PR TITLE
Update BWC version to 3.5.0 after OpenSearch 3.5.0 release

### DIFF
--- a/.github/workflows/backwards_compatibility_tests_workflow.yml
+++ b/.github/workflows/backwards_compatibility_tests_workflow.yml
@@ -21,8 +21,8 @@ jobs:
       matrix:
         java: [21, 25]
         os: [ubuntu-latest]
-        bwc_version: ["3.3.0"]
-        opensearch_version: ["3.4.0"]
+        bwc_version: ["3.3.0", "3.4.0", "3.5.0"]
+        opensearch_version: ["3.6.0-SNAPSHOT"]
 
     name: SearchRelevance Rolling-Upgrade BWC Tests
     runs-on: ${{ matrix.os }}
@@ -54,8 +54,8 @@ jobs:
       matrix:
         java: [21, 25]
         os: [ubuntu-latest]
-        bwc_version: ["3.3.0"]
-        opensearch_version: ["3.4.0"]
+        bwc_version: ["3.3.0", "3.4.0", "3.5.0"]
+        opensearch_version: ["3.6.0-SNAPSHOT"]
 
     name: SearchRelevance Restart-Upgrade BWC Tests
     runs-on: ${{ matrix.os }}

--- a/gradle.properties
+++ b/gradle.properties
@@ -14,8 +14,8 @@ org.gradle.parallel=true
 # https://github.com/opensearch-project/OpenSearch/blob/main/libs/core/src/main/java/org/opensearch/Version.java .
 # Wired compatibility of OpenSearch works like 3.x version is compatible with 2.(latest-major) version.
 # Therefore, to run rolling-upgrade BWC Test on local machine the BWC version here should be set 2.(latest-major).
-systemProp.bwc.version=3.3.0
-systemProp.bwc.bundle.version=3.3.0
+systemProp.bwc.version=3.5.0
+systemProp.bwc.bundle.version=3.5.0
 
 # For fixing Spotless check with Java 17
 org.gradle.jvmargs=--add-exports jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED \

--- a/qa/restart-upgrade/build.gradle
+++ b/qa/restart-upgrade/build.gradle
@@ -65,6 +65,8 @@ testClusters {
 
 def versionsBelow3_3 = ["3.0", "3.1", "3.2"]
 def versionsBelow3_4 = versionsBelow3_3 + "3.3"
+def versionsBelow3_5 = versionsBelow3_4 + "3.4"
+def versionsBelow3_6 = versionsBelow3_5 + "3.5"
 
 // Task to run BWC tests against the old cluster
 task testAgainstOldCluster(type: StandaloneRestIntegTestTask) {

--- a/qa/rolling-upgrade/build.gradle
+++ b/qa/rolling-upgrade/build.gradle
@@ -65,6 +65,8 @@ testClusters {
 
 def versionsBelow3_3 = ["3.0", "3.1", "3.2"]
 def versionsBelow3_4 = versionsBelow3_3 + "3.3"
+def versionsBelow3_5 = versionsBelow3_4 + "3.4"
+def versionsBelow3_6 = versionsBelow3_5 + "3.5"
 
 // Task to run BWC tests against the old cluster
 task testAgainstOldCluster(type: StandaloneRestIntegTestTask) {

--- a/qa/rolling-upgrade/src/test/java/org/opensearch/searchrelevance/bwc/rolling/LlmJudgmentBWCIT.java
+++ b/qa/rolling-upgrade/src/test/java/org/opensearch/searchrelevance/bwc/rolling/LlmJudgmentBWCIT.java
@@ -110,11 +110,18 @@ public class LlmJudgmentBWCIT extends AbstractSearchRelevanceRollingUpgradeTestC
         assertEquals("Judgment name should match", judgmentName, judgment.get("name"));
         assertEquals("Judgment type should be LLM_JUDGMENT", "LLM_JUDGMENT", judgment.get("type"));
 
-        // Validate OLD format: should NOT have new fields like promptTemplate and llmJudgmentRatingType
+        // Validate OLD format fields based on BWC version
+        // promptTemplate was introduced in 3.5.0 (PR #264), so versions before 3.5.0 should NOT have it
         Map<String, Object> metadata = (Map<String, Object>) judgment.get("metadata");
         if (metadata != null) {
-            assertNull("OLD format should not have promptTemplate", metadata.get("promptTemplate"));
-            assertNull("OLD format should not have llmJudgmentRatingType", metadata.get("llmJudgmentRatingType"));
+            String bwcVersion = getBWCVersion();
+            if (bwcVersion != null && (bwcVersion.startsWith("3.3") || bwcVersion.startsWith("3.4"))) {
+                assertNull("OLD format (pre-3.5.0) should not have promptTemplate", metadata.get("promptTemplate"));
+                assertNull("OLD format (pre-3.5.0) should not have llmJudgmentRatingType", metadata.get("llmJudgmentRatingType"));
+            } else {
+                // For 3.5.0+, promptTemplate is supported and a default value is stored
+                assertNotNull("3.5.0+ format should have default promptTemplate", metadata.get("promptTemplate"));
+            }
         }
     }
 


### PR DESCRIPTION
### Description
Update backward compatibility (BWC) test versions after the OpenSearch 3.5.0 release. 
BWC tests now verify upgrade paths from **3.3.0, 3.4.0, and 3.5.0 → 3.6.0-SNAPSHOT**, 
ensuring backward compatibility with all prior released versions.

### Issues Resolved

N/A - Infrastructure version bump

### Check List
- [x] New functionality includes testing
- [x] New functionality has been documented
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and Signing Commits, please see [CONTRIBUTING.md](https://github.com/opensearch-project/search-relevance/blob/main/CONTRIBUTING.md).