### PR TITLE
Remove PR #414 from main changelog 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,6 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Enhancements
 
 ### Bug Fixes
-- Fixed QuerySet creation failing when query or answer text contains `#` or `:` characters ([#414](https://github.com/opensearch-project/search-relevance/pull/414))
 
 ### Infrastructure
 - Update updateVersion task and fix BWC version properties ([#475](https://github.com/opensearch-project/search-relevance/pull/475))


### PR DESCRIPTION
### Description
PR #414 is backported to 3.7. Remove it from current CHANGELOG

Merge this PR only after https://github.com/opensearch-project/search-relevance/pull/476 is merged


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
