### PR TITLE
Update updateVersion task and fix BWC version properties

### DIFF
--- a/.github/workflows/backwards_compatibility_tests_workflow.yml
+++ b/.github/workflows/backwards_compatibility_tests_workflow.yml
@@ -21,8 +21,8 @@ jobs:
       matrix:
         java: [21, 25]
         os: [ubuntu-latest]
-        bwc_version: ["3.3.0", "3.4.0", "3.5.0"]
-        opensearch_version: ["3.6.0-SNAPSHOT"]
+        bwc_version: ["3.3.0", "3.4.0", "3.5.0", "3.6.0"]
+        opensearch_version: ["3.7.0-SNAPSHOT"]
 
     name: SearchRelevance Rolling-Upgrade BWC Tests
     runs-on: ${{ matrix.os }}
@@ -54,8 +54,8 @@ jobs:
       matrix:
         java: [21, 25]
         os: [ubuntu-latest]
-        bwc_version: ["3.3.0", "3.4.0", "3.5.0"]
-        opensearch_version: ["3.6.0-SNAPSHOT"]
+        bwc_version: ["3.3.0", "3.4.0", "3.5.0", "3.6.0"]
+        opensearch_version: ["3.7.0-SNAPSHOT"]
 
     name: SearchRelevance Restart-Upgrade BWC Tests
     runs-on: ${{ matrix.os }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Bug Fixes
 
 ### Infrastructure
+- Update updateVersion task and fix BWC version properties ([#475](https://github.com/opensearch-project/search-relevance/pull/475))
 
 ### Documentation
 

--- a/build.gradle
+++ b/build.gradle
@@ -595,8 +595,158 @@ task updateVersion {
     doLast {
         ext.newVersion = System.getProperty('newVersion')
         println "Setting version to ${newVersion}."
-         // String tokenization to support -SNAPSHOT
-        ant.replaceregexp(file:'build.gradle', match: '"opensearch.version", "\\d.*"', replace: '"opensearch.version", "' + newVersion.tokenize('-')[0] + '-SNAPSHOT"', flags:'g', byline:true)
+
+        ext.newVersionWithoutSnapshot = newVersion.tokenize('-')[0]
+        ext.currentVersionWithoutSnapshot = opensearch_version.tokenize('-')[0]
+
+        // Step 1: Update build.gradle with new OpenSearch version
+        ant.replaceregexp(
+            file: 'build.gradle',
+            match: '"opensearch.version", "\\d.*"',
+            replace: "\"opensearch.version\", \"${newVersionWithoutSnapshot}-SNAPSHOT\"",
+            flags: 'g',
+            byline: true
+        )
+
+        // Step 2: Read current BWC versions from gradle.properties
+        def gradlePropsFile = file('gradle.properties')
+        def currentBwcVersion = null
+        def currentBwcBundleVersion = null
+
+        gradlePropsFile.eachLine { line ->
+            if (line.startsWith('systemProp.bwc.version=')) {
+                currentBwcVersion = line.split('=')[1].trim().tokenize('-')[0]
+            }
+            if (line.startsWith('systemProp.bwc.bundle.version=')) {
+                currentBwcBundleVersion = line.split('=')[1].trim()
+            }
+        }
+
+        if (currentBwcVersion == null || currentBwcBundleVersion == null) {
+            throw new GradleException("Could not read BWC versions from gradle.properties")
+        }
+
+        println "Current BWC version: ${currentBwcVersion}"
+        println "Current BWC bundle version: ${currentBwcBundleVersion}"
+        println "New OpenSearch version: ${newVersionWithoutSnapshot}"
+        println "Previous OpenSearch version: ${currentVersionWithoutSnapshot}"
+
+        def currentVersionParts = currentVersionWithoutSnapshot.tokenize('.')
+        def newVersionParts = newVersionWithoutSnapshot.tokenize('.')
+        def currentMajor = currentVersionParts[0] as Integer
+        def currentMinor = currentVersionParts[1] as Integer
+        def newMajor = newVersionParts[0] as Integer
+        def newMinor = newVersionParts[1] as Integer
+        def isPatchVersionBump = (currentMajor == newMajor && currentMinor == newMinor)
+        def isMinorVersionBump = (currentMajor == newMajor && currentMinor != newMinor)
+        def isMajorVersionBump = (currentMajor != newMajor)
+
+        if (isPatchVersionBump) {
+            println "Detected patch version bump (${currentVersionWithoutSnapshot} -> ${newVersionWithoutSnapshot}), will skip adding to BWC version arrays"
+        } else if (isMinorVersionBump) {
+            println "Detected minor version bump (${currentVersionWithoutSnapshot} -> ${newVersionWithoutSnapshot}), will skip updating bwc.bundle.version"
+        } else if (isMajorVersionBump) {
+            println "Detected major version bump (${currentVersionWithoutSnapshot} -> ${newVersionWithoutSnapshot})"
+        }
+
+        // Step 3: Update gradle.properties - systemProp.bwc.version
+        ant.replaceregexp(
+            file: 'gradle.properties',
+            match: "systemProp.bwc.version=${currentBwcVersion}(-SNAPSHOT)?",
+            replace: "systemProp.bwc.version=${newVersionWithoutSnapshot}-SNAPSHOT",
+            flags: 'g',
+            byline: true
+        )
+
+        // Step 4: Update gradle.properties - systemProp.bwc.bundle.version (only for major bumps)
+        if (isMajorVersionBump) {
+            ant.replaceregexp(
+                file: 'gradle.properties',
+                match: "systemProp.bwc.bundle.version=${currentBwcBundleVersion}",
+                replace: "systemProp.bwc.bundle.version=${currentVersionWithoutSnapshot}",
+                flags: 'g',
+                byline: true
+            )
+            println "Updated systemProp.bwc.bundle.version to ${currentVersionWithoutSnapshot}"
+        } else {
+            println "Skipped updating systemProp.bwc.bundle.version (only updated for major version bumps)"
+        }
+
+        // Step 5: Update backwards_compatibility_tests_workflow.yml - opensearch_version
+        ant.replaceregexp(
+            file: '.github/workflows/backwards_compatibility_tests_workflow.yml',
+            match: "opensearch_version\\s*:\\s*\\[\\s*\"${currentVersionWithoutSnapshot}-SNAPSHOT\"\\s*\\]",
+            replace: "opensearch_version: [\"${newVersionWithoutSnapshot}-SNAPSHOT\"]",
+            flags: 'g',
+            byline: true
+        )
+
+        // Step 6: Update backwards_compatibility_tests_workflow.yml - bwc_version arrays
+        def workflowFile = file('.github/workflows/backwards_compatibility_tests_workflow.yml')
+        def workflowContent = workflowFile.text
+
+        if (!isPatchVersionBump && !workflowContent.contains("\"${currentVersionWithoutSnapshot}\"")) {
+            def updatedContent = workflowContent
+
+            def isCurrentVersionNewer = { String lastVersion ->
+                def lastVersionParts = lastVersion.tokenize('.')
+                def lastMajor = lastVersionParts[0] as Integer
+                def lastMinor = lastVersionParts[1] as Integer
+                def lastPatch = lastVersionParts.size() > 2 ? lastVersionParts[2] as Integer : 0
+
+                def currVersionParts = currentVersionWithoutSnapshot.tokenize('.')
+                def currMajor = currVersionParts[0] as Integer
+                def currMinor = currVersionParts[1] as Integer
+                def currPatch = currVersionParts.size() > 2 ? currVersionParts[2] as Integer : 0
+
+                return (currMajor > lastMajor) ||
+                       (currMajor == lastMajor && currMinor > lastMinor) ||
+                       (currMajor == lastMajor && currMinor == lastMinor && currPatch > lastPatch)
+            }
+
+            def extractVersions = { String content ->
+                def matcher = content =~ /bwc_version\s*:\s*\[([^\]]+)\]/
+                if (matcher.find()) {
+                    def versionListStr = matcher.group(1)
+                    return versionListStr.findAll(/"([^"]+)"/).collect { it.replaceAll('"', '').trim() }
+                }
+                return []
+            }
+
+            def rollingStart = updatedContent.indexOf('Rolling-Upgrade-BWCTests-SearchRelevance:')
+            def restartStart = updatedContent.indexOf('Restart-Upgrade-BWCTests-SearchRelevance:')
+
+            if (rollingStart != -1 && restartStart != -1) {
+                def rollingSection = updatedContent.substring(rollingStart, restartStart)
+                def rollingVersions = extractVersions(rollingSection)
+                if (!rollingVersions.isEmpty() && isCurrentVersionNewer(rollingVersions.last())) {
+                    def updatedRollingSection = rollingSection.replaceFirst(
+                        /(?m)(^\s*bwc_version\s*:\s*\[([^\]]+))\]/,
+                        "\$1, \"${currentVersionWithoutSnapshot}\"]"
+                    )
+                    updatedContent = updatedContent.substring(0, rollingStart) + updatedRollingSection + updatedContent.substring(restartStart)
+                    println "Added ${currentVersionWithoutSnapshot} to Rolling-Upgrade BWC version list"
+                }
+
+                def restartSection = updatedContent.substring(updatedContent.indexOf('Restart-Upgrade-BWCTests-SearchRelevance:'))
+                def restartVersions = extractVersions(restartSection)
+                if (!restartVersions.isEmpty() && isCurrentVersionNewer(restartVersions.last())) {
+                    def updatedRestartSection = restartSection.replaceFirst(
+                        /(?m)(^\s*bwc_version\s*:\s*\[([^\]]+))\]/,
+                        "\$1, \"${currentVersionWithoutSnapshot}\"]"
+                    )
+                    def newRestartStart = updatedContent.indexOf('Restart-Upgrade-BWCTests-SearchRelevance:')
+                    updatedContent = updatedContent.substring(0, newRestartStart) + updatedRestartSection
+                    println "Added ${currentVersionWithoutSnapshot} to Restart-Upgrade BWC version list"
+                }
+            }
+
+            workflowFile.text = updatedContent
+        } else if (isPatchVersionBump) {
+            println "Skipped adding ${currentVersionWithoutSnapshot} to BWC version list (patch version bump)"
+        } else {
+            println "Version ${currentVersionWithoutSnapshot} already exists in BWC version list"
+        }
     }
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -14,8 +14,8 @@ org.gradle.parallel=true
 # https://github.com/opensearch-project/OpenSearch/blob/main/libs/core/src/main/java/org/opensearch/Version.java .
 # Wired compatibility of OpenSearch works like 3.x version is compatible with 2.(latest-major) version.
 # Therefore, to run rolling-upgrade BWC Test on local machine the BWC version here should be set 2.(latest-major).
