### PR TITLE
Added compile time dependency to neural-search

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -251,6 +251,7 @@ dependencies {
     zipArchive group: 'org.opensearch.plugin', name:'opensearch-knn', version: "${opensearch_build}"
     zipArchive group: 'org.opensearch.plugin', name:'neural-search', version: "${opensearch_build}"
     zipArchive group: 'org.opensearch.plugin', name:'opensearch-ubi', version: "${opensearch_build}"
+    implementation "org.opensearch:opensearch-neural-search:${opensearch_build}"
     opensearchPlugin "org.opensearch.plugin:opensearch-security:${opensearch_build}@zip"
     opensearchPlugin "org.opensearch.plugin:opensearch-job-scheduler:${opensearch_build}@zip"
 }


### PR DESCRIPTION
### Description
Added compile-time dependency to neural-search, this allows direct access to classes related to hybrid and neural queries. This is technical change needed for future enhancements in search optimizer. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
