### PR TITLE
[Feature branch] [Part 1] Add new fields in QuerySet to support LLM Generated Query Set Feature

### DIFF
--- a/src/main/java/org/opensearch/searchrelevance/common/PluginConstants.java
+++ b/src/main/java/org/opensearch/searchrelevance/common/PluginConstants.java
@@ -7,6 +7,8 @@
  */
 package org.opensearch.searchrelevance.common;
 
+import java.util.List;
+
 /**
  * Plugin constants that shared cross the project.
  */
@@ -68,7 +70,7 @@ public class PluginConstants {
     public static final String UBI_EVENTS_INDEX = "ubi_events";
 
     public static final String CLICK_MODEL = "clickModel";
-    public static final String NAX_RANK = "maxRank";
+    public static final String MAX_RANK = "maxRank";
     public static final String START_DATE = "startDate";
     public static final String END_DATE = "endDate";
     /* The customized UBI index names */
@@ -100,6 +102,14 @@ public class PluginConstants {
 
     public static final int DEFAULTED_QUERY_SET_SIZE = 10;
     public static final String MANUAL = "manual";
+    public static final String LLM_RANDOM = "llm_random";
+    public static final String MODEL_ID = "modelId";
+    public static final String NUMBER_OF_QUERY_TERMS = "numberOfQueryTerms";
+    public static final String CATEGORIES = "categories";
+    public static final String LEXICAL = "lexical";
+    public static final String SEMANTIC = "semantic";
+    public static final int DEFAULT_NUMBER_OF_QUERY_TERMS = 100;
+    public static final List<String> DEFAULT_CATEGORIES = List.of("lexical", "semantic");
     public static final String PROCEED = "proceed";
     public static final String ABORT = "abort";
     public static final int BATCH_SIZE_FOR_DELETE_BY_QUERY = 1000;

--- a/src/main/java/org/opensearch/searchrelevance/common/validator/IndexValidator.java
+++ b/src/main/java/org/opensearch/searchrelevance/common/validator/IndexValidator.java
@@ -1,0 +1,81 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+package org.opensearch.searchrelevance.common.validator;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import org.opensearch.cluster.metadata.MappingMetadata;
+import org.opensearch.cluster.service.ClusterService;
+
+/**
+ * Utility class for validating index existence and mapping fields.
+ */
+public class IndexValidator {
+
+    /**
+     * Checks if the given index exists in the cluster and has a mapping.
+     * @param clusterService opensearch cluster instance
+     * @param index the index name
+     * @return true if index exists with a mapping, false otherwise
+     */
+    public static boolean checkIndexAndMappingExists(ClusterService clusterService, String index) {
+        if (clusterService == null || !clusterService.state().metadata().hasIndex(index)) {
+            return false;
+        }
+
+        MappingMetadata mappingMetadata = clusterService.state().metadata().index(index).mapping();
+        return mappingMetadata != null;
+    }
+
+    /**
+     * Validates that the specified context fields exist in the index mapping.
+     *
+     * @param mappingMetadata the mapping metadata of the index to validate against
+     * @param contextFields the list of field paths to check, supports nested fields using dot notation
+     */
+    public static void validateFieldsExistInIndexMapping(MappingMetadata mappingMetadata, List<String> contextFields) {
+        List<String> invalidFields = new ArrayList<>();
+        for (String contextField : contextFields) {
+            if (!hasField(mappingMetadata, contextField)) {
+                invalidFields.add(contextField);
+            }
+        }
+        if (!invalidFields.isEmpty()) {
+            throw new IllegalArgumentException("Context fields " + invalidFields + " do not exist in the index mapping");
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private static boolean hasField(MappingMetadata mappingMetadata, String fieldPath) {
+        var sourceAsMap = mappingMetadata.sourceAsMap();
+        if (!(sourceAsMap.get("properties") instanceof Map)) {
+            return false;
+        }
+        Map<String, Object> current = (Map<String, Object>) sourceAsMap.get("properties");
+
+        String[] pathParts = fieldPath.split("\\.");
+        for (int i = 0; i < pathParts.length; i++) {
+            if (!current.containsKey(pathParts[i])) {
+                return false;
+            }
+            if (i < pathParts.length - 1) {
+                if (!(current.get(pathParts[i]) instanceof Map)) {
+                    return false;
+                }
+                var fieldDef = (Map<String, Object>) current.get(pathParts[i]);
+                if (!(fieldDef.get("properties") instanceof Map)) {
+                    return false;
+                }
+                current = (Map<String, Object>) fieldDef.get("properties");
+            }
+        }
+        return true;
+    }
+}

--- a/src/main/java/org/opensearch/searchrelevance/dao/QuerySetDao.java
+++ b/src/main/java/org/opensearch/searchrelevance/dao/QuerySetDao.java
@@ -30,8 +30,11 @@ import org.opensearch.search.SearchHit;
 import org.opensearch.search.builder.SearchSourceBuilder;
 import org.opensearch.searchrelevance.exception.SearchRelevanceException;
 import org.opensearch.searchrelevance.indices.SearchRelevanceIndicesManager;
+import org.opensearch.searchrelevance.model.AsyncStatus;
 import org.opensearch.searchrelevance.model.QuerySet;
 import org.opensearch.searchrelevance.model.QuerySetEntry;
+import org.opensearch.searchrelevance.model.QuerySetType;
+import org.opensearch.searchrelevance.ubi.QuerySampler;
 
 /**
  * Data access object layer for query set system index
@@ -65,7 +68,7 @@ public class QuerySetDao {
         }
         try {
             searchRelevanceIndicesManager.putDoc(
-                querySet.id(),
+                querySet.getId(),
                 querySet.toXContent(XContentFactory.jsonBuilder(), ToXContent.EMPTY_PARAMS),
                 QUERY_SET,
                 listener
@@ -145,7 +148,7 @@ public class QuerySetDao {
 
                     results.put(
                         METRICS_QUERY_TEXT_FIELD_NAME,
-                        querySet.querySetQueries().stream().map(QuerySetEntry::queryText).collect(Collectors.toList())
+                        querySet.getQuerySetQueries().stream().map(QuerySetEntry::queryText).collect(Collectors.toList())
                     );
                     stepListener.onResponse(results);
                 } catch (Exception e) {
@@ -162,7 +165,8 @@ public class QuerySetDao {
         });
     }
 
-    private QuerySet convertToQuerySet(SearchResponse response) {
+    @SuppressWarnings("unchecked")
+    public QuerySet convertToQuerySet(SearchResponse response) {
         SearchHit hit = response.getHits().getHits()[0];
         Map<String, Object> sourceMap = hit.getSourceAsMap();
 
@@ -176,12 +180,48 @@ public class QuerySetDao {
                 .collect(Collectors.toList());
         }
 
-        return QuerySet.Builder.builder()
+        String sampling = (String) sourceMap.get(QuerySet.SAMPLING);
+
+        AsyncStatus status = AsyncStatus.COMPLETED;
+        if (sourceMap.containsKey(QuerySet.STATUS)) {
+            try {
+                status = AsyncStatus.valueOf((String) sourceMap.get(QuerySet.STATUS));
+            } catch (IllegalArgumentException e) {
+                // Fall back to COMPLETED for unrecognized values
+            }
+        }
+
+        QuerySetType type = null;
+        if (sourceMap.containsKey(QuerySet.TYPE)) {
+            type = QuerySetType.fromString((String) sourceMap.get(QuerySet.TYPE));
+        }
+        if (type == null) {
+            if ("manual".equals(sampling)) {
+                type = QuerySetType.MANUAL_QUERY_SET;
+            } else if (QuerySampler.getSamplingTechniquesSupportedByUBI().contains(sampling)) {
+                type = QuerySetType.UBI_QUERY_SET;
+            } else {
+                type = QuerySetType.LLM_QUERY_SET;
+            }
+        }
+
+        int numberOfQueryTerms = sourceMap.containsKey(QuerySet.NUMBER_OF_QUERY_TERMS)
+            ? ((Number) sourceMap.get(QuerySet.NUMBER_OF_QUERY_TERMS)).intValue()
+            : querySetEntries.size();
+
+        return QuerySet.builder()
             .id((String) sourceMap.get(QuerySet.ID))
             .name((String) sourceMap.get(QuerySet.NAME))
             .description((String) sourceMap.get(QuerySet.DESCRIPTION))
             .timestamp((String) sourceMap.get(QuerySet.TIME_STAMP))
-            .sampling((String) sourceMap.get(QuerySet.SAMPLING))
+            .sampling(sampling)
+            .status(status)
+            .type(type)
+            .numberOfQueryTerms(numberOfQueryTerms)
+            .modelId((String) sourceMap.get(QuerySet.MODEL_ID))
+            .sourceIndex((String) sourceMap.get(QuerySet.SOURCE_INDEX))
+            .contextFields(sourceMap.containsKey(QuerySet.CONTEXT_FIELDS) ? (List<String>) sourceMap.get(QuerySet.CONTEXT_FIELDS) : null)
+            .categories(sourceMap.containsKey(QuerySet.CATEGORIES) ? (List<String>) sourceMap.get(QuerySet.CATEGORIES) : null)
             .querySetQueries(querySetEntries)
             .build();
     }

--- a/src/main/java/org/opensearch/searchrelevance/executors/ExperimentRunningManager.java
+++ b/src/main/java/org/opensearch/searchrelevance/executors/ExperimentRunningManager.java
@@ -143,8 +143,8 @@ public class ExperimentRunningManager {
         // First, get QuerySet asynchronously
         querySetDao.getQuerySet(request.getQuerySetId(), ActionListener.wrap(querySetResponse -> {
             try {
-                QuerySet querySet = convertToQuerySet(querySetResponse);
-                List<String> queryTextWithReferences = querySet.querySetQueries()
+                QuerySet querySet = querySetDao.convertToQuerySet(querySetResponse);
+                List<String> queryTextWithReferences = querySet.getQuerySetQueries()
                     .stream()
                     .map(e -> e.queryText())
                     .collect(Collectors.toList());
@@ -288,37 +288,6 @@ public class ExperimentRunningManager {
             }
         }));
         return future;
-    }
-
-    private QuerySet convertToQuerySet(SearchResponse response) {
-        if (response.getHits().getTotalHits().value() == 0) {
-            throw new SearchRelevanceException("QuerySet not found", RestStatus.NOT_FOUND);
-        }
-
-        Map<String, Object> sourceMap = response.getHits().getHits()[0].getSourceAsMap();
-
-        // Convert querySetQueries from list of maps to List<QuerySetEntry>
-        List<org.opensearch.searchrelevance.model.QuerySetEntry> querySetEntries = new ArrayList<>();
-        Object querySetQueriesObj = sourceMap.get("querySetQueries");
-        if (querySetQueriesObj instanceof List) {
-            List<Map<String, Object>> querySetQueriesList = (List<Map<String, Object>>) querySetQueriesObj;
-            querySetEntries = querySetQueriesList.stream()
-                .map(
-                    entryMap -> org.opensearch.searchrelevance.model.QuerySetEntry.Builder.builder()
-                        .queryText((String) entryMap.get("queryText"))
-                        .build()
-                )
-                .collect(Collectors.toList());
-        }
-
-        return org.opensearch.searchrelevance.model.QuerySet.Builder.builder()
-            .id((String) sourceMap.get("id"))
-            .name((String) sourceMap.get("name"))
-            .description((String) sourceMap.get("description"))
-            .timestamp((String) sourceMap.get("timestamp"))
-            .sampling((String) sourceMap.get("sampling"))
-            .querySetQueries(querySetEntries)
-            .build();
     }
 
     private SearchConfiguration convertToSearchConfiguration(SearchResponse response) {

--- a/src/main/java/org/opensearch/searchrelevance/judgments/LlmJudgmentsProcessor.java
+++ b/src/main/java/org/opensearch/searchrelevance/judgments/LlmJudgmentsProcessor.java
@@ -159,7 +159,10 @@ public class LlmJudgmentsProcessor implements BaseJudgmentsProcessor {
         boolean overwriteCache,
         ActionListener<List<Map<String, Object>>> listener
     ) {
-        List<String> queryTextsWithCustomInput = querySet.querySetQueries().stream().map(e -> e.queryText()).collect(Collectors.toList());
+        List<String> queryTextsWithCustomInput = querySet.getQuerySetQueries()
+            .stream()
+            .map(e -> e.queryText())
+            .collect(Collectors.toList());
         int totalQueries = queryTextsWithCustomInput.size();
 
         log.info("Starting LLM judgment generation for {} total queries", totalQueries);

--- a/src/main/java/org/opensearch/searchrelevance/model/QuerySet.java
+++ b/src/main/java/org/opensearch/searchrelevance/model/QuerySet.java
@@ -14,9 +14,14 @@ import org.opensearch.core.xcontent.ToXContent.Params;
 import org.opensearch.core.xcontent.ToXContentObject;
 import org.opensearch.core.xcontent.XContentBuilder;
 
+import lombok.Builder;
+import lombok.Getter;
+
 /**
  * QuerySet is a system index object that represents all query set sampling/inserting params.
  */
+@Getter
+@Builder
 public class QuerySet implements ToXContentObject {
 
     public static final String ID = "id";
@@ -24,7 +29,14 @@ public class QuerySet implements ToXContentObject {
     public static final String DESCRIPTION = "description";
     public static final String TIME_STAMP = "timestamp";
     public static final String SAMPLING = "sampling";
+    public static final String STATUS = "status";
+    public static final String TYPE = "type";
+    public static final String NUMBER_OF_QUERY_TERMS = "numberOfQueryTerms";
     public static final String QUERY_SET_QUERIES = "querySetQueries";
+    public static final String MODEL_ID = "modelId";
+    public static final String SOURCE_INDEX = "sourceIndex";
+    public static final String CONTEXT_FIELDS = "contextFields";
+    public static final String CATEGORIES = "categories";
 
     /**
      * Identifier of the system index
@@ -32,18 +44,16 @@ public class QuerySet implements ToXContentObject {
     private final String id;
     private final String name;
     private final String description;
-    private final String sampling;
     private final String timestamp;
+    private final String sampling;
+    private final AsyncStatus status;
+    private final QuerySetType type;
+    private final int numberOfQueryTerms;
+    private final String modelId;
+    private final String sourceIndex;
+    private final List<String> contextFields;
+    private final List<String> categories;
     private final List<QuerySetEntry> querySetQueries;
-
-    public QuerySet(String id, String name, String description, String timestamp, String sampling, List<QuerySetEntry> querySetQueries) {
-        this.id = id;
-        this.description = description;
-        this.name = name;
-        this.sampling = sampling;
-        this.timestamp = timestamp;
-        this.querySetQueries = querySetQueries;
-    }
 
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
@@ -52,7 +62,22 @@ public class QuerySet implements ToXContentObject {
         xContentBuilder.field(NAME, this.name == null ? "" : this.name.trim());
         xContentBuilder.field(DESCRIPTION, this.description == null ? "" : this.description.trim());
         xContentBuilder.field(SAMPLING, this.sampling == null ? "" : this.sampling.trim());
-        xContentBuilder.field(TIME_STAMP, this.timestamp.trim());
+        xContentBuilder.field(TIME_STAMP, this.timestamp != null ? this.timestamp.trim() : null);
+        xContentBuilder.field(STATUS, this.status != null ? this.status.name() : null);
+        xContentBuilder.field(TYPE, this.type != null ? this.type.getValue() : null);
+        xContentBuilder.field(NUMBER_OF_QUERY_TERMS, this.numberOfQueryTerms);
+        if (this.modelId != null) {
+            xContentBuilder.field(MODEL_ID, this.modelId);
+        }
+        if (this.sourceIndex != null) {
+            xContentBuilder.field(SOURCE_INDEX, this.sourceIndex);
+        }
+        if (this.contextFields != null && !this.contextFields.isEmpty()) {
+            xContentBuilder.field(CONTEXT_FIELDS, this.contextFields);
+        }
+        if (this.categories != null && !this.categories.isEmpty()) {
+            xContentBuilder.field(CATEGORIES, this.categories);
+        }
         // Add the query_set_queries field
         xContentBuilder.startArray(QUERY_SET_QUERIES);
         for (QuerySetEntry entry : querySetQueries) {
@@ -61,87 +86,4 @@ public class QuerySet implements ToXContentObject {
         xContentBuilder.endArray();
         return xContentBuilder.endObject();
     }
-
-    public static class Builder {
-        private String id;
-        private String name = "";
-        private String description = "";
-        private String sampling = "";
-        private String timestamp = "";
-        private List<QuerySetEntry> querySetQueries;
-
-        private Builder() {}
-
-        private Builder(QuerySet t) {
-            this.id = t.id;
-            this.name = t.name;
-            this.description = t.description;
-            this.sampling = t.sampling;
-            this.timestamp = t.timestamp;
-            this.querySetQueries = t.querySetQueries;
-        }
-
-        public Builder id(String id) {
-            this.id = id;
-            return this;
-        }
-
-        public Builder name(String name) {
-            this.name = name;
-            return this;
-        }
-
-        public Builder description(String description) {
-            this.description = description;
-            return this;
-        }
-
-        public Builder sampling(String sampling) {
-            this.sampling = sampling;
-            return this;
-        }
-
-        public Builder timestamp(String timestamp) {
-            this.timestamp = timestamp;
-            return this;
-        }
-
-        public Builder querySetQueries(List<QuerySetEntry> querySetQueries) {
-            this.querySetQueries = querySetQueries;
-            return this;
-        }
-
-        public QuerySet build() {
-            return new QuerySet(this.id, this.name, this.description, this.timestamp, this.sampling, this.querySetQueries);
-        }
-
-        public static Builder builder() {
-            return new Builder();
-        }
-
-        public static Builder builder(QuerySet t) {
-            return new Builder(t);
-        }
-    }
-
-    public String id() {
-        return id;
-    }
-
-    public String name() {
-        return name;
-    }
-
-    public String sampling() {
-        return sampling;
-    }
-
-    public String timestamp() {
-        return timestamp;
-    }
-
-    public List<QuerySetEntry> querySetQueries() {
-        return querySetQueries;
-    }
-
 }

--- a/src/main/java/org/opensearch/searchrelevance/model/QuerySetType.java
+++ b/src/main/java/org/opensearch/searchrelevance/model/QuerySetType.java
@@ -1,0 +1,36 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+package org.opensearch.searchrelevance.model;
+
+/**
+ * Enum representing the origin type of a query set.
+ */
+public enum QuerySetType {
+    LLM_QUERY_SET("llm_query_set"),
+    MANUAL_QUERY_SET("manual_query_set"),
+    UBI_QUERY_SET("ubi_query_set");
+
+    private final String value;
+
+    QuerySetType(String value) {
+        this.value = value;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public static QuerySetType fromString(String type) {
+        for (QuerySetType t : values()) {
+            if (t.value.equalsIgnoreCase(type) || t.name().equalsIgnoreCase(type)) {
+                return t;
+            }
+        }
+        return null;
+    }
+}

--- a/src/main/java/org/opensearch/searchrelevance/rest/RestPutJudgmentAction.java
+++ b/src/main/java/org/opensearch/searchrelevance/rest/RestPutJudgmentAction.java
@@ -22,8 +22,8 @@ import static org.opensearch.searchrelevance.common.PluginConstants.END_DATE;
 import static org.opensearch.searchrelevance.common.PluginConstants.IGNORE_FAILURE;
 import static org.opensearch.searchrelevance.common.PluginConstants.JUDGMENTS_URL;
 import static org.opensearch.searchrelevance.common.PluginConstants.JUDGMENT_RATINGS;
+import static org.opensearch.searchrelevance.common.PluginConstants.MAX_RANK;
 import static org.opensearch.searchrelevance.common.PluginConstants.NAME;
-import static org.opensearch.searchrelevance.common.PluginConstants.NAX_RANK;
 import static org.opensearch.searchrelevance.common.PluginConstants.QUERYSET_ID;
 import static org.opensearch.searchrelevance.common.PluginConstants.SEARCH_CONFIGURATION_LIST;
 import static org.opensearch.searchrelevance.common.PluginConstants.SIZE;
@@ -185,7 +185,7 @@ public class RestPutJudgmentAction extends BaseRestHandler {
             }
             case UBI_JUDGMENT -> {
                 String clickModel = (String) source.get(CLICK_MODEL);
-                int maxRank = (int) source.get(NAX_RANK);
+                int maxRank = (int) source.get(MAX_RANK);
 
                 String startDate = (String) source.getOrDefault(START_DATE, "");
                 String endDate = (String) source.getOrDefault(END_DATE, "");

--- a/src/main/java/org/opensearch/searchrelevance/rest/RestPutQuerySetAction.java
+++ b/src/main/java/org/opensearch/searchrelevance/rest/RestPutQuerySetAction.java
@@ -9,15 +9,28 @@ package org.opensearch.searchrelevance.rest;
 
 import static java.util.Collections.singletonList;
 import static org.opensearch.rest.RestRequest.Method.PUT;
+import static org.opensearch.searchrelevance.common.PluginConstants.CATEGORIES;
+import static org.opensearch.searchrelevance.common.PluginConstants.CONTEXT_FIELDS;
+import static org.opensearch.searchrelevance.common.PluginConstants.DEFAULT_CATEGORIES;
+import static org.opensearch.searchrelevance.common.PluginConstants.DEFAULT_NUMBER_OF_QUERY_TERMS;
 import static org.opensearch.searchrelevance.common.PluginConstants.DESCRIPTION;
+import static org.opensearch.searchrelevance.common.PluginConstants.INDEX;
+import static org.opensearch.searchrelevance.common.PluginConstants.LEXICAL;
+import static org.opensearch.searchrelevance.common.PluginConstants.LLM_RANDOM;
 import static org.opensearch.searchrelevance.common.PluginConstants.MANUAL;
+import static org.opensearch.searchrelevance.common.PluginConstants.MODEL_ID;
 import static org.opensearch.searchrelevance.common.PluginConstants.NAME;
+import static org.opensearch.searchrelevance.common.PluginConstants.NUMBER_OF_QUERY_TERMS;
 import static org.opensearch.searchrelevance.common.PluginConstants.QUERYSETS_URL;
 import static org.opensearch.searchrelevance.common.PluginConstants.QUERY_SET_QUERIES;
 import static org.opensearch.searchrelevance.common.PluginConstants.SAMPLING;
+import static org.opensearch.searchrelevance.common.PluginConstants.SEMANTIC;
+import static org.opensearch.searchrelevance.common.PluginConstants.TYPE;
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -33,17 +46,19 @@ import org.opensearch.core.xcontent.XContentParser;
 import org.opensearch.rest.BaseRestHandler;
 import org.opensearch.rest.BytesRestResponse;
 import org.opensearch.rest.RestRequest;
+import org.opensearch.searchrelevance.model.QuerySetType;
 import org.opensearch.searchrelevance.model.QueryWithReference;
 import org.opensearch.searchrelevance.settings.SearchRelevanceSettingsAccessor;
 import org.opensearch.searchrelevance.transport.queryset.PutQuerySetAction;
 import org.opensearch.searchrelevance.transport.queryset.PutQuerySetRequest;
+import org.opensearch.searchrelevance.utils.ParserUtils;
 import org.opensearch.searchrelevance.utils.TextValidationUtil;
 import org.opensearch.transport.client.node.NodeClient;
 
 import lombok.AllArgsConstructor;
 
 /**
- * Rest Action to facilitate requests to put a query set from manual input.
+ * Rest Action to facilitate requests to put a query set.
  */
 @AllArgsConstructor
 public class RestPutQuerySetAction extends BaseRestHandler {
@@ -69,56 +84,44 @@ public class RestPutQuerySetAction extends BaseRestHandler {
         XContentParser parser = request.contentParser();
         Map<String, Object> source = parser.map();
 
-        String name = (String) source.get(NAME);
-        RestChannelConsumer errorResponse = validateField(name, "name");
-        if (errorResponse != null) {
-            return errorResponse;
-        }
-
-        String description = (String) source.get(DESCRIPTION);
-        if (description != null) {
-            errorResponse = validateField(description, "description");
-            if (errorResponse != null) {
-                return errorResponse;
-            }
-        }
-        // Default values for sampling as manual
-        String sampling = (String) source.getOrDefault(SAMPLING, MANUAL);
-
-        List<QueryWithReference> querySetQueries;
-        if (sampling.equals(MANUAL)) {
-            List<Object> rawQueries = (List<Object>) source.get(QUERY_SET_QUERIES);
-            if (rawQueries.size() > settingsAccessor.getMaxQuerySetAllowed()) {
-                return channel -> channel.sendResponse(new BytesRestResponse(RestStatus.FORBIDDEN, "Query Set Limit Exceeded."));
-            }
-
-            // Validate and parse each query using the utility method
-            try {
-                querySetQueries = rawQueries.stream().map(obj -> {
-                    Map<String, Object> queryMap = (Map<String, Object>) obj;
-                    TextValidationUtil.QueryValidationResult validationResult = TextValidationUtil.validateAndParseQuery(queryMap);
-
-                    if (!validationResult.isValid()) {
-                        throw new IllegalArgumentException(validationResult.getErrorMessage());
-                    }
-
-                    return validationResult.getQueryWithReference();
-                }).collect(Collectors.toList());
-            } catch (IllegalArgumentException e) {
-                return channel -> channel.sendResponse(new BytesRestResponse(RestStatus.BAD_REQUEST, e.getMessage()));
-            }
-        } else {
-            querySetQueries = Collections.emptyList();
-        }
-
         PutQuerySetRequest putRequest;
         try {
-            putRequest = new PutQuerySetRequest(name, description, sampling, querySetQueries);
+            Object typeObj = source.getOrDefault(TYPE, null);
+            String typeStr = null;
+            if (typeObj != null) {
+                if (!(typeObj instanceof String)) {
+                    throw new IllegalArgumentException("type must be a string");
+                }
+                typeStr = (String) typeObj;
+            }
+            QuerySetType querySetType = typeStr != null ? QuerySetType.fromString(typeStr) : null;
+            if (typeStr != null && querySetType == null) {
+                throw new IllegalArgumentException("Invalid type: must be one of " + Arrays.toString(QuerySetType.values()));
+            }
+            if (querySetType == QuerySetType.LLM_QUERY_SET) {
+                putRequest = prepareLlmRandomQuerySetRequest(source);
+            } else if (querySetType == null || querySetType == QuerySetType.MANUAL_QUERY_SET) {
+                putRequest = prepareManualQuerySetRequest(source);
+            } else {
+                throw new IllegalArgumentException(
+                    "Only '"
+                        + QuerySetType.LLM_QUERY_SET.getValue()
+                        + "' and '"
+                        + QuerySetType.MANUAL_QUERY_SET.getValue()
+                        + "' types are supported"
+                );
+            }
         } catch (IllegalArgumentException e) {
             return channel -> channel.sendResponse(new BytesRestResponse(RestStatus.BAD_REQUEST, e.getMessage()));
+        } catch (IllegalStateException e) {
+            return channel -> channel.sendResponse(new BytesRestResponse(RestStatus.FORBIDDEN, e.getMessage()));
         }
 
-        return channel -> client.execute(PutQuerySetAction.INSTANCE, putRequest, new ActionListener<IndexResponse>() {
+        return executePutQuerySetRequest(client, putRequest);
+    }
+
+    private RestChannelConsumer executePutQuerySetRequest(NodeClient client, PutQuerySetRequest putRequest) {
+        return channel -> client.execute(PutQuerySetAction.INSTANCE, putRequest, new ActionListener<>() {
             @Override
             public void onResponse(IndexResponse response) {
                 try {
@@ -144,30 +147,138 @@ public class RestPutQuerySetAction extends BaseRestHandler {
         });
     }
 
-    /**
-     * Validates a field using TextValidationUtil and returns an error response if invalid
-     *
-     * @param fieldValue The value to validate
-     * @param fieldName The name of the field for error messages
-     * @return RestChannelConsumer with error response if invalid, null if valid
-     */
-    private RestChannelConsumer validateField(String fieldValue, String fieldName) {
-        TextValidationUtil.ValidationResult validation;
-
-        if ("name".equals(fieldName)) {
-            validation = TextValidationUtil.validateName(fieldValue);
-        } else if ("description".equals(fieldName)) {
-            validation = TextValidationUtil.validateDescription(fieldValue);
-        } else {
-            validation = TextValidationUtil.validateText(fieldValue);
+    private PutQuerySetRequest prepareLlmRandomQuerySetRequest(Map<String, Object> source) {
+        String name = validateFieldOrThrow(source.get(NAME), "name");
+        String description = source.get(DESCRIPTION) != null ? validateFieldOrThrow(source.get(DESCRIPTION), "description") : null;
+        String sampling = validateSampling(source.getOrDefault(SAMPLING, LLM_RANDOM));
+        if (!LLM_RANDOM.equals(sampling)) {
+            throw new IllegalArgumentException("Sampling must be '" + LLM_RANDOM + "' for generating query sets by LLM");
         }
+        String indexName = validateFieldOrThrow(source.get(INDEX), INDEX);
+        int numberOfQueryTerms = parseNumberOfQueryTerms(source);
+        String modelId = validateFieldOrThrow(source.get(MODEL_ID), MODEL_ID);
+        List<String> categories = parseCategories(source);
 
-        if (!validation.isValid()) {
-            return channel -> channel.sendResponse(
-                new BytesRestResponse(RestStatus.BAD_REQUEST, "Invalid " + fieldName + ": " + validation.getErrorMessage())
-            );
+        List<String> contextFields = ParserUtils.convertObjToList(source, CONTEXT_FIELDS);
+        if (contextFields.isEmpty()) {
+            throw new IllegalArgumentException("ContextFields cannot be empty");
         }
-        return null;
+        return new PutQuerySetRequest(
+            name,
+            description,
+            sampling,
+            Collections.emptyList(),
+            indexName,
+            modelId,
+            numberOfQueryTerms,
+            contextFields,
+            categories
+        );
     }
 
+    private PutQuerySetRequest prepareManualQuerySetRequest(Map<String, Object> source) {
+        String name = validateFieldOrThrow(source.get(NAME), "name");
+        String description = source.get(DESCRIPTION) != null ? validateFieldOrThrow(source.get(DESCRIPTION), "description") : null;
+        Object samplingObj = source.getOrDefault(SAMPLING, MANUAL);
+        if (!(samplingObj instanceof String)) {
+            throw new IllegalArgumentException("sampling must be a string");
+        }
+        String sampling = (String) samplingObj;
+        if (!MANUAL.equals(sampling)) {
+            throw new IllegalArgumentException("Sampling must be '" + MANUAL + "' for manual query sets");
+        }
+        if (source.get(MODEL_ID) != null) {
+            throw new IllegalArgumentException("modelId is not allowed for manual query sets");
+        }
+        if (source.get(INDEX) != null) {
+            throw new IllegalArgumentException("index is not allowed for manual query sets");
+        }
+        if (source.get(CONTEXT_FIELDS) != null) {
+            throw new IllegalArgumentException("contextFields is not allowed for manual query sets");
+        }
+        if (source.get(CATEGORIES) != null) {
+            throw new IllegalArgumentException("categories is not allowed for manual query sets");
+        }
+        List<QueryWithReference> querySetQueries = parseAndValidateManualQuerySet(source);
+        return new PutQuerySetRequest(name, description, sampling, querySetQueries);
+    }
+
+    private String validateSampling(Object value) {
+        if (!MANUAL.equals(value) && !LLM_RANDOM.equals(value)) {
+            throw new IllegalArgumentException("Invalid sampling: must be '" + MANUAL + "' or '" + LLM_RANDOM + "'");
+        }
+        return (String) value;
+    }
+
+    private int parseNumberOfQueryTerms(Map<String, Object> source) {
+        Object rawValue = source.getOrDefault(NUMBER_OF_QUERY_TERMS, DEFAULT_NUMBER_OF_QUERY_TERMS);
+        if (rawValue instanceof Number) {
+            int value = ((Number) rawValue).intValue();
+            if (value <= 0 || value > 10000) {
+                throw new IllegalArgumentException("numberOfQueryTerms must be between 1 and 10000");
+            }
+            return value;
+        }
+        throw new IllegalArgumentException("Invalid numberOfQueryTerms: must be a number");
+    }
+
+    private List<String> parseCategories(Map<String, Object> source) {
+        List<String> categories = ParserUtils.convertObjToList(source, CATEGORIES);
+        if (categories.isEmpty()) {
+            return DEFAULT_CATEGORIES;
+        }
+        if (categories.size() != new HashSet<>(categories).size()) {
+            throw new IllegalArgumentException("Duplicate categories are not allowed");
+        }
+        if (!DEFAULT_CATEGORIES.containsAll(categories)) {
+            throw new IllegalArgumentException("Invalid categories: must be '" + LEXICAL + "' and/or '" + SEMANTIC + "'");
+        }
+        return categories;
+    }
+
+    private String validateFieldOrThrow(Object fieldValue, String fieldName) {
+        if (!(fieldValue instanceof String value)) {
+            throw new IllegalArgumentException("Invalid " + fieldName + ": must be a string");
+        }
+        TextValidationUtil.ValidationResult validation;
+        if ("name".equals(fieldName)) {
+            validation = TextValidationUtil.validateName(value);
+        } else if ("description".equals(fieldName)) {
+            validation = TextValidationUtil.validateDescription(value);
+        } else {
+            validation = TextValidationUtil.validateText(value);
+        }
+        if (!validation.isValid()) {
+            throw new IllegalArgumentException("Invalid " + fieldName + ": " + validation.getErrorMessage());
+        }
+        return value;
+    }
+
+    @SuppressWarnings("unchecked")
+    private List<QueryWithReference> parseAndValidateManualQuerySet(Map<String, Object> source) {
+        Object rawQueriesObj = source.get(QUERY_SET_QUERIES);
+        if (!(rawQueriesObj instanceof List)) {
+            throw new IllegalArgumentException("Query set queries must be a list");
+        }
+        List<Object> rawQueries = (List<Object>) rawQueriesObj;
+        if (rawQueries.isEmpty()) {
+            throw new IllegalArgumentException("Query set queries cannot be empty for manual sampling");
+        }
+        if (rawQueries.size() > settingsAccessor.getMaxQuerySetAllowed()) {
+            throw new IllegalStateException("Query Set Limit Exceeded.");
+        }
+
+        return rawQueries.stream().map(obj -> {
+            if (!(obj instanceof Map)) {
+                throw new IllegalArgumentException("Each query must be a JSON object");
+            }
+            @SuppressWarnings("unchecked")
+            Map<String, Object> queryMap = (Map<String, Object>) obj;
+            TextValidationUtil.QueryValidationResult validationResult = TextValidationUtil.validateAndParseQuery(queryMap);
+            if (!validationResult.isValid()) {
+                throw new IllegalArgumentException(validationResult.getErrorMessage());
+            }
+            return validationResult.getQueryWithReference();
+        }).collect(Collectors.toList());
+    }
 }

--- a/src/main/java/org/opensearch/searchrelevance/transport/queryset/PostQuerySetTransportAction.java
+++ b/src/main/java/org/opensearch/searchrelevance/transport/queryset/PostQuerySetTransportAction.java
@@ -25,8 +25,10 @@ import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.rest.RestStatus;
 import org.opensearch.searchrelevance.dao.QuerySetDao;
 import org.opensearch.searchrelevance.exception.SearchRelevanceException;
+import org.opensearch.searchrelevance.model.AsyncStatus;
 import org.opensearch.searchrelevance.model.QuerySet;
 import org.opensearch.searchrelevance.model.QuerySetEntry;
+import org.opensearch.searchrelevance.model.QuerySetType;
 import org.opensearch.searchrelevance.ubi.QuerySampler;
 import org.opensearch.searchrelevance.utils.TimeUtils;
 import org.opensearch.tasks.Task;
@@ -98,7 +100,17 @@ public class PostQuerySetTransportAction extends HandledTransportAction<PostQuer
             .map(entry -> QuerySetEntry.Builder.builder().queryText(entry.getKey()).build())
             .collect(Collectors.toList());
 
-        QuerySet querySet = new QuerySet(id, name, description, timestamp, sampling, querySetEntries);
+        QuerySet querySet = QuerySet.builder()
+            .id(id)
+            .name(name)
+            .description(description)
+            .timestamp(timestamp)
+            .sampling(sampling)
+            .status(AsyncStatus.COMPLETED)
+            .type(QuerySetType.UBI_QUERY_SET)
+            .numberOfQueryTerms(querySetEntries.size())
+            .querySetQueries(querySetEntries)
+            .build();
         querySetDao.putQuerySet(querySet, listener);
     }
 }

--- a/src/main/java/org/opensearch/searchrelevance/transport/queryset/PutQuerySetRequest.java
+++ b/src/main/java/org/opensearch/searchrelevance/transport/queryset/PutQuerySetRequest.java
@@ -8,8 +8,10 @@
 package org.opensearch.searchrelevance.transport.queryset;
 
 import java.io.IOException;
+import java.util.Collections;
 import java.util.List;
 
+import org.opensearch.Version;
 import org.opensearch.action.ActionRequest;
 import org.opensearch.action.ActionRequestValidationException;
 import org.opensearch.common.Nullable;
@@ -20,7 +22,9 @@ import org.opensearch.searchrelevance.model.QueryWithReference;
 import reactor.util.annotation.NonNull;
 
 /**
- * Put Request supports sampling as manual, when querySetQueries is provided.
+ * Put Request for query sets. Supports both manual and LLM-based creation.
+ * LLM-specific fields (index, modelId, numberOfQueryTerms, contextFields, categories)
+ * are optional and only populated for LLM query set requests.
  */
 public class PutQuerySetRequest extends ActionRequest {
     private final String name;
@@ -28,16 +32,42 @@ public class PutQuerySetRequest extends ActionRequest {
     private final String sampling;
     private final List<QueryWithReference> querySetQueries;
 
+    // LLM-specific fields (null for manual query sets)
+    private final String index;
+    private final String modelId;
+    private final int numberOfQueryTerms;
+    private final List<String> contextFields;
+    private final List<String> categories;
+
     public PutQuerySetRequest(
         @NonNull String name,
         String description,
         @NonNull String sampling,
         @NonNull List<QueryWithReference> querySetQueries
     ) {
+        this(name, description, sampling, querySetQueries, null, null, 0, Collections.emptyList(), Collections.emptyList());
+    }
+
+    public PutQuerySetRequest(
+        @NonNull String name,
+        String description,
+        @NonNull String sampling,
+        @NonNull List<QueryWithReference> querySetQueries,
+        String index,
+        String modelId,
+        int numberOfQueryTerms,
+        @NonNull List<String> contextFields,
+        @NonNull List<String> categories
+    ) {
         this.name = name;
         this.description = description;
         this.sampling = sampling;
         this.querySetQueries = querySetQueries;
+        this.index = index;
+        this.modelId = modelId;
+        this.numberOfQueryTerms = numberOfQueryTerms;
+        this.contextFields = contextFields;
+        this.categories = categories;
     }
 
     public PutQuerySetRequest(StreamInput in) throws IOException {
@@ -46,6 +76,19 @@ public class PutQuerySetRequest extends ActionRequest {
         this.description = in.readOptionalString();
         this.sampling = in.readString();
         this.querySetQueries = in.readList(QueryWithReference::new);
+        if (in.getVersion().onOrAfter(Version.V_3_6_0)) {
+            this.index = in.readOptionalString();
+            this.modelId = in.readOptionalString();
+            this.numberOfQueryTerms = in.readInt();
+            this.contextFields = in.readStringList();
+            this.categories = in.readStringList();
+        } else {
+            this.index = null;
+            this.modelId = null;
+            this.numberOfQueryTerms = 0;
+            this.contextFields = Collections.emptyList();
+            this.categories = Collections.emptyList();
+        }
     }
 
     @Override
@@ -55,6 +98,13 @@ public class PutQuerySetRequest extends ActionRequest {
         out.writeOptionalString(description);
         out.writeString(sampling);
         out.writeList(querySetQueries);
+        if (out.getVersion().onOrAfter(Version.V_3_6_0)) {
+            out.writeOptionalString(index);
+            out.writeOptionalString(modelId);
+            out.writeInt(numberOfQueryTerms);
+            out.writeStringCollection(contextFields);
+            out.writeStringCollection(categories);
+        }
     }
 
     public String getName() {
@@ -72,6 +122,28 @@ public class PutQuerySetRequest extends ActionRequest {
 
     public List<QueryWithReference> getQuerySetQueries() {
         return querySetQueries;
+    }
+
+    @Nullable
+    public String getIndex() {
+        return index;
+    }
+
+    @Nullable
+    public String getModelId() {
+        return modelId;
+    }
+
+    public int getNumberOfQueryTerms() {
+        return numberOfQueryTerms;
+    }
+
+    public List<String> getContextFields() {
+        return contextFields;
+    }
+
+    public List<String> getCategories() {
+        return categories;
     }
 
     @Override

--- a/src/main/java/org/opensearch/searchrelevance/transport/queryset/PutQuerySetTransportAction.java
+++ b/src/main/java/org/opensearch/searchrelevance/transport/queryset/PutQuerySetTransportAction.java
@@ -7,23 +7,31 @@
  */
 package org.opensearch.searchrelevance.transport.queryset;
 
+import static org.opensearch.searchrelevance.common.PluginConstants.LLM_RANDOM;
+import static org.opensearch.searchrelevance.common.PluginConstants.MANUAL;
 import static org.opensearch.searchrelevance.model.QueryWithReference.DELIMITER;
 
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
 import org.opensearch.action.index.IndexResponse;
 import org.opensearch.action.support.ActionFilters;
 import org.opensearch.action.support.HandledTransportAction;
+import org.opensearch.cluster.metadata.MappingMetadata;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.inject.Inject;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.rest.RestStatus;
+import org.opensearch.searchrelevance.common.validator.IndexValidator;
 import org.opensearch.searchrelevance.dao.QuerySetDao;
 import org.opensearch.searchrelevance.exception.SearchRelevanceException;
+import org.opensearch.searchrelevance.model.AsyncStatus;
 import org.opensearch.searchrelevance.model.QuerySet;
 import org.opensearch.searchrelevance.model.QuerySetEntry;
+import org.opensearch.searchrelevance.model.QuerySetType;
 import org.opensearch.searchrelevance.model.QueryWithReference;
 import org.opensearch.searchrelevance.utils.TimeUtils;
 import org.opensearch.tasks.Task;
@@ -55,45 +63,87 @@ public class PutQuerySetTransportAction extends HandledTransportAction<PutQueryS
             listener.onFailure(new SearchRelevanceException("Request cannot be null", RestStatus.BAD_REQUEST));
             return;
         }
-        String id = UUID.randomUUID().toString();
-        String timestamp = TimeUtils.getTimestamp();
 
-        String name = request.getName();
-        String description = request.getDescription();
-
-        // Given sampling type by default "manual" to support manually uploaded querySetQueries.
         String sampling = request.getSampling();
-        if (!"manual".equals(sampling)) {
+        QuerySet querySet;
+        if (MANUAL.equals(sampling)) {
+            querySet = manualSampling(request);
+        } else if (LLM_RANDOM.equals(sampling)) {
+            querySet = llmRandomSampling(request, listener);
+            if (querySet == null) {
+                return;
+            }
+        } else {
             listener.onFailure(
-                new SearchRelevanceException("Support sampling as manual only. sampling: " + sampling, RestStatus.BAD_REQUEST)
+                new SearchRelevanceException(
+                    "Support sampling as manual and llm_random only. sampling: " + sampling,
+                    RestStatus.BAD_REQUEST
+                )
             );
+            return;
         }
-        List<QueryWithReference> queryWithReferenceList = request.getQuerySetQueries();
-        List<QuerySetEntry> querySetQueries = convertQuerySetQueriesList(queryWithReferenceList);
-
-        QuerySet querySet = new QuerySet(id, name, description, timestamp, sampling, querySetQueries);
         querySetDao.putQuerySet(querySet, listener);
     }
 
-    /**
-     * Query set input is a list of queryText and customizedKeyValueMap pair.
-     * Converts to format: "queryText#json_format"
-     * e.g:
-     * Input:
-     * {
-     *     "queryText": "What is OpenSearch?",
-     *     "referenceAnswer": "OpenSearch is a community-driven, open source search and analytics suite"
-     * }
-     * Output: "What is OpenSearch?#{"referenceAnswer":"OpenSearch is a community-driven, open source search and analytics suite"}"
-     *
-     * @param queryWithReferenceList - list of queryText and customizedKeyValueMap pair
-     * @return - querySetQueries as a list of QuerySetEntry objects
-     */
+    private QuerySet manualSampling(PutQuerySetRequest request) {
+        String id = UUID.randomUUID().toString();
+        String timestamp = TimeUtils.getTimestamp();
+        List<QuerySetEntry> querySetQueries = convertQuerySetQueriesList(request.getQuerySetQueries());
+        return QuerySet.builder()
+            .id(id)
+            .name(request.getName())
+            .description(request.getDescription())
+            .timestamp(timestamp)
+            .sampling(request.getSampling())
+            .status(AsyncStatus.COMPLETED)
+            .type(QuerySetType.MANUAL_QUERY_SET)
+            .numberOfQueryTerms(querySetQueries.size())
+            .querySetQueries(querySetQueries)
+            .build();
+    }
+
+    // TODO Add llm Random Sampling logic
+    private QuerySet llmRandomSampling(PutQuerySetRequest request, ActionListener<IndexResponse> listener) {
+        String index = request.getIndex();
+        if (!IndexValidator.checkIndexAndMappingExists(clusterService, index)) {
+            listener.onFailure(
+                new SearchRelevanceException(
+                    String.format(Locale.ROOT, "Index with provided name [%s] does not exist", index),
+                    RestStatus.BAD_REQUEST
+                )
+            );
+            return null;
+        }
+        try {
+            MappingMetadata mappingMetadata = clusterService.state().metadata().index(index).mapping();
+            IndexValidator.validateFieldsExistInIndexMapping(mappingMetadata, request.getContextFields());
+        } catch (IllegalArgumentException e) {
+            listener.onFailure(new SearchRelevanceException(e.getMessage(), RestStatus.BAD_REQUEST));
+            return null;
+        }
+
+        String id = UUID.randomUUID().toString();
+        String timestamp = TimeUtils.getTimestamp();
+        return QuerySet.builder()
+            .id(id)
+            .name(request.getName())
+            .description(request.getDescription())
+            .timestamp(timestamp)
+            .sampling(request.getSampling())
+            .status(AsyncStatus.COMPLETED)
+            .type(QuerySetType.LLM_QUERY_SET)
+            .numberOfQueryTerms(request.getNumberOfQueryTerms())
+            .modelId(request.getModelId())
+            .sourceIndex(request.getIndex())
+            .contextFields(request.getContextFields())
+            .categories(request.getCategories())
+            .querySetQueries(new ArrayList<>())
+            .build();
+    }
+
     private List<QuerySetEntry> convertQuerySetQueriesList(List<QueryWithReference> queryWithReferenceList) {
         return queryWithReferenceList.stream().map(queryWithReference -> {
             StringBuilder queryTextBuilder = new StringBuilder(queryWithReference.getQueryText());
-
-            // Append customizedKeyValueMap as JSON format
             if (queryWithReference.getCustomizedKeyValueMap() != null && !queryWithReference.getCustomizedKeyValueMap().isEmpty()) {
                 try {
                     queryTextBuilder.append(DELIMITER);
@@ -105,7 +155,6 @@ public class PutQuerySetTransportAction extends HandledTransportAction<PutQueryS
                     );
                 }
             }
-
             return QuerySetEntry.Builder.builder().queryText(queryTextBuilder.toString()).build();
         }).collect(Collectors.toList());
     }

--- a/src/main/java/org/opensearch/searchrelevance/ubi/QuerySampler.java
+++ b/src/main/java/org/opensearch/searchrelevance/ubi/QuerySampler.java
@@ -9,6 +9,7 @@ package org.opensearch.searchrelevance.ubi;
 
 import static org.opensearch.searchrelevance.common.PluginConstants.UBI_QUERIES_INDEX;
 
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 
@@ -57,5 +58,14 @@ public abstract class QuerySampler {
             case TopNQuerySampler.NAME -> new TopNQuerySampler(size, client, ubiQueriesIndex);
             default -> throw new SearchRelevanceException("Unknown sampler type: " + name, RestStatus.BAD_REQUEST);
         };
+    }
+
+    /**
+     * Returns the list of sampling technique names supported by UBI-based query set creation.
+     *
+     * @return list of supported UBI sampling technique names
+     */
+    public static List<String> getSamplingTechniquesSupportedByUBI() {
+        return List.of(ProbabilityProportionalToSizeQuerySampler.NAME, RandomQuerySampler.NAME, TopNQuerySampler.NAME);
     }
 }

--- a/src/main/resources/mappings/queryset.json
+++ b/src/main/resources/mappings/queryset.json
@@ -1,12 +1,19 @@
 {
   "_meta": {
-    "schema_version": 0
+    "schema_version": 1
   },
   "properties": {
     "id": { "type": "keyword" },
     "timestamp": { "type": "date", "format": "strict_date_time" },
     "name": { "type": "keyword" },
     "description": { "type": "text" },
+    "type": { "type": "keyword" },
+    "status": { "type": "keyword" },
+    "numberOfQueryTerms": { "type": "integer" },
+    "modelId": { "type": "keyword" },
+    "sourceIndex": { "type": "keyword" },
+    "contextFields": { "type": "keyword" },
+    "categories": { "type": "keyword" },
     "querySetQueries": {
       "type": "nested",
       "properties": {

--- a/src/test/java/org/opensearch/searchrelevance/action/queryset/QuerySetIT.java
+++ b/src/test/java/org/opensearch/searchrelevance/action/queryset/QuerySetIT.java
@@ -66,6 +66,9 @@ public class QuerySetIT extends BaseSearchRelevanceIT {
         assertNotNull(source.get("id"));
         assertEquals("query_set", source.get("name"));
         assertEquals("Test query set", source.get("description"));
+        assertEquals("COMPLETED", source.get("status"));
+        assertEquals("manual_query_set", source.get("type"));
+        assertEquals(8, ((Number) source.get("numberOfQueryTerms")).intValue());
 
         String searchBody = "{" + "\"query\": {" + "\"term\": {" + "\"id\": \"" + querySetId + "\"" + "}" + "}" + "}";
         Response searchResponse = makeRequest(

--- a/src/test/java/org/opensearch/searchrelevance/common/validator/IndexValidatorTests.java
+++ b/src/test/java/org/opensearch/searchrelevance/common/validator/IndexValidatorTests.java
@@ -1,0 +1,127 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+package org.opensearch.searchrelevance.common.validator;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.Map;
+
+import org.opensearch.cluster.ClusterState;
+import org.opensearch.cluster.metadata.IndexMetadata;
+import org.opensearch.cluster.metadata.MappingMetadata;
+import org.opensearch.cluster.metadata.Metadata;
+import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.test.OpenSearchTestCase;
+
+public class IndexValidatorTests extends OpenSearchTestCase {
+
+    public void testCheckIndexAndMappingExists_ValidIndex() {
+        ClusterService clusterService = mock(ClusterService.class);
+        ClusterState clusterState = mock(ClusterState.class);
+        Metadata metadata = mock(Metadata.class);
+        IndexMetadata indexMetadata = mock(IndexMetadata.class);
+        MappingMetadata mappingMetadata = mock(MappingMetadata.class);
+
+        when(clusterService.state()).thenReturn(clusterState);
+        when(clusterState.metadata()).thenReturn(metadata);
+        when(metadata.hasIndex("my-index")).thenReturn(true);
+        when(metadata.index("my-index")).thenReturn(indexMetadata);
+        when(indexMetadata.mapping()).thenReturn(mappingMetadata);
+
+        assertTrue(IndexValidator.checkIndexAndMappingExists(clusterService, "my-index"));
+    }
+
+    public void testCheckIndexAndMappingExists_IndexNotFound() {
+        ClusterService clusterService = mock(ClusterService.class);
+        ClusterState clusterState = mock(ClusterState.class);
+        Metadata metadata = mock(Metadata.class);
+
+        when(clusterService.state()).thenReturn(clusterState);
+        when(clusterState.metadata()).thenReturn(metadata);
+        when(metadata.hasIndex("missing-index")).thenReturn(false);
+
+        assertFalse(IndexValidator.checkIndexAndMappingExists(clusterService, "missing-index"));
+    }
+
+    public void testCheckIndexAndMappingExists_NullMapping() {
+        ClusterService clusterService = mock(ClusterService.class);
+        ClusterState clusterState = mock(ClusterState.class);
+        Metadata metadata = mock(Metadata.class);
+        IndexMetadata indexMetadata = mock(IndexMetadata.class);
+
+        when(clusterService.state()).thenReturn(clusterState);
+        when(clusterState.metadata()).thenReturn(metadata);
+        when(metadata.hasIndex("no-mapping")).thenReturn(true);
+        when(metadata.index("no-mapping")).thenReturn(indexMetadata);
+        when(indexMetadata.mapping()).thenReturn(null);
+
+        assertFalse(IndexValidator.checkIndexAndMappingExists(clusterService, "no-mapping"));
+    }
+
+    public void testCheckIndexAndMappingExists_NullClusterService() {
+        assertFalse(IndexValidator.checkIndexAndMappingExists(null, "any-index"));
+    }
+
+    public void testValidateFieldsExistInIndexMapping_AllFieldsExist() {
+        MappingMetadata mappingMetadata = mock(MappingMetadata.class);
+        when(mappingMetadata.sourceAsMap()).thenReturn(
+            Map.of("properties", Map.of("field1", Map.of("type", "text"), "field2", Map.of("type", "keyword")))
+        );
+
+        // Should not throw
+        IndexValidator.validateFieldsExistInIndexMapping(mappingMetadata, List.of("field1", "field2"));
+    }
+
+    public void testValidateFieldsExistInIndexMapping_SomeFieldsMissing() {
+        MappingMetadata mappingMetadata = mock(MappingMetadata.class);
+        when(mappingMetadata.sourceAsMap()).thenReturn(Map.of("properties", Map.of("field1", Map.of("type", "text"))));
+
+        IllegalArgumentException exception = expectThrows(
+            IllegalArgumentException.class,
+            () -> IndexValidator.validateFieldsExistInIndexMapping(mappingMetadata, List.of("field1", "missing_field"))
+        );
+        assertTrue(exception.getMessage().contains("missing_field"));
+        assertTrue(exception.getMessage().contains("do not exist"));
+    }
+
+    public void testValidateFieldsExistInIndexMapping_NestedField() {
+        MappingMetadata mappingMetadata = mock(MappingMetadata.class);
+        when(mappingMetadata.sourceAsMap()).thenReturn(
+            Map.of("properties", Map.of("parent", Map.of("properties", Map.of("child", Map.of("type", "text")))))
+        );
+
+        // Should not throw
+        IndexValidator.validateFieldsExistInIndexMapping(mappingMetadata, List.of("parent.child"));
+    }
+
+    public void testValidateFieldsExistInIndexMapping_NestedFieldMissing() {
+        MappingMetadata mappingMetadata = mock(MappingMetadata.class);
+        when(mappingMetadata.sourceAsMap()).thenReturn(
+            Map.of("properties", Map.of("parent", Map.of("properties", Map.of("child", Map.of("type", "text")))))
+        );
+
+        IllegalArgumentException exception = expectThrows(
+            IllegalArgumentException.class,
+            () -> IndexValidator.validateFieldsExistInIndexMapping(mappingMetadata, List.of("parent.missing"))
+        );
+        assertTrue(exception.getMessage().contains("parent.missing"));
+    }
+
+    public void testValidateFieldsExistInIndexMapping_NoProperties() {
+        MappingMetadata mappingMetadata = mock(MappingMetadata.class);
+        when(mappingMetadata.sourceAsMap()).thenReturn(Map.of());
+
+        IllegalArgumentException exception = expectThrows(
+            IllegalArgumentException.class,
+            () -> IndexValidator.validateFieldsExistInIndexMapping(mappingMetadata, List.of("any_field"))
+        );
+        assertTrue(exception.getMessage().contains("any_field"));
+    }
+}

--- a/src/test/java/org/opensearch/searchrelevance/dao/QuerySetDaoTests.java
+++ b/src/test/java/org/opensearch/searchrelevance/dao/QuerySetDaoTests.java
@@ -1,0 +1,136 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+package org.opensearch.searchrelevance.dao;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.lucene.search.TotalHits;
+import org.junit.Before;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.opensearch.action.search.SearchResponse;
+import org.opensearch.search.SearchHit;
+import org.opensearch.search.SearchHits;
+import org.opensearch.searchrelevance.indices.SearchRelevanceIndicesManager;
+import org.opensearch.searchrelevance.model.AsyncStatus;
+import org.opensearch.searchrelevance.model.QuerySet;
+import org.opensearch.searchrelevance.model.QuerySetType;
+import org.opensearch.test.OpenSearchTestCase;
+
+public class QuerySetDaoTests extends OpenSearchTestCase {
+
+    @Mock
+    private SearchRelevanceIndicesManager searchRelevanceIndicesManager;
+
+    private QuerySetDao querySetDao;
+
+    @Before
+    public void setup() {
+        MockitoAnnotations.openMocks(this);
+        querySetDao = new QuerySetDao(searchRelevanceIndicesManager);
+    }
+
+    public void testConvertToQuerySet_AllFieldsPresent() {
+        Map<String, Object> sourceMap = new HashMap<>();
+        sourceMap.put("id", "qs-1");
+        sourceMap.put("name", "test-qs");
+        sourceMap.put("description", "test desc");
+        sourceMap.put("timestamp", "2024-01-01T00:00:00Z");
+        sourceMap.put("sampling", "manual");
+        sourceMap.put("status", "COMPLETED");
+        sourceMap.put("type", "manual_query_set");
+        sourceMap.put("numberOfQueryTerms", 3);
+        sourceMap.put("querySetQueries", List.of(Map.of("queryText", "q1"), Map.of("queryText", "q2"), Map.of("queryText", "q3")));
+
+        SearchResponse response = buildSearchResponse(sourceMap);
+        QuerySet querySet = querySetDao.convertToQuerySet(response);
+
+        assertEquals("qs-1", querySet.getId());
+        assertEquals("test-qs", querySet.getName());
+        assertEquals("manual", querySet.getSampling());
+        assertEquals(AsyncStatus.COMPLETED, querySet.getStatus());
+        assertEquals(QuerySetType.MANUAL_QUERY_SET, querySet.getType());
+        assertEquals(3, querySet.getNumberOfQueryTerms());
+        assertEquals(3, querySet.getQuerySetQueries().size());
+    }
+
+    public void testConvertToQuerySet_MissingNewFields_ManualSampling() {
+        Map<String, Object> sourceMap = new HashMap<>();
+        sourceMap.put("id", "qs-old");
+        sourceMap.put("name", "old-qs");
+        sourceMap.put("timestamp", "2024-01-01T00:00:00Z");
+        sourceMap.put("sampling", "manual");
+        sourceMap.put("querySetQueries", List.of(Map.of("queryText", "q1")));
+
+        SearchResponse response = buildSearchResponse(sourceMap);
+        QuerySet querySet = querySetDao.convertToQuerySet(response);
+
+        assertEquals(AsyncStatus.COMPLETED, querySet.getStatus());
+        assertEquals(QuerySetType.MANUAL_QUERY_SET, querySet.getType());
+        assertEquals(1, querySet.getNumberOfQueryTerms());
+    }
+
+    public void testConvertToQuerySet_MissingNewFields_UbiSampling() {
+        Map<String, Object> sourceMap = new HashMap<>();
+        sourceMap.put("id", "qs-ubi");
+        sourceMap.put("name", "ubi-qs");
+        sourceMap.put("timestamp", "2024-01-01T00:00:00Z");
+        sourceMap.put("sampling", "pptss");
+        sourceMap.put("querySetQueries", List.of(Map.of("queryText", "q1"), Map.of("queryText", "q2")));
+
+        SearchResponse response = buildSearchResponse(sourceMap);
+        QuerySet querySet = querySetDao.convertToQuerySet(response);
+
+        assertEquals(AsyncStatus.COMPLETED, querySet.getStatus());
+        assertEquals(QuerySetType.UBI_QUERY_SET, querySet.getType());
+        assertEquals(2, querySet.getNumberOfQueryTerms());
+    }
+
+    public void testConvertToQuerySet_EmptyResponse() {
+        SearchResponse response = mock(SearchResponse.class);
+        SearchHits searchHits = new SearchHits(new SearchHit[0], new TotalHits(0, TotalHits.Relation.EQUAL_TO), 0.0f);
+        when(response.getHits()).thenReturn(searchHits);
+
+        expectThrows(ArrayIndexOutOfBoundsException.class, () -> querySetDao.convertToQuerySet(response));
+    }
+
+    public void testConvertToQuerySet_NoQuerySetQueries() {
+        Map<String, Object> sourceMap = new HashMap<>();
+        sourceMap.put("id", "qs-empty");
+        sourceMap.put("name", "empty-qs");
+        sourceMap.put("timestamp", "2024-01-01T00:00:00Z");
+        sourceMap.put("sampling", "manual");
+        sourceMap.put("status", "COMPLETED");
+        sourceMap.put("type", "manual_query_set");
+        sourceMap.put("numberOfQueryTerms", 0);
+
+        SearchResponse response = buildSearchResponse(sourceMap);
+        QuerySet querySet = querySetDao.convertToQuerySet(response);
+
+        assertTrue(querySet.getQuerySetQueries().isEmpty());
+        assertEquals(0, querySet.getNumberOfQueryTerms());
+    }
+
+    private SearchResponse buildSearchResponse(Map<String, Object> sourceMap) {
+        SearchHit hit = new SearchHit(1);
+        hit.sourceRef(
+            new org.opensearch.core.common.bytes.BytesArray(
+                new com.fasterxml.jackson.databind.ObjectMapper().valueToTree(sourceMap).toString()
+            )
+        );
+        SearchHits searchHits = new SearchHits(new SearchHit[] { hit }, new TotalHits(1, TotalHits.Relation.EQUAL_TO), 1.0f);
+        SearchResponse response = mock(SearchResponse.class);
+        when(response.getHits()).thenReturn(searchHits);
+        return response;
+    }
+}

--- a/src/test/java/org/opensearch/searchrelevance/indices/SearchRelevanceIndicesManagerTests.java
+++ b/src/test/java/org/opensearch/searchrelevance/indices/SearchRelevanceIndicesManagerTests.java
@@ -57,7 +57,9 @@ import org.opensearch.search.SearchHits;
 import org.opensearch.search.builder.SearchSourceBuilder;
 import org.opensearch.search.sort.SortOrder;
 import org.opensearch.searchrelevance.exception.SearchRelevanceException;
+import org.opensearch.searchrelevance.model.AsyncStatus;
 import org.opensearch.searchrelevance.model.QuerySet;
+import org.opensearch.searchrelevance.model.QuerySetType;
 import org.opensearch.test.OpenSearchTestCase;
 import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.transport.client.AdminClient;
@@ -160,7 +162,17 @@ public class SearchRelevanceIndicesManagerTests extends OpenSearchTestCase {
     }
 
     public void testPutDocWhenSucceeded() throws IOException {
-        QuerySet querySet = new QuerySet("test_id", "test_name", "test_description", "test_timestamp", "test_sampling", List.of());
+        QuerySet querySet = QuerySet.builder()
+            .id("test_id")
+            .name("test_name")
+            .description("test_description")
+            .timestamp("test_timestamp")
+            .sampling("test_sampling")
+            .status(AsyncStatus.COMPLETED)
+            .type(QuerySetType.MANUAL_QUERY_SET)
+            .numberOfQueryTerms(0)
+            .querySetQueries(List.of())
+            .build();
         XContentBuilder xContentBuilder = querySet.toXContent(XContentFactory.jsonBuilder(), ToXContent.EMPTY_PARAMS);
 
         IndexRequestBuilder indexRequestBuilder = mock(IndexRequestBuilder.class);
@@ -182,7 +194,17 @@ public class SearchRelevanceIndicesManagerTests extends OpenSearchTestCase {
     }
 
     public void testPutDocWhenFailed() throws IOException {
-        QuerySet querySet = new QuerySet("test_id", "test_name", "test_description", "test_timestamp", "test_sampling", List.of());
+        QuerySet querySet = QuerySet.builder()
+            .id("test_id")
+            .name("test_name")
+            .description("test_description")
+            .timestamp("test_timestamp")
+            .sampling("test_sampling")
+            .status(AsyncStatus.COMPLETED)
+            .type(QuerySetType.MANUAL_QUERY_SET)
+            .numberOfQueryTerms(0)
+            .querySetQueries(List.of())
+            .build();
         XContentBuilder xContentBuilder = querySet.toXContent(XContentFactory.jsonBuilder(), ToXContent.EMPTY_PARAMS);
 
         when(client.prepareIndex(QUERY_SET.getIndexName())).thenThrow(
@@ -202,7 +224,17 @@ public class SearchRelevanceIndicesManagerTests extends OpenSearchTestCase {
 
     public void testGetDocByDocIdWhenSucceeded() throws IOException {
         String docId = "test_id";
-        QuerySet querySet = new QuerySet(docId, "test_name", "test_description", "test_timestamp", "test_sampling", List.of());
+        QuerySet querySet = QuerySet.builder()
+            .id(docId)
+            .name("test_name")
+            .description("test_description")
+            .timestamp("test_timestamp")
+            .sampling("test_sampling")
+            .status(AsyncStatus.COMPLETED)
+            .type(QuerySetType.MANUAL_QUERY_SET)
+            .numberOfQueryTerms(0)
+            .querySetQueries(List.of())
+            .build();
         XContentBuilder xContentBuilder = querySet.toXContent(XContentFactory.jsonBuilder(), ToXContent.EMPTY_PARAMS);
 
         Map<String, Object> sourceMap = new HashMap<>();
@@ -267,8 +299,28 @@ public class SearchRelevanceIndicesManagerTests extends OpenSearchTestCase {
     }
 
     public void testListDocsWhenSucceeded() throws IOException {
-        QuerySet querySet1 = new QuerySet("id1", "name1", "desc1", "timestamp1", "sampling1", List.of());
-        QuerySet querySet2 = new QuerySet("id2", "name2", "desc2", "timestamp2", "sampling2", List.of());
+        QuerySet querySet1 = QuerySet.builder()
+            .id("id1")
+            .name("name1")
+            .description("desc1")
+            .timestamp("timestamp1")
+            .sampling("sampling1")
+            .status(AsyncStatus.COMPLETED)
+            .type(QuerySetType.MANUAL_QUERY_SET)
+            .numberOfQueryTerms(0)
+            .querySetQueries(List.of())
+            .build();
+        QuerySet querySet2 = QuerySet.builder()
+            .id("id2")
+            .name("name2")
+            .description("desc2")
+            .timestamp("timestamp2")
+            .sampling("sampling2")
+            .status(AsyncStatus.COMPLETED)
+            .type(QuerySetType.MANUAL_QUERY_SET)
+            .numberOfQueryTerms(0)
+            .querySetQueries(List.of())
+            .build();
 
         SearchHit[] hits = new SearchHit[] {
             new SearchHit(1, "id1", Map.of(), Map.of()).sourceRef(
@@ -433,7 +485,17 @@ public class SearchRelevanceIndicesManagerTests extends OpenSearchTestCase {
         when(indicesAdminClient.create(any(CreateIndexRequest.class))).thenReturn(createFuture);
 
         // Execute via putDoc (which calls executeWithIndexCreationSynchronizedMode -> createIndexIfAbsentSync)
-        QuerySet querySet = new QuerySet("test_id", "test_name", "test_description", "test_timestamp", "test_sampling", List.of());
+        QuerySet querySet = QuerySet.builder()
+            .id("test_id")
+            .name("test_name")
+            .description("test_description")
+            .timestamp("test_timestamp")
+            .sampling("test_sampling")
+            .status(AsyncStatus.COMPLETED)
+            .type(QuerySetType.MANUAL_QUERY_SET)
+            .numberOfQueryTerms(0)
+            .querySetQueries(List.of())
+            .build();
         XContentBuilder xContentBuilder = querySet.toXContent(XContentFactory.jsonBuilder(), ToXContent.EMPTY_PARAMS);
 
         IndexRequestBuilder indexRequestBuilder = mock(IndexRequestBuilder.class);
@@ -473,7 +535,17 @@ public class SearchRelevanceIndicesManagerTests extends OpenSearchTestCase {
         when(mappingMetadata.sourceAsMap()).thenReturn(mappingSource);
 
         // Execute via putDoc
-        QuerySet querySet = new QuerySet("test_id", "test_name", "test_description", "test_timestamp", "test_sampling", List.of());
+        QuerySet querySet = QuerySet.builder()
+            .id("test_id")
+            .name("test_name")
+            .description("test_description")
+            .timestamp("test_timestamp")
+            .sampling("test_sampling")
+            .status(AsyncStatus.COMPLETED)
+            .type(QuerySetType.MANUAL_QUERY_SET)
+            .numberOfQueryTerms(0)
+            .querySetQueries(List.of())
+            .build();
         XContentBuilder xContentBuilder = querySet.toXContent(XContentFactory.jsonBuilder(), ToXContent.EMPTY_PARAMS);
 
         IndexRequestBuilder indexRequestBuilder = mock(IndexRequestBuilder.class);
@@ -496,9 +568,9 @@ public class SearchRelevanceIndicesManagerTests extends OpenSearchTestCase {
      * Test that when index exists without _meta.schema_version (legacy index, version 0),
      * NO mapping update occurs when current version is also 0.
      */
-    public void testCreateIndexIfAbsentSync_LegacyIndexWithoutSchemaVersion_NoUpdate() throws IOException {
+    public void testCreateIndexIfAbsentSync_LegacyIndexWithoutSchemaVersion_TriggersUpdate() throws IOException {
         // Setup: index exists with no schema version (legacy index = version 0)
-        // Current JSON schema_version is also 0, so no update needed
+        // Current JSON schema_version is 1, so update is needed
         when(metadata.hasIndex(QUERY_SET.getIndexName())).thenReturn(true);
 
         // Mock IndexMetadata with no _meta field (legacy index)
@@ -512,8 +584,25 @@ public class SearchRelevanceIndicesManagerTests extends OpenSearchTestCase {
         mappingSource.put("properties", new HashMap<>());
         when(mappingMetadata.sourceAsMap()).thenReturn(mappingSource);
 
+        // Mock putMapping with 2-arg overload (request, listener) used by updateMappingSync
+        doAnswer(invocation -> {
+            ActionListener<org.opensearch.action.support.clustermanager.AcknowledgedResponse> actionListener = invocation.getArgument(1);
+            actionListener.onResponse(new org.opensearch.action.support.clustermanager.AcknowledgedResponse(true));
+            return null;
+        }).when(indicesAdminClient).putMapping(any(PutMappingRequest.class), any(ActionListener.class));
+
         // Execute via putDoc
-        QuerySet querySet = new QuerySet("test_id", "test_name", "test_description", "test_timestamp", "test_sampling", List.of());
+        QuerySet querySet = QuerySet.builder()
+            .id("test_id")
+            .name("test_name")
+            .description("test_description")
+            .timestamp("test_timestamp")
+            .sampling("test_sampling")
+            .status(AsyncStatus.COMPLETED)
+            .type(QuerySetType.MANUAL_QUERY_SET)
+            .numberOfQueryTerms(0)
+            .querySetQueries(List.of())
+            .build();
         XContentBuilder xContentBuilder = querySet.toXContent(XContentFactory.jsonBuilder(), ToXContent.EMPTY_PARAMS);
 
         IndexRequestBuilder indexRequestBuilder = mock(IndexRequestBuilder.class);
@@ -527,9 +616,9 @@ public class SearchRelevanceIndicesManagerTests extends OpenSearchTestCase {
         ActionListener<SearchResponse> listener = mock(ActionListener.class);
         indicesManager.putDoc("test_id", xContentBuilder, QUERY_SET, listener);
 
-        // Verify: create index NOT called, putMapping NOT called (version 0 >= 0)
+        // Verify: create index NOT called, putMapping IS called (version 0 < 1)
         verify(indicesAdminClient, never()).create(any(CreateIndexRequest.class), any(ActionListener.class));
-        verify(indicesAdminClient, never()).putMapping(any(PutMappingRequest.class), any(ActionListener.class));
+        verify(indicesAdminClient).putMapping(any(PutMappingRequest.class), any(ActionListener.class));
     }
 
     /**
@@ -545,7 +634,17 @@ public class SearchRelevanceIndicesManagerTests extends OpenSearchTestCase {
         when(indexMetadata.mapping()).thenReturn(null); // No mapping = unexpected state
 
         // Execute via putDoc
-        QuerySet querySet = new QuerySet("test_id", "test_name", "test_description", "test_timestamp", "test_sampling", List.of());
+        QuerySet querySet = QuerySet.builder()
+            .id("test_id")
+            .name("test_name")
+            .description("test_description")
+            .timestamp("test_timestamp")
+            .sampling("test_sampling")
+            .status(AsyncStatus.COMPLETED)
+            .type(QuerySetType.MANUAL_QUERY_SET)
+            .numberOfQueryTerms(0)
+            .querySetQueries(List.of())
+            .build();
         XContentBuilder xContentBuilder = querySet.toXContent(XContentFactory.jsonBuilder(), ToXContent.EMPTY_PARAMS);
 
         IndexRequestBuilder indexRequestBuilder = mock(IndexRequestBuilder.class);
@@ -588,7 +687,17 @@ public class SearchRelevanceIndicesManagerTests extends OpenSearchTestCase {
         when(mappingMetadata.sourceAsMap()).thenReturn(mappingSource);
 
         // Execute via putDoc
-        QuerySet querySet = new QuerySet("test_id", "test_name", "test_description", "test_timestamp", "test_sampling", List.of());
+        QuerySet querySet = QuerySet.builder()
+            .id("test_id")
+            .name("test_name")
+            .description("test_description")
+            .timestamp("test_timestamp")
+            .sampling("test_sampling")
+            .status(AsyncStatus.COMPLETED)
+            .type(QuerySetType.MANUAL_QUERY_SET)
+            .numberOfQueryTerms(0)
+            .querySetQueries(List.of())
+            .build();
         XContentBuilder xContentBuilder = querySet.toXContent(XContentFactory.jsonBuilder(), ToXContent.EMPTY_PARAMS);
 
         IndexRequestBuilder indexRequestBuilder = mock(IndexRequestBuilder.class);
@@ -629,7 +738,17 @@ public class SearchRelevanceIndicesManagerTests extends OpenSearchTestCase {
         when(mappingMetadata.sourceAsMap()).thenReturn(mappingSource);
 
         // Execute via putDoc
-        QuerySet querySet = new QuerySet("test_id", "test_name", "test_description", "test_timestamp", "test_sampling", List.of());
+        QuerySet querySet = QuerySet.builder()
+            .id("test_id")
+            .name("test_name")
+            .description("test_description")
+            .timestamp("test_timestamp")
+            .sampling("test_sampling")
+            .status(AsyncStatus.COMPLETED)
+            .type(QuerySetType.MANUAL_QUERY_SET)
+            .numberOfQueryTerms(0)
+            .querySetQueries(List.of())
+            .build();
         XContentBuilder xContentBuilder = querySet.toXContent(XContentFactory.jsonBuilder(), ToXContent.EMPTY_PARAMS);
 
         IndexRequestBuilder indexRequestBuilder = mock(IndexRequestBuilder.class);
@@ -680,7 +799,17 @@ public class SearchRelevanceIndicesManagerTests extends OpenSearchTestCase {
         }).when(indicesAdminClient).putMapping(any(PutMappingRequest.class), any(ActionListener.class));
 
         // Execute via putDoc
-        QuerySet querySet = new QuerySet("test_id", "test_name", "test_description", "test_timestamp", "test_sampling", List.of());
+        QuerySet querySet = QuerySet.builder()
+            .id("test_id")
+            .name("test_name")
+            .description("test_description")
+            .timestamp("test_timestamp")
+            .sampling("test_sampling")
+            .status(AsyncStatus.COMPLETED)
+            .type(QuerySetType.MANUAL_QUERY_SET)
+            .numberOfQueryTerms(0)
+            .querySetQueries(List.of())
+            .build();
         XContentBuilder xContentBuilder = querySet.toXContent(XContentFactory.jsonBuilder(), ToXContent.EMPTY_PARAMS);
 
         IndexRequestBuilder indexRequestBuilder = mock(IndexRequestBuilder.class);
@@ -724,7 +853,17 @@ public class SearchRelevanceIndicesManagerTests extends OpenSearchTestCase {
             return null;
         }).when(indicesAdminClient).putMapping(any(PutMappingRequest.class), any(ActionListener.class));
 
-        QuerySet querySet = new QuerySet("test_id", "test_name", "test_description", "test_timestamp", "test_sampling", List.of());
+        QuerySet querySet = QuerySet.builder()
+            .id("test_id")
+            .name("test_name")
+            .description("test_description")
+            .timestamp("test_timestamp")
+            .sampling("test_sampling")
+            .status(AsyncStatus.COMPLETED)
+            .type(QuerySetType.MANUAL_QUERY_SET)
+            .numberOfQueryTerms(0)
+            .querySetQueries(List.of())
+            .build();
         XContentBuilder xContentBuilder = querySet.toXContent(XContentFactory.jsonBuilder(), ToXContent.EMPTY_PARAMS);
 
         IndexRequestBuilder indexRequestBuilder = mock(IndexRequestBuilder.class);

--- a/src/test/java/org/opensearch/searchrelevance/indices/SearchRelevanceIndicesManagerTests.java
+++ b/src/test/java/org/opensearch/searchrelevance/indices/SearchRelevanceIndicesManagerTests.java
@@ -678,9 +678,9 @@ public class SearchRelevanceIndicesManagerTests extends OpenSearchTestCase {
         when(metadata.index(QUERY_SET.getIndexName())).thenReturn(indexMetadata);
         when(indexMetadata.mapping()).thenReturn(mappingMetadata);
 
-        // Set explicit schema_version = 0 (same as current JSON version)
+        // Set explicit schema_version = 1 (same as current JSON version)
         Map<String, Object> metaMap = new HashMap<>();
-        metaMap.put(SearchRelevanceIndices.META_SCHEMA_VERSION_KEY, 0);
+        metaMap.put(SearchRelevanceIndices.META_SCHEMA_VERSION_KEY, QUERY_SET.getSchemaVersion());
         Map<String, Object> mappingSource = new HashMap<>();
         mappingSource.put("_meta", metaMap);
         mappingSource.put("properties", new HashMap<>());
@@ -711,7 +711,7 @@ public class SearchRelevanceIndicesManagerTests extends OpenSearchTestCase {
         ActionListener<SearchResponse> listener = mock(ActionListener.class);
         indicesManager.putDoc("test_id", xContentBuilder, QUERY_SET, listener);
 
-        // Verify: putMapping NOT called (explicit version 0 >= current version 0)
+        // Verify: putMapping NOT called (explicit version >= current version)
         verify(indicesAdminClient, never()).create(any(CreateIndexRequest.class), any(ActionListener.class));
         verify(indicesAdminClient, never()).putMapping(any(PutMappingRequest.class), any(ActionListener.class));
     }

--- a/src/test/java/org/opensearch/searchrelevance/transport/experiment/PutExperimentTransportActionTests.java
+++ b/src/test/java/org/opensearch/searchrelevance/transport/experiment/PutExperimentTransportActionTests.java
@@ -40,6 +40,7 @@ import org.opensearch.searchrelevance.metrics.MetricsHelper;
 import org.opensearch.searchrelevance.model.AsyncStatus;
 import org.opensearch.searchrelevance.model.Experiment;
 import org.opensearch.searchrelevance.model.ExperimentType;
+import org.opensearch.searchrelevance.model.QuerySet;
 import org.opensearch.searchrelevance.settings.SearchRelevanceSettingsAccessor;
 import org.opensearch.test.OpenSearchTestCase;
 import org.opensearch.threadpool.ThreadPool;
@@ -134,6 +135,17 @@ public class PutExperimentTransportActionTests extends OpenSearchTestCase {
             listener.onResponse(mockQuerySetResponse);
             return null;
         }).when(querySetDao).getQuerySet(eq("test-queryset-id"), any(ActionListener.class));
+
+        when(querySetDao.convertToQuerySet(mockQuerySetResponse)).thenReturn(
+            QuerySet.builder()
+                .id("test-queryset-id")
+                .name("test-queryset")
+                .description("test description")
+                .timestamp("2023-01-01T00:00:00Z")
+                .sampling("random")
+                .querySetQueries(List.of())
+                .build()
+        );
 
         ActionListener<IndexResponse> responseListener = mock(ActionListener.class);
         transportAction.doExecute(null, request, responseListener);


### PR DESCRIPTION
## Summary                                                                                                                                                                                                        
                                                                                                                                                                                                                    
  Adds support for LLM-based query set generation alongside the existing manual and UBI-based creation flows. Introduces a `QuerySetType` enum to track how each query set was created, and extends the `QuerySet`  
  model with metadata fields needed for LLM generation (`modelId`, `sourceIndex`, `contextFields`, `categories`).                                                                                                   
                                                                                                                                                                                                                    
  ## Changes                                                                                                                                                                                                        
                                                                                                                                                                                                                    
  ### New Files                                                                                                                                                                                                     
  - **`QuerySetType`** — Enum (`llm_query_set`, `manual_query_set`, `ubi_query_set`) with `fromString` that handles both lowercase values and uppercase enum names for backward compatibility                       
  - **`IndexValidator`** — Validates index existence, mapping presence, and that context fields exist in the index mapping (supports nested fields via dot notation)                                                
                                                                                                                                                                                                                    
  ### Model & Schema                                                                                                                                                                                                
  - **`QuerySet`** — Rewritten with Lombok `@Getter`/`@Builder`. Added `status`, `type`, `numberOfQueryTerms`, `modelId`, `sourceIndex`, `contextFields`, `categories`. LLM-specific fields are conditionally       
  serialized (omitted when null/empty)                                                                                                                                                                              
  - **`queryset.json`** — Bumped `schema_version` from `0` to `1` with new mapping fields                                                                                                                           
                                                                                                                                                                                                                    
  ### Transport Layer                                                                                                                                                                                               
  - **`PutQuerySetRequest`** — Flattened LLM fields into single request class (no separate `PutLlmQuerySetRequest`). Version-gated serialization at `V_3_6_0` for rolling upgrade compatibility                     
  - **`PutQuerySetTransportAction`** — Routes between `manualSampling` and `llmRandomSampling` based on sampling type. LLM path validates index existence and context fields via `IndexValidator`                   
  - **`PostQuerySetTransportAction`** — Updated to use builder with `status`/`type` for UBI query sets                                                                                                              
                                                                                                                                                                                                                    
  ### REST Layer                                                                                                                                                                                                    
  - **`RestPutQuerySetAction`** — Rewritten with `QuerySetType.fromString` routing. Separate `prepareLlmRandomQuerySetRequest` and `prepareManualQuerySetRequest` methods. Input validation includes:               
    - `type` and `sampling` must be strings                                                                                                                                                                         
    - Only `llm_query_set` and `manual_query_set` types accepted via PUT                                                                                                                                            
    - LLM fields (`modelId`, `index`, `contextFields`, `categories`) rejected on manual requests                                                                                                                    
    - `numberOfQueryTerms` must be between 1 and 10,000                                                                                                                                                             
                                                                                                                                                                                                                    
  ### Data Layer                                                                                                                                                                                                    
  - **`QuerySetDao`** — `convertToQuerySet` made public (single source of truth). Reads all new fields. Uses `fromString` with null-safe fallback to infer type from sampling for legacy documents                  
  - **`ExperimentRunningManager`** — Removed duplicate `convertToQuerySet`, delegates to `QuerySetDao`                                                                                                              
                                                                                                                                                                                                                    
  ### Other                                                                                                                                                                                                         
  - **`PluginConstants`** — Added `LLM_RANDOM`, `MODEL_ID`, `NUMBER_OF_QUERY_TERMS`, `CATEGORIES`, `LEXICAL`, `SEMANTIC`, defaults. Fixed typo `NAX_RANK` → `MAX_RANK`                                              
  - **`QuerySampler`** — Added `getSamplingTechniquesSupportedByUBI()` for type inference in DAO                                                                                                                    
  - **`LlmJudgmentsProcessor`**, **`RestPutJudgmentAction`** — Updated for Lombok getter style and `MAX_RANK` rename                                                                                                
                                                                                                                                                                                                                    
  ## Backward Compatibility                                                                                                                                                                                         
  - `PutQuerySetRequest` serialization is version-gated at `V_3_6_0` — old nodes can still communicate with new nodes during rolling upgrades                                                                       
  - `QuerySetType.fromString` matches both `"manual_query_set"` (new format) and `"MANUAL_QUERY_SET"` (old enum name format)                                                                                        
  - `QuerySetDao` infers `type` from `sampling` field when reading legacy documents that lack the `type` field                                                                                                      
  - `queryset.json` schema version bump from 0 → 1 triggers automatic mapping migration on existing indices                                                                                                         
                                                                                                                                                                                                                    
  ## Testing                                                                                                                                                                                                        
  - **`IndexValidatorTests`** — Index existence, null mapping, null cluster service, field validation (flat + nested), missing fields                                                                               
  - **`QuerySetDaoTests`** — Round-trip with all fields, legacy documents missing new fields (manual + UBI inference), empty queries                                                                                
  - **`SearchRelevanceIndicesManagerTests`** — Updated for builder pattern, fixed legacy migration test (v0 → v1 now triggers `putMapping`), fixed same-version test                                                
  - **`PutExperimentTransportActionTests`** — Added `convertToQuerySet` mock for `ExperimentRunningManager` delegation                                                                                              
  - **`QuerySetIT`** — Added assertions for `status`, `type`, `numberOfQueryTerms` on created query sets                 
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
