### PR TITLE
Fix race condition in index mapping migration that crashes nodes during rolling upgrades    

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Enhancements
 
 ### Bug Fixes
+- Fix race condition in index mapping migration that crashes nodes during rolling upgrades ([#443](https://github.com/opensearch-project/search-relevance/pull/443))
 
 ### Infrastructure
 

--- a/qa/restart-upgrade/src/test/java/org/opensearch/searchrelevance/bwc/restart/SearchConfigMappingRestartIT.java
+++ b/qa/restart-upgrade/src/test/java/org/opensearch/searchrelevance/bwc/restart/SearchConfigMappingRestartIT.java
@@ -1,0 +1,90 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+package org.opensearch.searchrelevance.bwc.restart;
+
+import java.util.Map;
+
+import org.opensearch.client.Request;
+import org.opensearch.client.Response;
+import org.opensearch.searchrelevance.bwc.IndexMappingTestHelper;
+
+/**
+ * BWC Integration Test for search_configuration mapping update during full cluster restart.
+ * Exercises the actual plugin auto-migration path via the REST API.
+ */
+public class SearchConfigMappingRestartIT extends AbstractSearchRelevanceRestartUpgradeTestCase {
+
+    private static final String SEARCH_CONFIG_INDEX = "search-relevance-search-config";
+    private static final String SEARCH_CONFIG_ENDPOINT = "/_plugins/_search_relevance/search_configurations";
+    private static final String OLD_MAPPING_RESOURCE = "mappings/search_configuration_v0.json";
+    private static final String TEST_DOC_RESOURCE = "mappings/search_configuration_test_document.json";
+    private static final String TEST_DOC_ID = "test-search-config-bwc";
+
+    public void testSearchConfigMappingUpdate_RestartUpgrade() throws Exception {
+        switch (getClusterType()) {
+            case OLD:
+                testOldCluster();
+                break;
+            case UPGRADED:
+                try {
+                    testUpgradedCluster();
+                } finally {
+                    wipeOfTestResources(SEARCH_CONFIG_INDEX);
+                }
+                break;
+            default:
+                throw new IllegalStateException("Unknown cluster type: " + getClusterType());
+        }
+    }
+
+    private void testOldCluster() throws Exception {
+        if (!IndexMappingTestHelper.checkIndexExists(client(), SEARCH_CONFIG_INDEX, logger)) {
+            String oldMapping = IndexMappingTestHelper.readMappingResource(OLD_MAPPING_RESOURCE);
+            IndexMappingTestHelper.createIndexWithMapping(client(), SEARCH_CONFIG_INDEX, oldMapping, logger);
+        }
+
+        String testDoc = IndexMappingTestHelper.readMappingResource(TEST_DOC_RESOURCE);
+        IndexMappingTestHelper.insertTestDocument(client(), SEARCH_CONFIG_INDEX, TEST_DOC_ID, testDoc);
+
+        logger.info("OLD cluster: search_configuration index ready with test document");
+    }
+
+    private void testUpgradedCluster() throws Exception {
+        // Verify old data survives
+        Map<String, Object> oldDoc = IndexMappingTestHelper.getDocument(client(), SEARCH_CONFIG_INDEX, TEST_DOC_ID, logger);
+        assertNotNull("Old document should survive restart upgrade", oldDoc);
+
+        // Create via plugin API — triggers auto-migration
+        Request request = new Request("PUT", SEARCH_CONFIG_ENDPOINT);
+        request.setJsonEntity(
+            "{"
+                + "\"name\": \"bwc-restart-config\","
+                + "\"description\": \"Created after restart to test auto-migration\","
+                + "\"index\": \"test-index\","
+                + "\"query\": \"{\\\"match_all\\\": {}}\""
+                + "}"
+        );
+
+        Response response = client().performRequest(request);
+        assertEquals("Plugin API should succeed after auto-migration", 200, response.getStatusLine().getStatusCode());
+
+        // Verify mapping updated
+        Map<String, Object> mapping = IndexMappingTestHelper.getIndexMapping(client(), SEARCH_CONFIG_INDEX);
+        Map<String, Object> properties = IndexMappingTestHelper.getMappingProperties(mapping);
+        assertTrue("Mapping should have description field", properties.containsKey("description"));
+
+        Map<String, Object> meta = IndexMappingTestHelper.getMappingMeta(mapping);
+        assertEquals("Schema version should be 1", 1, ((Number) meta.get("schema_version")).intValue());
+
+        // Old data still accessible
+        oldDoc = IndexMappingTestHelper.getDocument(client(), SEARCH_CONFIG_INDEX, TEST_DOC_ID, logger);
+        assertNotNull("Old document should still be accessible", oldDoc);
+
+        logger.info("UPGRADED cluster: Plugin auto-migration succeeded after restart");
+    }
+}

--- a/qa/rolling-upgrade/src/test/java/org/opensearch/searchrelevance/bwc/rolling/SearchConfigMappingBWCIT.java
+++ b/qa/rolling-upgrade/src/test/java/org/opensearch/searchrelevance/bwc/rolling/SearchConfigMappingBWCIT.java
@@ -1,0 +1,154 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+package org.opensearch.searchrelevance.bwc.rolling;
+
+import java.util.Map;
+
+import org.opensearch.client.Request;
+import org.opensearch.client.Response;
+import org.opensearch.searchrelevance.bwc.IndexMappingTestHelper;
+
+/**
+ * BWC Integration Test for search_configuration index mapping updates during rolling upgrade.
+ *
+ * This test validates that the updateMappingSync fix (CountDownLatch) works correctly
+ * by exercising the actual plugin auto-migration path — creating a search configuration
+ * via the plugin REST API in the UPGRADED cluster, which triggers createIndexIfAbsentSync
+ * → updateMappingSync → document write. If the mapping update doesn't complete before
+ * the document write, the description field would be auto-mapped incorrectly.
+ *
+ * Test scenario:
+ * 1. OLD cluster: Verify search_configuration index exists (created by plugin on startup)
+ *    and insert a test document with old schema (no description field)
+ * 2. MIXED cluster: Validate old data is still accessible
+ * 3. UPGRADED cluster: Create a new search configuration via plugin API — this triggers
+ *    the auto-migration from schema_version 0 to 1, proving the CountDownLatch fix works
+ */
+public class SearchConfigMappingBWCIT extends AbstractSearchRelevanceRollingUpgradeTestCase {
+
+    private static final String SEARCH_CONFIG_INDEX = "search-relevance-search-config";
+    private static final String SEARCH_CONFIG_ENDPOINT = "/_plugins/_search_relevance/search_configurations";
+    private static final String OLD_MAPPING_RESOURCE = "mappings/search_configuration_v0.json";
+    private static final String TEST_DOC_RESOURCE = "mappings/search_configuration_test_document.json";
+    private static final String TEST_DOC_ID = "test-search-config-bwc";
+
+    public void testSearchConfigMappingUpdate_RollingUpgrade() throws Exception {
+        switch (getClusterType()) {
+            case OLD:
+                testOldCluster();
+                break;
+            case MIXED:
+                testMixedCluster();
+                break;
+            case UPGRADED:
+                try {
+                    testUpgradedCluster();
+                } finally {
+                    wipeOfTestResources(SEARCH_CONFIG_INDEX);
+                }
+                break;
+            default:
+                throw new IllegalStateException("Unknown cluster type: " + getClusterType());
+        }
+    }
+
+    /**
+     * OLD cluster: The plugin auto-creates the index on startup.
+     * Insert a test document without the description field.
+     */
+    private void testOldCluster() throws Exception {
+        // Index may already exist from plugin startup; if not, create with old mapping
+        if (!IndexMappingTestHelper.checkIndexExists(client(), SEARCH_CONFIG_INDEX, logger)) {
+            String oldMapping = IndexMappingTestHelper.readMappingResource(OLD_MAPPING_RESOURCE);
+            IndexMappingTestHelper.createIndexWithMapping(client(), SEARCH_CONFIG_INDEX, oldMapping, logger);
+        }
+
+        assertTrue(
+            "search_configuration index should exist",
+            IndexMappingTestHelper.checkIndexExists(client(), SEARCH_CONFIG_INDEX, logger)
+        );
+
+        // Insert a document without description (old format)
+        String testDoc = IndexMappingTestHelper.readMappingResource(TEST_DOC_RESOURCE);
+        IndexMappingTestHelper.insertTestDocument(client(), SEARCH_CONFIG_INDEX, TEST_DOC_ID, testDoc);
+
+        logger.info("OLD cluster: search_configuration index ready with test document");
+    }
+
+    /**
+     * MIXED cluster: Verify old data is still accessible.
+     */
+    private void testMixedCluster() throws Exception {
+        assertTrue(
+            "search_configuration index should exist in MIXED cluster",
+            IndexMappingTestHelper.checkIndexExists(client(), SEARCH_CONFIG_INDEX, logger)
+        );
+
+        Map<String, Object> doc = IndexMappingTestHelper.getDocument(client(), SEARCH_CONFIG_INDEX, TEST_DOC_ID, logger);
+        assertNotNull("Test document should be accessible in MIXED cluster", doc);
+        assertEquals("bwc-test-config", doc.get("name"));
+
+        logger.info("MIXED cluster: search_configuration data accessible");
+    }
+
+    /**
+     * UPGRADED cluster: Create a search configuration via the plugin REST API.
+     * This exercises the real auto-migration path:
+     *   createIndexIfAbsentSync → detects version 0 < 1 → updateMappingSync (with CountDownLatch)
+     *   → document write with description field
+     *
+     * If updateMappingSync doesn't wait for completion, the description field could be
+     * auto-mapped as a different type, or the mapping update could conflict.
+     */
+    private void testUpgradedCluster() throws Exception {
+        assertTrue(
+            "search_configuration index should exist after upgrade",
+            IndexMappingTestHelper.checkIndexExists(client(), SEARCH_CONFIG_INDEX, logger)
+        );
+
+        // Verify old data survives
+        Map<String, Object> oldDoc = IndexMappingTestHelper.getDocument(client(), SEARCH_CONFIG_INDEX, TEST_DOC_ID, logger);
+        assertNotNull("Old document should survive upgrade", oldDoc);
+
+        // Create a new search configuration via the plugin API.
+        // This triggers the actual auto-migration: updateMappingSync adds description field
+        // to the mapping, then the document is written with description.
+        Request request = new Request("PUT", SEARCH_CONFIG_ENDPOINT);
+        request.setJsonEntity(
+            "{"
+                + "\"name\": \"bwc-upgraded-config\","
+                + "\"description\": \"Created after upgrade to test auto-migration\","
+                + "\"index\": \"test-index\","
+                + "\"query\": \"{\\\"match_all\\\": {}}\""
+                + "}"
+        );
+
+        Response response = client().performRequest(request);
+        assertEquals("Plugin API should succeed after auto-migration", 200, response.getStatusLine().getStatusCode());
+
+        Map<String, Object> responseMap = IndexMappingTestHelper.parseResponse(response);
+        String newConfigId = (String) responseMap.get("search_configuration_id");
+        assertNotNull("Should get a search_configuration_id back", newConfigId);
+
+        // Verify the mapping now has the description field with correct type
+        Map<String, Object> mapping = IndexMappingTestHelper.getIndexMapping(client(), SEARCH_CONFIG_INDEX);
+        Map<String, Object> properties = IndexMappingTestHelper.getMappingProperties(mapping);
+        assertTrue("Mapping should have description field after auto-migration", properties.containsKey("description"));
+
+        // Verify schema_version was updated to 1
+        Map<String, Object> meta = IndexMappingTestHelper.getMappingMeta(mapping);
+        assertNotNull("Mapping should have _meta", meta);
+        assertEquals("Schema version should be 1 after auto-migration", 1, ((Number) meta.get("schema_version")).intValue());
+
+        // Verify old data still accessible
+        oldDoc = IndexMappingTestHelper.getDocument(client(), SEARCH_CONFIG_INDEX, TEST_DOC_ID, logger);
+        assertNotNull("Old document should still be accessible after auto-migration", oldDoc);
+
+        logger.info("UPGRADED cluster: Plugin auto-migration succeeded, description field added, old data preserved");
+    }
+}

--- a/qa/src/test/resources/mappings/search_configuration_test_document.json
+++ b/qa/src/test/resources/mappings/search_configuration_test_document.json
@@ -1,0 +1,8 @@
+{
+  "id": "test-search-config-bwc",
+  "timestamp": "2024-01-01T00:00:00.000Z",
+  "name": "bwc-test-config",
+  "index": "test-index",
+  "queryBody": "{\"query\":{\"match_all\":{}}}",
+  "searchPipeline": "test-pipeline"
+}

--- a/qa/src/test/resources/mappings/search_configuration_v0.json
+++ b/qa/src/test/resources/mappings/search_configuration_v0.json
@@ -1,6 +1,6 @@
 {
   "_meta": {
-    "schema_version": 1
+    "schema_version": 0
   },
   "properties": {
     "id": { "type": "keyword" },
@@ -8,7 +8,6 @@
     "name": { "type": "keyword" },
     "index": { "type": "keyword" },
     "queryBody": { "type": "text" },
-    "searchPipeline": { "type": "keyword" },
-    "description": {"type": "text"}
+    "searchPipeline": { "type": "keyword" }
   }
 }

--- a/qa/src/test/resources/mappings/search_configuration_v1.json
+++ b/qa/src/test/resources/mappings/search_configuration_v1.json
@@ -9,6 +9,6 @@
     "index": { "type": "keyword" },
     "queryBody": { "type": "text" },
     "searchPipeline": { "type": "keyword" },
-    "description": {"type": "text"}
+    "description": { "type": "text" }
   }
 }

