### PR TITLE
Fix experiment search requests wrapping query and breaking search pipeline field path resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### Bug Fixes
 - Implement referential integrity validation for search configurations, experiments, and judgments ([#360](https://github.com/opensearch-project/search-relevance/pull/360))
+- Preserve the original query structure when building experiment search requests so search pipeline request processors can resolve field paths instead of failing on a wrapped query ([#490](https://github.com/opensearch-project/search-relevance/pull/490))
 
 ### Infrastructure
 - Update updateVersion task and fix BWC version properties ([#475](https://github.com/opensearch-project/search-relevance/pull/475))

--- a/src/main/java/org/opensearch/searchrelevance/model/builder/SearchRequestBuilder.java
+++ b/src/main/java/org/opensearch/searchrelevance/model/builder/SearchRequestBuilder.java
@@ -74,7 +74,7 @@ public class SearchRequestBuilder {
             try (XContentParser parser = newParserWithRegistry(queryBody)) {
                 return AbstractQueryBuilder.parseInnerQueryBuilder(parser);
             } catch (Exception e) {
-                log.debug("Could not parse query with NamedXContentRegistry, falling back to wrapper query: {}", e.getMessage());
+                log.warn("Could not parse query with NamedXContentRegistry, falling back to wrapper query: {}", e.getMessage());
             }
         }
         // Fall back to wrapper query to support custom/unregistered query types

--- a/src/main/java/org/opensearch/searchrelevance/model/builder/SearchRequestBuilder.java
+++ b/src/main/java/org/opensearch/searchrelevance/model/builder/SearchRequestBuilder.java
@@ -20,6 +20,8 @@ import org.opensearch.core.xcontent.DeprecationHandler;
 import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.core.xcontent.XContentParser;
+import org.opensearch.index.query.AbstractQueryBuilder;
+import org.opensearch.index.query.QueryBuilder;
 import org.opensearch.index.query.QueryBuilders;
 import org.opensearch.search.builder.SearchSourceBuilder;
 
@@ -59,6 +61,27 @@ public class SearchRequestBuilder {
     }
 
     /**
+     * Parses the top-level "query" into a QueryBuilder using the cluster's NamedXContentRegistry so
+     * that the original query structure is preserved when the request is serialized. Falls back to a
+     * wrapper query for query types that cannot be parsed (e.g. custom/unregistered query types).
+     */
+    private static QueryBuilder buildQueryBuilder(Object queryObject) throws IOException {
+        XContentBuilder builder = JsonXContent.contentBuilder();
+        builder.value(queryObject);
+        String queryBody = builder.toString();
+
+        if (NAMED_XCONTENT_REGISTRY != null) {
+            try (XContentParser parser = newParserWithRegistry(queryBody)) {
+                return AbstractQueryBuilder.parseInnerQueryBuilder(parser);
+            } catch (Exception e) {
+                log.debug("Could not parse query with NamedXContentRegistry, falling back to wrapper query: {}", e.getMessage());
+            }
+        }
+        // Fall back to wrapper query to support custom/unregistered query types
+        return QueryBuilders.wrapperQuery(queryBody);
+    }
+
+    /**
      * Builds a search request with the given parameters.
      * @param index - target index to be searched against
      * @param query - DSL query that includes queryBody and optional extra fields, like pipeline, aggregation, exclude ...
@@ -82,7 +105,7 @@ public class SearchRequestBuilder {
             );
             Map<String, Object> fullQueryMap = tempParser.map();
 
-            // Handle 'query' separately using WrapperQuery to support custom/unregistered query types
+            // Handle 'query' separately so it can be parsed into a QueryBuilder
             Object queryObject = fullQueryMap.remove(QUERY_FIELD_NAME);
 
             // Parse everything except query using SearchSourceBuilder.fromXContent with real registry
@@ -97,12 +120,9 @@ public class SearchRequestBuilder {
 
             SearchSourceBuilder sourceBuilder = SearchSourceBuilder.fromXContent(parser);
 
-            // Handle query separately using WrapperQuery
+            // Set the query, preserving its original structure so search pipeline processors can resolve field paths
             if (queryObject != null) {
-                builder = JsonXContent.contentBuilder();
-                builder.value(queryObject);
-                String queryBody = builder.toString();
-                sourceBuilder.query(QueryBuilders.wrapperQuery(queryBody));
+                sourceBuilder.query(buildQueryBuilder(queryObject));
             }
 
             // Precheck if query contains a different size value
@@ -156,7 +176,7 @@ public class SearchRequestBuilder {
             // Validate hybrid query
             validateHybridQuery(fullQueryMap);
 
-            // Handle 'query' separately using WrapperQuery to support custom/unregistered query types
+            // Handle 'query' separately so it can be parsed into a QueryBuilder
             Object queryObject = fullQueryMap.remove(QUERY_FIELD_NAME);
 
             // Parse everything except query using SearchSourceBuilder.fromXContent with real registry
@@ -171,12 +191,9 @@ public class SearchRequestBuilder {
 
             SearchSourceBuilder sourceBuilder = SearchSourceBuilder.fromXContent(parser);
 
-            // Handle query separately using WrapperQuery
+            // Set the query, preserving its original structure so search pipeline processors can resolve field paths
             if (queryObject != null) {
-                builder = JsonXContent.contentBuilder();
-                builder.value(queryObject);
-                String queryBody = builder.toString();
-                sourceBuilder.query(QueryBuilders.wrapperQuery(queryBody));
+                sourceBuilder.query(buildQueryBuilder(queryObject));
             }
 
             // validate that query does not have internal temporary pipeline definition

--- a/src/main/java/org/opensearch/searchrelevance/plugin/SearchRelevancePlugin.java
+++ b/src/main/java/org/opensearch/searchrelevance/plugin/SearchRelevancePlugin.java
@@ -72,6 +72,7 @@ import org.opensearch.searchrelevance.indices.SearchRelevanceIndicesManager;
 import org.opensearch.searchrelevance.metrics.MetricsHelper;
 import org.opensearch.searchrelevance.ml.MLAccessor;
 import org.opensearch.searchrelevance.model.ScheduledJob;
+import org.opensearch.searchrelevance.model.builder.SearchRequestBuilder;
 import org.opensearch.searchrelevance.rest.RestCreateQuerySetAction;
 import org.opensearch.searchrelevance.rest.RestDeleteExperimentAction;
 import org.opensearch.searchrelevance.rest.RestDeleteJudgmentAction;
@@ -219,6 +220,7 @@ public class SearchRelevancePlugin extends Plugin
         this.scheduledExperimentHistoryDao = new ScheduledExperimentHistoryDao(searchRelevanceIndicesManager);
         MachineLearningNodeClient mlClient = new MachineLearningNodeClient(client);
         this.mlAccessor = new MLAccessor(mlClient);
+        SearchRequestBuilder.initialize(xContentRegistry);
         SearchRelevanceExecutor.initialize(threadPool);
         ExperimentTaskManager experimentTaskManager = new ExperimentTaskManager(
             client,

--- a/src/test/java/org/opensearch/searchrelevance/model/builder/SearchRequestBuilderTests.java
+++ b/src/test/java/org/opensearch/searchrelevance/model/builder/SearchRequestBuilderTests.java
@@ -87,6 +87,77 @@ public class SearchRequestBuilderTests extends OpenSearchTestCase {
         return null;
     }
 
+    public void testBuildSearchRequest_preservesQueryStructure_forSearchPipeline() throws Exception {
+        String query = "{\"query\":{\"term\":{\"embedding\":{\"value\":\"" + WILDCARD_QUERY_TEXT + "\"}}}}";
+
+        SearchRequest searchRequest = SearchRequestBuilder.buildSearchRequest(TEST_INDEX, query, TEST_QUERY_TEXT, TEST_PIPELINE, TEST_SIZE);
+        assertNotNull(searchRequest);
+        assertEquals(TEST_PIPELINE, searchRequest.pipeline());
+
+        SearchSourceBuilder sourceBuilder = searchRequest.source();
+        assertNotNull(sourceBuilder);
+
+        Map<String, Object> sourceMap = parseJsonToMap(sourceBuilder.toString());
+        @SuppressWarnings("unchecked")
+        Map<String, Object> queryMap = (Map<String, Object>) sourceMap.get("query");
+        assertNotNull(queryMap);
+        assertFalse("Query must not be encoded inside a wrapper query", queryMap.containsKey("wrapper"));
+        assertTrue("Original term query structure must be preserved", queryMap.containsKey("term"));
+
+        @SuppressWarnings("unchecked")
+        Map<String, Object> termMap = (Map<String, Object>) queryMap.get("term");
+        assertTrue("Field path query.term.embedding must be resolvable", termMap.containsKey("embedding"));
+    }
+
+    public void testBuildSearchRequest_fallsBackToWrapper_forUnregisteredQueryType() throws Exception {
+        String hybridQuery = "{\"query\":{\"hybrid\":{\"queries\":[{\"match\":{\"name\":\""
+            + WILDCARD_QUERY_TEXT
+            + "\"}},{\"match\":{\"name\":\""
+            + WILDCARD_QUERY_TEXT
+            + "\"}}]}}}";
+
+        SearchRequest searchRequest = SearchRequestBuilder.buildSearchRequest(TEST_INDEX, hybridQuery, TEST_QUERY_TEXT, null, TEST_SIZE);
+        assertNotNull(searchRequest);
+
+        SearchSourceBuilder sourceBuilder = searchRequest.source();
+        assertNotNull(sourceBuilder);
+
+        Map<String, Object> sourceMap = parseJsonToMap(sourceBuilder.toString());
+        @SuppressWarnings("unchecked")
+        Map<String, Object> queryMap = (Map<String, Object>) sourceMap.get("query");
+        assertNotNull(queryMap);
+        assertTrue("Unregistered query type should fall back to wrapper query", queryMap.containsKey("wrapper"));
+    }
+
+    public void testBuildSearchRequest_fallsBackToWrapper_whenRegistryNotInitialized() throws Exception {
+        SearchRequestBuilder.initialize(null);
+        String query = "{\"query\":{\"match\":{\"title\":\"" + WILDCARD_QUERY_TEXT + "\"}}}";
+
+        SearchRequest searchRequest = SearchRequestBuilder.buildSearchRequest(TEST_INDEX, query, TEST_QUERY_TEXT, null, TEST_SIZE);
+        assertNotNull(searchRequest);
+
+        SearchSourceBuilder sourceBuilder = searchRequest.source();
+        assertNotNull(sourceBuilder);
+
+        Map<String, Object> sourceMap = parseJsonToMap(sourceBuilder.toString());
+        @SuppressWarnings("unchecked")
+        Map<String, Object> queryMap = (Map<String, Object>) sourceMap.get("query");
+        assertNotNull(queryMap);
+        assertTrue("Query should fall back to wrapper when registry is not initialized", queryMap.containsKey("wrapper"));
+    }
+
+    public void testBuildSearchRequest_whenNoTopLevelQuery_thenNoQuerySet() {
+        String query = "{\"_source\":{\"includes\":[\"title\"]}}";
+
+        SearchRequest searchRequest = SearchRequestBuilder.buildSearchRequest(TEST_INDEX, query, TEST_QUERY_TEXT, null, TEST_SIZE);
+        assertNotNull(searchRequest);
+
+        SearchSourceBuilder sourceBuilder = searchRequest.source();
+        assertNotNull(sourceBuilder);
+        assertNull("No query should be set when the source has no top-level query", sourceBuilder.query());
+        assertEquals(TEST_SIZE, sourceBuilder.size());
+    }
+
     public void testBuildSearchRequestSimpleQuery() {
         String simpleQuery = "{\"query\":{\"match\":{\"title\":\"" + WILDCARD_QUERY_TEXT + "\"}}}";
 


### PR DESCRIPTION
### Description

Experiment search requests wrapped the configured query in a wrapper query, which base64-encodes it. Search pipeline request processors (e.g. `ml_inference`) could then no longer resolve field paths such as `query.term.embedding.value` against the request body, so experiments using a `searchPipeline` failed with `ERROR`.

This parses the top-level query with the cluster's `NamedXContentRegistry` into a real `QueryBuilder`, preserving the original structure when the request is serialized, and falls back to a wrapper query only for query types that cannot be parsed (e.g. custom/unregistered types like LTR).

> [!NOTE]
> Since the query is now parsed and re-serialized, it gets normalized to its canonical form with
> default values filled in. For example, `{"match":{"title":"foo"}}` is expanded to
> `{"match":{"title":{"query":"foo","operator":"OR","boost":1.0, ...}}}`. The query semantics are
> unchanged, but the serialized shape differs from the original input. If a search pipeline request
> processor maps an input field that changes shape under normalization — for instance, expecting
> `query.match.title` to be a string when it now becomes an object — it will see the normalized form.
> This only affects the short-hand forms of such queries, and it is still a clear improvement over
> the previous wrapper query, which exposed nothing the processors could read.

### Files changed

- **`model/builder/SearchRequestBuilder.java`**
  Added a `buildQueryBuilder(...)` helper that parses the top-level query into a `QueryBuilder` via the registry (preserving structure), with a wrapper-query fallback for unparseable types. Replaced the unconditional `QueryBuilders.wrapperQuery(...)` calls in both `buildSearchRequest` and `buildRequestForHybridSearch`.
- **`/plugin/SearchRelevancePlugin.java`**
  Wired the cluster's `NamedXContentRegistry` into `SearchRequestBuilder` during `createComponents` (this `initialize(...)` call was previously missing, so registry-based parsing was never active at runtime).
- **`/model/builder/SearchRequestBuilderTests.java`**
  Added unit tests: structure preservation, wrapper fallback for unregistered query types, fallback when the registry is not initialized, and the no-top-level-query case.

### Testing

Unit tests and spotless pass. 
Below is an end-to-end run on a local cluster with a real text-embedding model and an `ml_inference` search
pipeline that resolves `query.term.embedding.value`, reproducing the scenario from the issue.

#### 1. Index a few documents

Request:
```
POST /semantic-docs/_bulk?refresh=true
{"index":{"_id":"1"}}
{"title":"apple iphone smartphone device"}
{"index":{"_id":"2"}}
{"title":"banana fruit healthy snack"}
{"index":{"_id":"3"}}
{"title":"orange citrus juice drink"}
{"index":{"_id":"4"}}
{"title":"samsung galaxy android phone"}
```

Response:
```
{
  "took": 64,
  "errors": false,
  "items": [
    { "_id": "1", "result": "created", "status": 201 },
    { "_id": "2", "result": "created", "status": 201 },
    { "_id": "3", "result": "created", "status": 201 },
    { "_id": "4", "result": "created", "status": 201 }
  ]
}
```

#### 2. Search pipeline that resolves `query.term.embedding.value`

Request:
```
PUT /_search/pipeline/reg_document_content_embedding_search_pipeline
{
  "description": "Semantic search over content_embedding",
  "request_processors": [
    { "ml_inference": {
        "model_id": "<MODEL_ID>",
        "function_name": "text_embedding",
        "model_input": "{\"text_docs\":[\"${input_map.query}\"],\"target_response\":[\"sentence_embedding\"]}",
        "input_map": [ { "query": "query.term.embedding.value" } ],
        "output_map": [ { "query_embedding": "$.inference_results[0].output[0].data" } ],
        "query_template": "{\"size\":10,\"query\":{\"knn\":{\"content_embedding\":{\"vector\":${query_embedding},\"k\":10}}}}"
    } }
  ]
}
```

Response:
```
{ "acknowledged": true }
```

#### 3. Old behavior: a wrapped query reproduces the reported error

Request:
```
POST /semantic-docs/_search?search_pipeline=reg_document_content_embedding_search_pipeline
{ "size": 10, "query": { "wrapper": { "query": "eyJ0ZXJtIjp7ImVtYmVkZGluZyI6eyJ2YWx1ZSI6ImFwcGxlIn19fQ==" } } }
```

Response:
```
{
  "error": {
    "root_cause": [ {
        "type": "illegal_argument_exception",
        "reason": "cannot find field: query.term.embedding.value in query string: {\"size\":10,\"query\":{\"wrapper\":{\"query\":\"eyJ0ZXJtIjp7ImVtYmVkZGluZyI6eyJ2YWx1ZSI6ImFwcGxlIn19fQ==\"}}}"
    } ],
    "type": "illegal_argument_exception",
    "reason": "cannot find field: query.term.embedding.value in query string: {\"size\":10,\"query\":{\"wrapper\":{\"query\":\"eyJ0ZXJtIjp7ImVtYmVkZGluZyI6eyJ2YWx1ZSI6ImFwcGxlIn19fQ==\"}}}"
  },
  "status": 400
}
```

#### 4. After the fix: the same query keeps its structure and resolves correctly

Request:
```
POST /semantic-docs/_search?search_pipeline=reg_document_content_embedding_search_pipeline
{ "query": { "term": { "embedding": { "value": "apple" } } } }
```

Response (`content_embedding` vectors omitted from `_source` for readability):
```
{
  "took": 10,
  "timed_out": false,
  "hits": {
    "total": { "value": 4, "relation": "eq" },
    "max_score": 0.75694907,
    "hits": [
      { "_id": "1", "_score": 0.75694907, "title": "apple iphone smartphone device" },
      { "_id": "4", "_score": 0.7068475,  "title": "samsung galaxy android phone" },
      { "_id": "3", "_score": 0.61485934, "title": "orange citrus juice drink" },
      { "_id": "2", "_score": 0.60795957, "title": "banana fruit healthy snack" }
    ]
  }
}
```

#### 5. A PAIRWISE_COMPARISON experiment using `searchPipeline` now completes (previously `ERROR`)

Request:
```
PUT /_plugins/_search_relevance/experiments
{
  "querySetId": "<QUERY_SET_ID>",
  "searchConfigurationList": [ "<CONFIG_ID_1>", "<CONFIG_ID_2>" ],
  "size": 10,
  "type": "PAIRWISE_COMPARISON"
}
```

Response:
```
{ "experiment_id": "<EXPERIMENT_ID>", "experiment_result": "CREATED" }
```

Request:
```
GET /_plugins/_search_relevance/experiments/<EXPERIMENT_ID>
```

Response:
```
{
  "id": "<EXPERIMENT_ID>",
  "type": "PAIRWISE_COMPARISON",
  "status": "COMPLETED",
  "size": 10,
  "results": [
    {
      "query_text": "banana",
      "snapshots": [
        { "searchConfigurationId": "<CONFIG_ID_1>", "docIds": ["2","3","4","1"] },
        { "searchConfigurationId": "<CONFIG_ID_2>", "docIds": ["2","3","4","1"] }
      ],
      "metrics": [ {"metric":"jaccard","value":1.0}, {"metric":"rbo50","value":1.0}, {"metric":"rbo90","value":1.0}, {"metric":"frequencyWeighted","value":1.0} ]
    },
    {
      "query_text": "apple",
      "snapshots": [
        { "searchConfigurationId": "<CONFIG_ID_1>", "docIds": ["1","4","3","2"] },
        { "searchConfigurationId": "<CONFIG_ID_2>", "docIds": ["1","4","3","2"] }
      ],
      "metrics": [ {"metric":"jaccard","value":1.0}, {"metric":"rbo50","value":1.0}, {"metric":"rbo90","value":1.0}, {"metric":"frequencyWeighted","value":1.0} ]
    }
  ]
}
```

The experiment status is `COMPLETED` with real results (no `error` field), whereas before the fix this same setup failed with `cannot find field: query.term.embedding.value`.


### Issues Resolved
Resolves opensearch-project/dashboards-search-relevance#834

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
