### PR TITLE
Fix flaky DCG and MRR assertions in integration tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 * Fixed thread pool starvation in LLM judgment processing ([#387](https://github.com/opensearch-project/search-relevance/pull/387))
 
 ### Infrastructure
+* Fix flaky DCG and MRR assertions in integration tests ([#427](https://github.com/opensearch-project/search-relevance/pull/427))
+
+### Infrastructure
 
 ### Documentation
 

--- a/src/test/java/org/opensearch/searchrelevance/experiment/BaseExperimentIT.java
+++ b/src/test/java/org/opensearch/searchrelevance/experiment/BaseExperimentIT.java
@@ -11,6 +11,8 @@ import static org.opensearch.searchrelevance.common.PluginConstants.EXPERIMENT_I
 import static org.opensearch.searchrelevance.common.PluginConstants.JUDGMENTS_URL;
 import static org.opensearch.searchrelevance.common.PluginConstants.QUERYSETS_URL;
 import static org.opensearch.searchrelevance.common.PluginConstants.SEARCH_CONFIGURATIONS_URL;
+import static org.opensearch.searchrelevance.metrics.calculator.Evaluation.METRICS_DISCOUNTED_CUMULATIVE_GAIN_AT;
+import static org.opensearch.searchrelevance.metrics.calculator.Evaluation.METRICS_MEAN_RECIPROCAL_RANK;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
@@ -288,5 +290,17 @@ public abstract class BaseExperimentIT extends BaseSearchRelevanceIT {
 
         assertEquals(expectedType, source.get("type"));
         assertEquals(querySetId, source.get("querySetId"));
+    }
+
+    /**
+     * Returns the assertion tolerance for a given metric. Position-sensitive metrics
+     * (DCG, MRR) use a wider tolerance because BM25 per-shard IDF variation in
+     * multi-node clusters can change document ranking order between runs.
+     */
+    protected double getMetricTolerance(String metricName) {
+        if (metricName.startsWith(METRICS_DISCOUNTED_CUMULATIVE_GAIN_AT) || metricName.equals(METRICS_MEAN_RECIPROCAL_RANK)) {
+            return 0.2;
+        }
+        return 0.02;
     }
 }

--- a/src/test/java/org/opensearch/searchrelevance/experiment/PointwiseExperimentIT.java
+++ b/src/test/java/org/opensearch/searchrelevance/experiment/PointwiseExperimentIT.java
@@ -185,7 +185,7 @@ public class PointwiseExperimentIT extends BaseExperimentIT {
                 for (Map<String, Object> actualMetric : actualMetrics) {
                     String metricName = actualMetric.get("metric").toString();
                     Double actualValue = Double.parseDouble(actualMetric.get("value").toString());
-                    assertEquals(expectedMetrics.get(metricName), actualValue, 0.02);
+                    assertEquals(expectedMetrics.get(metricName), actualValue, getMetricTolerance(metricName));
                 }
             } else {
                 assertTrue(EXPECTED_QUERY_TERMS.contains(actualQueryTerm));

--- a/src/test/java/org/opensearch/searchrelevance/experiment/SearchEvaluationExperimentIT.java
+++ b/src/test/java/org/opensearch/searchrelevance/experiment/SearchEvaluationExperimentIT.java
@@ -232,7 +232,7 @@ public class SearchEvaluationExperimentIT extends BaseExperimentIT {
                             "Metric " + metricName + " should match expected value",
                             expectedMetrics.get(metricName),
                             actualValue,
-                            0.02
+                            getMetricTolerance(metricName)
                         );
                     }
                 }


### PR DESCRIPTION
### Description
Position-sensitive metrics (DCG, MRR) depend on exact document ranking order, which varies in multi-node clusters due to per-shard BM25 IDF differences. Use a wider assertion tolerance for these metrics while keeping the strict tolerance for normalized metrics (NDCG, Precision, MAP, Recall, Coverage).

Before the fix this test is flaky:

- with 3 nodes cluster: 10/10 passed (0% failure rate)
- with 4 nodes cluster: Failed on run 2 out of 10 (~10-20% failure rate)

### Issues Resolved
N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