--- a/src/main/java/org/opensearch/searchrelevance/indices/SearchRelevanceIndicesManager.java
+++ b/src/main/java/org/opensearch/searchrelevance/indices/SearchRelevanceIndicesManager.java
@@ -16,6 +16,10 @@ import java.io.InputStream;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.function.BiConsumer;
 
 import org.opensearch.ResourceAlreadyExistsException;
@@ -157,9 +161,22 @@ public class SearchRelevanceIndicesManager {
             return;
         }
 
-        // Existing version is older - update mapping
-        log.info("Updating index [{}] mapping from schema version [{}] to [{}]", indexName, existingVersion, currentVersion);
-        updateMappingSync(index);
+        // Existing version is older - update mapping (best-effort)
+        // If the update fails or times out (e.g., during rolling upgrade cluster transitions),
+        // log a warning and continue. Reads work fine with the old mapping, and the next
+        // write operation will retry the update.
+        try {
+            log.info("Updating index [{}] mapping from schema version [{}] to [{}]", indexName, existingVersion, currentVersion);
+            updateMappingSync(index);
+        } catch (Exception e) {
+            log.warn(
+                "Failed to update mapping for index [{}] from version [{}] to [{}]: {}. " + "Will retry on next operation.",
+                indexName,
+                existingVersion,
+                currentVersion,
+                e.getMessage()
+            );
+        }
     }
 
     /**
@@ -210,9 +227,9 @@ public class SearchRelevanceIndicesManager {
 
     /**
      * Update the mapping for an existing index synchronously.
-     * Uses a CountDownLatch to wait for the async putMapping to complete,
+     * Uses a CompletableFuture to wait for the async putMapping to complete,
      * ensuring the mapping is fully applied before any document write occurs.
-     * Note: CountDownLatch.await() is used instead of ActionFuture.actionGet()
+     * Note: CompletableFuture.get() is used instead of ActionFuture.actionGet()
      * because actionGet() is forbidden on transport threads.
      * @param index the index whose mapping should be updated
      * @throws SearchRelevanceException if the mapping update fails or times out
@@ -222,27 +239,25 @@ public class SearchRelevanceIndicesManager {
             index.getMapping(),
             org.opensearch.common.xcontent.XContentType.JSON
         );
-        final java.util.concurrent.CountDownLatch latch = new java.util.concurrent.CountDownLatch(1);
-        final java.util.concurrent.atomic.AtomicReference<Exception> error = new java.util.concurrent.atomic.AtomicReference<>();
+        final CompletableFuture<Void> future = new CompletableFuture<>();
         StashedThreadContext.run(client, () -> client.admin().indices().putMapping(putMappingRequest, new ActionListener<>() {
             @Override
             public void onResponse(org.opensearch.action.support.clustermanager.AcknowledgedResponse response) {
-                latch.countDown();
+                future.complete(null);
             }
 
             @Override
             public void onFailure(Exception e) {
-                error.set(e);
-                latch.countDown();
+                future.completeExceptionally(e);
             }
         }));
         try {
-            if (!latch.await(30, java.util.concurrent.TimeUnit.SECONDS)) {
-                throw new SearchRelevanceException(
-                    String.format(Locale.ROOT, "Timeout waiting for mapping update on index [%s]", index.getIndexName()),
-                    RestStatus.INTERNAL_SERVER_ERROR
-                );
-            }
+            future.get(30, TimeUnit.SECONDS);
+        } catch (TimeoutException e) {
+            throw new SearchRelevanceException(
+                String.format(Locale.ROOT, "Timeout waiting for mapping update on index [%s]", index.getIndexName()),
+                RestStatus.INTERNAL_SERVER_ERROR
+            );
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
             throw new SearchRelevanceException(
@@ -250,11 +265,10 @@ public class SearchRelevanceIndicesManager {
                 e,
                 RestStatus.INTERNAL_SERVER_ERROR
             );
-        }
-        if (error.get() != null) {
+        } catch (ExecutionException e) {
             throw new SearchRelevanceException(
                 String.format(Locale.ROOT, "Failed to update mapping for index [%s]", index.getIndexName()),
-                error.get(),
+                e.getCause(),
                 RestStatus.INTERNAL_SERVER_ERROR
             );
         }

--- a/src/main/java/org/opensearch/searchrelevance/indices/SearchRelevanceIndicesManager.java
+++ b/src/main/java/org/opensearch/searchrelevance/indices/SearchRelevanceIndicesManager.java
@@ -210,14 +210,54 @@ public class SearchRelevanceIndicesManager {
 
     /**
      * Update the mapping for an existing index synchronously.
+     * Uses a CountDownLatch to wait for the async putMapping to complete,
+     * ensuring the mapping is fully applied before any document write occurs.
+     * Note: CountDownLatch.await() is used instead of ActionFuture.actionGet()
+     * because actionGet() is forbidden on transport threads.
      * @param index the index whose mapping should be updated
+     * @throws SearchRelevanceException if the mapping update fails or times out
      */
     private void updateMappingSync(final SearchRelevanceIndices index) {
         final PutMappingRequest putMappingRequest = new PutMappingRequest(index.getIndexName()).source(
             index.getMapping(),
             org.opensearch.common.xcontent.XContentType.JSON
         );
-        StashedThreadContext.run(client, () -> client.admin().indices().putMapping(putMappingRequest));
+        final java.util.concurrent.CountDownLatch latch = new java.util.concurrent.CountDownLatch(1);
+        final java.util.concurrent.atomic.AtomicReference<Exception> error = new java.util.concurrent.atomic.AtomicReference<>();
+        StashedThreadContext.run(client, () -> client.admin().indices().putMapping(putMappingRequest, new ActionListener<>() {
+            @Override
+            public void onResponse(org.opensearch.action.support.clustermanager.AcknowledgedResponse response) {
+                latch.countDown();
+            }
+
+            @Override
+            public void onFailure(Exception e) {
+                error.set(e);
+                latch.countDown();
+            }
+        }));
+        try {
+            if (!latch.await(30, java.util.concurrent.TimeUnit.SECONDS)) {
+                throw new SearchRelevanceException(
+                    String.format(Locale.ROOT, "Timeout waiting for mapping update on index [%s]", index.getIndexName()),
+                    RestStatus.INTERNAL_SERVER_ERROR
+                );
+            }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new SearchRelevanceException(
+                String.format(Locale.ROOT, "Interrupted waiting for mapping update on index [%s]", index.getIndexName()),
+                e,
+                RestStatus.INTERNAL_SERVER_ERROR
+            );
+        }
+        if (error.get() != null) {
+            throw new SearchRelevanceException(
+                String.format(Locale.ROOT, "Failed to update mapping for index [%s]", index.getIndexName()),
+                error.get(),
+                RestStatus.INTERNAL_SERVER_ERROR
+            );
+        }
     }
 
     /**

--- a/src/main/java/org/opensearch/searchrelevance/indices/SearchRelevanceIndicesManager.java
+++ b/src/main/java/org/opensearch/searchrelevance/indices/SearchRelevanceIndicesManager.java
@@ -40,6 +40,7 @@ import org.opensearch.action.update.UpdateResponse;
 import org.opensearch.cluster.metadata.MappingMetadata;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.io.Streams;
+import org.opensearch.common.util.concurrent.ThreadContext;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.rest.RestStatus;
 import org.opensearch.core.xcontent.XContentBuilder;
@@ -240,18 +241,18 @@ public class SearchRelevanceIndicesManager {
             org.opensearch.common.xcontent.XContentType.JSON
         );
         final CompletableFuture<Void> future = new CompletableFuture<>();
-        StashedThreadContext.run(client, () -> client.admin().indices().putMapping(putMappingRequest, new ActionListener<>() {
-            @Override
-            public void onResponse(org.opensearch.action.support.clustermanager.AcknowledgedResponse response) {
-                future.complete(null);
-            }
+        try (ThreadContext.StoredContext context = client.threadPool().getThreadContext().stashContext()) {
+            client.admin().indices().putMapping(putMappingRequest, new ActionListener<>() {
+                @Override
+                public void onResponse(org.opensearch.action.support.clustermanager.AcknowledgedResponse response) {
+                    future.complete(null);
+                }
 
-            @Override
-            public void onFailure(Exception e) {
-                future.completeExceptionally(e);
-            }
-        }));
-        try {
+                @Override
+                public void onFailure(Exception e) {
+                    future.completeExceptionally(e);
+                }
+            });
             future.get(30, TimeUnit.SECONDS);
         } catch (TimeoutException e) {
             throw new SearchRelevanceException(

--- a/src/test/java/org/opensearch/searchrelevance/indices/SearchRelevanceIndicesManagerTests.java
+++ b/src/test/java/org/opensearch/searchrelevance/indices/SearchRelevanceIndicesManagerTests.java
@@ -449,7 +449,7 @@ public class SearchRelevanceIndicesManagerTests extends OpenSearchTestCase {
 
         // Verify: create index was called (sync version), putMapping was NOT called
         verify(indicesAdminClient).create(any(CreateIndexRequest.class));
-        verify(indicesAdminClient, never()).putMapping(any(PutMappingRequest.class));
+        verify(indicesAdminClient, never()).putMapping(any(PutMappingRequest.class), any(ActionListener.class));
     }
 
     /**
@@ -489,7 +489,7 @@ public class SearchRelevanceIndicesManagerTests extends OpenSearchTestCase {
 
         // Verify: create index NOT called, putMapping NOT called (version is same)
         verify(indicesAdminClient, never()).create(any(CreateIndexRequest.class), any(ActionListener.class));
-        verify(indicesAdminClient, never()).putMapping(any(PutMappingRequest.class));
+        verify(indicesAdminClient, never()).putMapping(any(PutMappingRequest.class), any(ActionListener.class));
     }
 
     /**
@@ -529,7 +529,7 @@ public class SearchRelevanceIndicesManagerTests extends OpenSearchTestCase {
 
         // Verify: create index NOT called, putMapping NOT called (version 0 >= 0)
         verify(indicesAdminClient, never()).create(any(CreateIndexRequest.class), any(ActionListener.class));
-        verify(indicesAdminClient, never()).putMapping(any(PutMappingRequest.class));
+        verify(indicesAdminClient, never()).putMapping(any(PutMappingRequest.class), any(ActionListener.class));
     }
 
     /**
@@ -604,7 +604,7 @@ public class SearchRelevanceIndicesManagerTests extends OpenSearchTestCase {
 
         // Verify: putMapping NOT called (explicit version 0 >= current version 0)
         verify(indicesAdminClient, never()).create(any(CreateIndexRequest.class), any(ActionListener.class));
-        verify(indicesAdminClient, never()).putMapping(any(PutMappingRequest.class));
+        verify(indicesAdminClient, never()).putMapping(any(PutMappingRequest.class), any(ActionListener.class));
     }
 
     /**
@@ -645,7 +645,7 @@ public class SearchRelevanceIndicesManagerTests extends OpenSearchTestCase {
 
         // Verify: putMapping NOT called (version 5 >= current version 0)
         verify(indicesAdminClient, never()).create(any(CreateIndexRequest.class), any(ActionListener.class));
-        verify(indicesAdminClient, never()).putMapping(any(PutMappingRequest.class));
+        verify(indicesAdminClient, never()).putMapping(any(PutMappingRequest.class), any(ActionListener.class));
     }
 
     /**
@@ -672,6 +672,13 @@ public class SearchRelevanceIndicesManagerTests extends OpenSearchTestCase {
         mappingSource.put("properties", new HashMap<>());
         when(mappingMetadata.sourceAsMap()).thenReturn(mappingSource);
 
+        // Mock putMapping to invoke listener (async 2-arg version)
+        doAnswer(invocation -> {
+            ActionListener<org.opensearch.action.support.clustermanager.AcknowledgedResponse> putListener = invocation.getArgument(1);
+            putListener.onResponse(new org.opensearch.action.support.clustermanager.AcknowledgedResponse(true));
+            return null;
+        }).when(indicesAdminClient).putMapping(any(PutMappingRequest.class), any(ActionListener.class));
+
         // Execute via putDoc
         QuerySet querySet = new QuerySet("test_id", "test_name", "test_description", "test_timestamp", "test_sampling", List.of());
         XContentBuilder xContentBuilder = querySet.toXContent(XContentFactory.jsonBuilder(), ToXContent.EMPTY_PARAMS);
@@ -689,7 +696,43 @@ public class SearchRelevanceIndicesManagerTests extends OpenSearchTestCase {
 
         // Verify: putMapping WAS called (version -2 < current version 0)
         verify(indicesAdminClient, never()).create(any(CreateIndexRequest.class), any(ActionListener.class));
-        verify(indicesAdminClient).putMapping(any(PutMappingRequest.class));
+        verify(indicesAdminClient).putMapping(any(PutMappingRequest.class), any(ActionListener.class));
+    }
+
+    /**
+     * Test that when putMapping fails, the error is propagated as SearchRelevanceException.
+     */
+    public void testCreateIndexIfAbsentSync_MappingUpdateFails_ThrowsException() throws IOException {
+        when(metadata.hasIndex(QUERY_SET.getIndexName())).thenReturn(true);
+
+        IndexMetadata indexMetadata = mock(IndexMetadata.class);
+        MappingMetadata mappingMetadata = mock(MappingMetadata.class);
+        when(metadata.index(QUERY_SET.getIndexName())).thenReturn(indexMetadata);
+        when(indexMetadata.mapping()).thenReturn(mappingMetadata);
+
+        Map<String, Object> metaMap = new HashMap<>();
+        metaMap.put(SearchRelevanceIndices.META_SCHEMA_VERSION_KEY, -1);
+        Map<String, Object> mappingSource = new HashMap<>();
+        mappingSource.put("_meta", metaMap);
+        when(mappingMetadata.sourceAsMap()).thenReturn(mappingSource);
+
+        // Mock putMapping to fail
+        doAnswer(invocation -> {
+            ActionListener<org.opensearch.action.support.clustermanager.AcknowledgedResponse> putListener = invocation.getArgument(1);
+            putListener.onFailure(new RuntimeException("Mapping update failed"));
+            return null;
+        }).when(indicesAdminClient).putMapping(any(PutMappingRequest.class), any(ActionListener.class));
+
+        QuerySet querySet = new QuerySet("test_id", "test_name", "test_description", "test_timestamp", "test_sampling", List.of());
+        XContentBuilder xContentBuilder = querySet.toXContent(XContentFactory.jsonBuilder(), ToXContent.EMPTY_PARAMS);
+
+        @SuppressWarnings("unchecked")
+        ActionListener<SearchResponse> listener = mock(ActionListener.class);
+
+        SearchRelevanceException exception = assertThrows(SearchRelevanceException.class, () -> {
+            indicesManager.putDoc("test_id", xContentBuilder, QUERY_SET, listener);
+        });
+        assertTrue(exception.getMessage().contains("Failed to update mapping"));
     }
 
     // ==================== Async createIndexIfAbsent with Retry Tests ====================
