### PR TITLE
Add description() getter to SearchConfiguration

### DIFF
--- a/src/main/java/org/opensearch/searchrelevance/model/SearchConfiguration.java
+++ b/src/main/java/org/opensearch/searchrelevance/model/SearchConfiguration.java
@@ -76,4 +76,8 @@ public class SearchConfiguration implements ToXContentObject {
         return searchPipeline;
     }
 
+    public String description() {
+        return description;
+    }
+
 }


### PR DESCRIPTION
Addresses #281

## Problem
The `SearchConfiguration` model has a `description` field that is included in `toXContent()` serialization, but there is no public getter method to access it programmatically.

This prevents external systems from reading the description field to understand the context and goals of a search configuration.

## Solution
Add the missing `description()` getter method to `SearchConfiguration`.

## Changes
```diff
+ public String description() {
+     return description;
+ }
```

## Impact
- External systems can now access search configuration descriptions
- Consistent with other getter methods (name(), query(), searchPipeline(), etc.)
- No breaking changes - purely additive
- Description field already exists and is serialized, just exposing it via getter

## Testing
- Existing tests pass (description field already used in toXContent)
- Getter follows same pattern as other field accessors