-systemProp.bwc.version=3.5.0
-systemProp.bwc.bundle.version=3.5.0
+systemProp.bwc.version=3.7.0-SNAPSHOT
+systemProp.bwc.bundle.version=3.6.0
 
 # For fixing Spotless check with Java 17
 org.gradle.jvmargs=--add-exports jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED \


### PR DESCRIPTION


### Description
Rewrite the updateVersion gradle task to match neural-search's approach, which also updates gradle.properties and the BWC workflow file. Fix stale BWC versions that were not updated during the 3.7.0 development cycle.

### Issues Resolved
N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).

### Test
```
diff --git a/.github/workflows/backwards_compatibility_tests_workflow.yml b/.github/workflows/backwards_compatibility_tests_workflow.yml
index 8f659da..8e779a9 100644
--- a/.github/workflows/backwards_compatibility_tests_workflow.yml
+++ b/.github/workflows/backwards_compatibility_tests_workflow.yml
@@ -21,8 +21,8 @@ jobs:
       matrix:
         java: [21, 25]
         os: [ubuntu-latest]
-        bwc_version: ["3.3.0", "3.4.0", "3.5.0", "3.6.0"]
-        opensearch_version: ["3.7.0-SNAPSHOT"]
+        bwc_version: ["3.3.0", "3.4.0", "3.5.0", "3.6.0", "3.7.0"]
+        opensearch_version: ["2.8.0-SNAPSHOT"]
 
     name: SearchRelevance Rolling-Upgrade BWC Tests
     runs-on: ${{ matrix.os }}
@@ -54,8 +54,8 @@ jobs:
       matrix:
         java: [21, 25]
         os: [ubuntu-latest]
-        bwc_version: ["3.3.0", "3.4.0", "3.5.0", "3.6.0"]
-        opensearch_version: ["3.7.0-SNAPSHOT"]
+        bwc_version: ["3.3.0", "3.4.0", "3.5.0", "3.6.0", "3.7.0"]
+        opensearch_version: ["2.8.0-SNAPSHOT"]
 
     name: SearchRelevance Restart-Upgrade BWC Tests
     runs-on: ${{ matrix.os }}
diff --git a/build.gradle b/build.gradle
index 9086316..e9e8072 100644
--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,7 @@ import java.util.stream.Collectors
 
 buildscript {
     ext {
-        opensearch_version = System.getProperty("opensearch.version", "3.7.0-SNAPSHOT")
+        opensearch_version = System.getProperty("opensearch.version", "2.8.0-SNAPSHOT")
         isSnapshot = "true" == System.getProperty("build.snapshot", "true")
         buildVersionQualifier = System.getProperty("build.version_qualifier", "")
         // 2.2.0-SNAPSHOT -> 2.2.0.0-SNAPSHOT
diff --git a/gradle.properties b/gradle.properties
index c137273..6f1d395 100644
--- a/gradle.properties
+++ b/gradle.properties
@@ -14,8 +14,8 @@ org.gradle.parallel=true
 # https://github.com/opensearch-project/OpenSearch/blob/main/libs/core/src/main/java/org/opensearch/Version.java .
 # Wired compatibility of OpenSearch works like 3.x version is compatible with 2.(latest-major) version.
 # Therefore, to run rolling-upgrade BWC Test on local machine the BWC version here should be set 2.(latest-major).
-systemProp.bwc.version=3.7.0-SNAPSHOT
-systemProp.bwc.bundle.version=3.6.0
+systemProp.bwc.version=2.8.0-SNAPSHOT
+systemProp.bwc.bundle.version=3.7.0
 
 # For fixing Spotless check with Java 17
 org.gradle.jvmargs=--add-exports jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED \

```