@@ -713,18 +756,18 @@ public class SearchRelevanceIndicesManagerTests extends OpenSearchTestCase {
         mappingSource.put("_meta", metaMap);
         when(mappingMetadata.sourceAsMap()).thenReturn(mappingSource);
 
-        // Mock successful putMapping
-        org.opensearch.action.support.PlainActionFuture<
-            org.opensearch.action.support.clustermanager.AcknowledgedResponse> putMappingFuture =
-                new org.opensearch.action.support.PlainActionFuture<>();
-        putMappingFuture.onResponse(new org.opensearch.action.support.clustermanager.AcknowledgedResponse(true));
-        when(indicesAdminClient.putMapping(any(PutMappingRequest.class))).thenReturn(putMappingFuture);
+        // Mock successful putMapping (async 2-arg version used by updateMappingSync)
+        doAnswer(invocation -> {
+            ActionListener<org.opensearch.action.support.clustermanager.AcknowledgedResponse> putListener = invocation.getArgument(1);
+            putListener.onResponse(new org.opensearch.action.support.clustermanager.AcknowledgedResponse(true));
+            return null;
+        }).when(indicesAdminClient).putMapping(any(PutMappingRequest.class), any(ActionListener.class));
 
         StepListener<Void> stepListener = new StepListener<>();
         indicesManager.createIndexIfAbsent(QUERY_SET, stepListener);
 
         // Verify: putMapping was called once
-        verify(indicesAdminClient).putMapping(any(PutMappingRequest.class));
+        verify(indicesAdminClient).putMapping(any(PutMappingRequest.class), any(ActionListener.class));
 
         // Verify: stepListener was called with success (no exception)
         assertNull(stepListener.result());
@@ -749,14 +792,18 @@ public class SearchRelevanceIndicesManagerTests extends OpenSearchTestCase {
         mappingSource.put("_meta", metaMap);
         when(mappingMetadata.sourceAsMap()).thenReturn(mappingSource);
 
-        // Mock putMapping to always fail
-        when(indicesAdminClient.putMapping(any(PutMappingRequest.class))).thenThrow(new RuntimeException("Mapping update failed"));
+        // Mock putMapping to always fail (async 2-arg version)
+        doAnswer(invocation -> {
+            ActionListener<org.opensearch.action.support.clustermanager.AcknowledgedResponse> putListener = invocation.getArgument(1);
+            putListener.onFailure(new RuntimeException("Mapping update failed"));
+            return null;
+        }).when(indicesAdminClient).putMapping(any(PutMappingRequest.class), any(ActionListener.class));
 
         StepListener<Void> stepListener = new StepListener<>();
         indicesManager.createIndexIfAbsent(QUERY_SET, stepListener);
 
         // Verify: putMapping was called 3 times (initial + 2 retries)
-        verify(indicesAdminClient, org.mockito.Mockito.times(3)).putMapping(any(PutMappingRequest.class));
+        verify(indicesAdminClient, org.mockito.Mockito.times(3)).putMapping(any(PutMappingRequest.class), any(ActionListener.class));
 
         // Verify: stepListener was called with failure
         try {
@@ -784,7 +831,7 @@ public class SearchRelevanceIndicesManagerTests extends OpenSearchTestCase {
         indicesManager.createIndexIfAbsent(QUERY_SET, stepListener);
 
         // Verify: putMapping was NOT called (failed before getting there)
-        verify(indicesAdminClient, never()).putMapping(any(PutMappingRequest.class));
+        verify(indicesAdminClient, never()).putMapping(any(PutMappingRequest.class), any(ActionListener.class));
 
         // Verify: stepListener was called with failure
         try {
@@ -819,7 +866,7 @@ public class SearchRelevanceIndicesManagerTests extends OpenSearchTestCase {
         indicesManager.createIndexIfAbsent(QUERY_SET, stepListener);
 
         // Verify: putMapping was NOT called (versions are same)
-        verify(indicesAdminClient, never()).putMapping(any(PutMappingRequest.class));
+        verify(indicesAdminClient, never()).putMapping(any(PutMappingRequest.class), any(ActionListener.class));
 
         // Verify: stepListener was called with success
         assertNull(stepListener.result());

--- a/src/test/java/org/opensearch/searchrelevance/indices/SearchRelevanceIndicesManagerTests.java
+++ b/src/test/java/org/opensearch/searchrelevance/indices/SearchRelevanceIndicesManagerTests.java
@@ -700,9 +700,10 @@ public class SearchRelevanceIndicesManagerTests extends OpenSearchTestCase {
     }
 
     /**
-     * Test that when putMapping fails, the error is propagated as SearchRelevanceException.
+     * Test that when putMapping fails, the error is logged but does not block the operation.
+     * The mapping update is best-effort — reads work with old mapping, writes will retry.
      */
-    public void testCreateIndexIfAbsentSync_MappingUpdateFails_ThrowsException() throws IOException {
+    public void testCreateIndexIfAbsentSync_MappingUpdateFails_ContinuesWithWarning() throws IOException {
         when(metadata.hasIndex(QUERY_SET.getIndexName())).thenReturn(true);
 
         IndexMetadata indexMetadata = mock(IndexMetadata.class);
@@ -726,13 +727,21 @@ public class SearchRelevanceIndicesManagerTests extends OpenSearchTestCase {
         QuerySet querySet = new QuerySet("test_id", "test_name", "test_description", "test_timestamp", "test_sampling", List.of());
         XContentBuilder xContentBuilder = querySet.toXContent(XContentFactory.jsonBuilder(), ToXContent.EMPTY_PARAMS);
 
+        IndexRequestBuilder indexRequestBuilder = mock(IndexRequestBuilder.class);
+        when(client.prepareIndex(QUERY_SET.getIndexName())).thenReturn(indexRequestBuilder);
+        when(indexRequestBuilder.setId("test_id")).thenReturn(indexRequestBuilder);
+        when(indexRequestBuilder.setOpType(DocWriteRequest.OpType.CREATE)).thenReturn(indexRequestBuilder);
+        when(indexRequestBuilder.setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE)).thenReturn(indexRequestBuilder);
+        when(indexRequestBuilder.setSource(xContentBuilder)).thenReturn(indexRequestBuilder);
+
         @SuppressWarnings("unchecked")
         ActionListener<SearchResponse> listener = mock(ActionListener.class);
 
-        SearchRelevanceException exception = assertThrows(SearchRelevanceException.class, () -> {
-            indicesManager.putDoc("test_id", xContentBuilder, QUERY_SET, listener);
-        });
-        assertTrue(exception.getMessage().contains("Failed to update mapping"));
+        // Should NOT throw — mapping update failure is best-effort
+        indicesManager.putDoc("test_id", xContentBuilder, QUERY_SET, listener);
+
+        // Verify putMapping was attempted
+        verify(indicesAdminClient).putMapping(any(PutMappingRequest.class), any(ActionListener.class));
     }
 
     // ==================== Async createIndexIfAbsent with Retry Tests ====================


### PR DESCRIPTION
### Description                                                                                                                                                                             
                                                                                                                                                                                              
  This PR fixes a race condition in the index mapping migration infrastructure that causes node crashes during rolling upgrades, and corrects a missed schema version bump for the            
  `search_configuration` index.                                                                                                                                                               
                                                                                                                                                                                              
  ### Problem                                                                                                                                                                                 
                                                                                                                                                                                              
  #### 1. Fire-and-forget mapping update causes type conflicts                                                                                                                                
                                                                                                                                                                                              
  When the Search Relevance plugin upgrades an existing index's mapping to a newer schema version, it uses `updateMappingSync` to apply the new mapping before writing documents. However,    
  `updateMappingSync` was not actually synchronous — it called `client.admin().indices().putMapping(request)` which returns an `ActionFuture` that was **never awaited**. The mapping update  
  was fire-and-forget.                                                                                                                                                                        
                                                                                                                                                                                              
  This created a race condition during rolling upgrades:                                                                                                                                      
                                                                                                                                                                                              
  1. An upgraded node detects the index has `schema_version` 0 but the plugin expects version 1                                                                                               
  2. `updateMappingSync` fires the `putMapping` request (e.g., adding `status` as `keyword`) but **returns immediately**                                                                      
  3. The document write proceeds **before** the mapping update completes                                                                                                                      
  4. OpenSearch sees an unknown field `status` with string value `"COMPLETED"` → auto-maps it as `text`                                                                                       
  5. The `putMapping` request arrives and tries to set `status` as `keyword` → **conflict**: `mapper [status] cannot be changed from type [keyword] to [text]`                                
                                                                                                                                                                                              
  This causes a fatal `AssertionError` that crashes the node.                                                                                                                                 
                                                                                                                                                                                              
  #### 2. Thread context restored before async callback                                                                                                                                       
                                                                                                                                                                                              
  `StashedThreadContext.run` uses try-with-resources on `stashContext()`. For async operations like `putMapping(request, listener)`, the stashed context was **restored immediately** after   
  the async call returned — before the listener callback fired on a different thread. This caused the listener to never receive a response, resulting in `CompletableFuture` timeouts.        
                                                                                                                                                                                              
  #### 3. Read operations blocked by mapping update failures                                                                                                                                  
                                                                                                                                                                                              
  Every operation (including reads like `GET /search_configurations/{id}`) went through `createIndexIfAbsentSync` which attempted the mapping migration. During rolling upgrades with cluster 
  instability (cluster manager transitioning, shards rebalancing), the mapping update could time out, causing **read operations to fail with 500 errors** even though reads work perfectly    
  fine with the old mapping.                                                                                                                                                                  
                                                                                                                                                                                              
  #### 4. Missing schema version bump for `search_configuration`                                                                                                                              
                                                                                                                                                                                              
  PR [#370](https://github.com/opensearch-project/search-relevance/pull/370) added a `description` field to `search_configuration.json` but **did not bump `schema_version`**. Since existing 
  version (0) >= current version (0), the mapping update is skipped entirely for existing indices. It works by accident because OpenSearch's dynamic mapping defaults strings to `text`, which
  happens to match the intended type — but this is not by design.                                                                                                                             
                                                                                                                                                                                              
  #### Why the race condition was never caught                                                                                                                                                
                                                                                                                                                                                              
  - **All indices started at `schema_version` 0** — PR [#344](https://github.com/opensearch-project/search-relevance/pull/344) added the migration infrastructure, but the buggy code path was
  never executed since existing version (0) >= current version (0) always skipped the update                                                                                                  
  - **First real version bump (`judgment_cache` 0→1 in PR [#349](https://github.com/opensearch-project/search-relevance/pull/349))** was tested via direct REST `PUT _mapping` calls in BWC   
  tests, completely bypassing the plugin's actual `updateMappingSync` code path                                                                                                               
  - **Unit tests** only verified `putMapping` was *called*, not that it *completed* before the document write                                                                                 
  - **`ActionFuture.actionGet()`** cannot be used to block because OpenSearch forbids blocking calls on transport threads (throws `AssertionError: Expected current thread to not be a        
  transport thread`)                                                                                                                                                                          
                                                                                                                                                                                              
  ### Fix                                                                                                                                                                                     
                                                                                                                                                                                              
  #### `updateMappingSync` (`SearchRelevanceIndicesManager.java`)                                                                                                                             
                                                                                                                                                                                              
  Three changes:                                                                                                                                                                              
                                                                                                                                                                                              
  1. **Fire-and-forget → `CompletableFuture`**: Replaced the 1-arg `putMapping(request)` with the async 2-arg `putMapping(request, listener)` and a `CompletableFuture` that blocks until the 
  listener is called. `CompletableFuture.get()` is safe on transport threads (unlike `ActionFuture.actionGet()` which triggers OpenSearch's blocking-operation assertion). Includes a         
  30-second timeout.                                                                                                                                                                          
                                                                                                                                                                                              
  2. **Thread context fix**: Replaced `StashedThreadContext.run` with direct `try (stashContext())` that keeps the stashed context active until `future.get()` completes. This ensures the    
  async `putMapping` listener callback fires with the correct thread context.                                                                                                                 
                                                                                                                                                                                              
  3. **Best-effort for existing indices**: `createIndexIfAbsentSync` now catches mapping update failures for existing indices, logs a warning, and continues. This prevents read operations   
  from returning 500 errors during upgrades. The mapping update will be retried on the next operation.                                                                                        
                                                                                                                                                                                              
  #### `search_configuration.json`                                                                                                                                                            
                                                                                                                                                                                              
  Bumped `schema_version` from 0 to 1 so the `description` field mapping is properly applied to existing indices during upgrade.                                                              
                                                                                                                                                                                              
  ### Testing                                                                                                                                                                                 
                                                                                                                                                                                              
  #### Unit tests (`SearchRelevanceIndicesManagerTests`)                                                                                                                                      
                                                                                                                                                                                              
  - Updated all `putMapping` mocks and verifications from 1-arg to 2-arg overload (matching the new async call)                                                                               
  - Added `testCreateIndexIfAbsentSync_MappingUpdateFails_ContinuesWithWarning` — verifies that mapping update failure is logged but does not block the operation                             
                                                                                                                                                                                              
  #### BWC integration tests — plugin auto-migration path                                                                                                                                     
                                                                                                                                                                                              
  These tests are the key validation. Unlike existing BWC tests that manually call `PUT _mapping` via REST, these exercise the **actual plugin code path**: `createIndexIfAbsentSync` →       
  `updateMappingSync` → document write.                                                                                                                                                       
                                                                                                                                                                                              
  | Test | Scenario |                                                                                                                                                                         
  |------|----------|                                                                                                                                                                         
  | `SearchConfigMappingBWCIT` (rolling upgrade) | OLD: insert doc without `description`. MIXED: verify data accessible. UPGRADED: create search config via plugin API → triggers auto-migration from v0 to v1 → verifies `description` field in mapping, `schema_version=1`, old data preserved |                                                                            
  | `SearchConfigMappingRestartIT` (full restart) | Same flow for restart upgrade |                                                                                                           
                                                                                                                                                                                              
  These tests would **fail without the fixes** because either the mapping update wouldn't complete before the document write (race condition), or the listener callback would never fire      
  (thread context issue).                                                                                                                                                                     
                                                                                                                                                                                              
  #### BWC test resources                                                                                                                                                                     
                                                                                                                                                                                              
  - `search_configuration_v0.json` — old schema (no `description`)                                                                                                                            
  - `search_configuration_v1.json` — new schema (with `description`)                                                                                                                          
  - `search_configuration_test_document.json` — test document in old format                                                                                                                   
                                                                                                                                                                                              
  ### Summary of changes                                                                                                                                                                      
                                                                                                                                                                                              
  | File | Change |                                                                                                                                                                           
  |------|--------|                                                                                                                                                                           
  | `SearchRelevanceIndicesManager.java` | `updateMappingSync`: fire-and-forget → `CompletableFuture` with proper thread context handling. `createIndexIfAbsentSync`: mapping update is  best-effort for existing indices |                                                                                                                                                          
  | `search_configuration.json` | `schema_version` 0 → 1 |                                                                                                                                    
  | `SearchRelevanceIndicesManagerTests.java` | Updated mocks/verifications to 2-arg `putMapping`; added best-effort failure test |                                                           
  | `SearchConfigMappingBWCIT.java` | Rolling upgrade BWC test exercising plugin auto-migration |                                                                                             
  | `SearchConfigMappingRestartIT.java` | Restart upgrade BWC test exercising plugin auto-migration |                                                                                         
  | `search_configuration_v0.json` | BWC test resource — old mapping |                                                                                                                        
  | `search_configuration_v1.json` | BWC test resource — new mapping |                                                                                                                        
  | `search_configuration_test_document.json` | BWC test resource — test document |                                                                                                           
                                                                                                                                                                                              
  ---                                                                                                                                                                                         
                                                                                                                                                                                              
  By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.                                                                          
  For more information on following Developer Certificate of Origin and signing off your commits, please check                                                                                
  [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).      