### PR TITLE
Fix BWC SearchConfigMapping tests by creating referenced index before search config creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### Infrastructure
 - Update updateVersion task and fix BWC version properties ([#475](https://github.com/opensearch-project/search-relevance/pull/475))
+- Fix BWC tests by creating the referenced index before creating the search configuration ([#497](https://github.com/opensearch-project/search-relevance/pull/497))
 
 ### Documentation
 

--- a/qa/restart-upgrade/src/test/java/org/opensearch/searchrelevance/bwc/restart/SearchConfigMappingRestartIT.java
+++ b/qa/restart-upgrade/src/test/java/org/opensearch/searchrelevance/bwc/restart/SearchConfigMappingRestartIT.java
@@ -21,6 +21,7 @@ public class SearchConfigMappingRestartIT extends AbstractSearchRelevanceRestart
 
     private static final String SEARCH_CONFIG_INDEX = "search-relevance-search-config";
     private static final String SEARCH_CONFIG_ENDPOINT = "/_plugins/_search_relevance/search_configurations";
+    private static final String TARGET_INDEX = "test-index";
     private static final String OLD_MAPPING_RESOURCE = "mappings/search_configuration_v0.json";
     private static final String TEST_DOC_RESOURCE = "mappings/search_configuration_test_document.json";
     private static final String TEST_DOC_ID = "test-search-config-bwc";
@@ -35,6 +36,7 @@ public class SearchConfigMappingRestartIT extends AbstractSearchRelevanceRestart
                     testUpgradedCluster();
                 } finally {
                     wipeOfTestResources(SEARCH_CONFIG_INDEX);
+                    wipeOfTestResources(TARGET_INDEX);
                 }
                 break;
             default:
@@ -59,13 +61,20 @@ public class SearchConfigMappingRestartIT extends AbstractSearchRelevanceRestart
         Map<String, Object> oldDoc = IndexMappingTestHelper.getDocument(client(), SEARCH_CONFIG_INDEX, TEST_DOC_ID, logger);
         assertNotNull("Old document should survive restart upgrade", oldDoc);
 
+        // Create the index referenced by the search configuration before the PUT
+        if (!IndexMappingTestHelper.checkIndexExists(client(), TARGET_INDEX, logger)) {
+            IndexMappingTestHelper.createIndexWithMapping(client(), TARGET_INDEX, "{\"properties\": {}}", logger);
+        }
+
         // Create via plugin API — triggers auto-migration
         Request request = new Request("PUT", SEARCH_CONFIG_ENDPOINT);
         request.setJsonEntity(
             "{"
                 + "\"name\": \"bwc-restart-config\","
                 + "\"description\": \"Created after restart to test auto-migration\","
-                + "\"index\": \"test-index\","
+                + "\"index\": \""
+                + TARGET_INDEX
+                + "\","
                 + "\"query\": \"{\\\"match_all\\\": {}}\""
                 + "}"
         );

--- a/qa/rolling-upgrade/src/test/java/org/opensearch/searchrelevance/bwc/rolling/SearchConfigMappingBWCIT.java
+++ b/qa/rolling-upgrade/src/test/java/org/opensearch/searchrelevance/bwc/rolling/SearchConfigMappingBWCIT.java
@@ -33,6 +33,7 @@ public class SearchConfigMappingBWCIT extends AbstractSearchRelevanceRollingUpgr
 
     private static final String SEARCH_CONFIG_INDEX = "search-relevance-search-config";
     private static final String SEARCH_CONFIG_ENDPOINT = "/_plugins/_search_relevance/search_configurations";
+    private static final String TARGET_INDEX = "test-index";
     private static final String OLD_MAPPING_RESOURCE = "mappings/search_configuration_v0.json";
     private static final String TEST_DOC_RESOURCE = "mappings/search_configuration_test_document.json";
     private static final String TEST_DOC_ID = "test-search-config-bwc";
@@ -50,6 +51,7 @@ public class SearchConfigMappingBWCIT extends AbstractSearchRelevanceRollingUpgr
                     testUpgradedCluster();
                 } finally {
                     wipeOfTestResources(SEARCH_CONFIG_INDEX);
+                    wipeOfTestResources(TARGET_INDEX);
                 }
                 break;
             default:
@@ -115,6 +117,11 @@ public class SearchConfigMappingBWCIT extends AbstractSearchRelevanceRollingUpgr
         Map<String, Object> oldDoc = IndexMappingTestHelper.getDocument(client(), SEARCH_CONFIG_INDEX, TEST_DOC_ID, logger);
         assertNotNull("Old document should survive upgrade", oldDoc);
 
+        // Create the index referenced by the search configuration before the PUT
+        if (!IndexMappingTestHelper.checkIndexExists(client(), TARGET_INDEX, logger)) {
+            IndexMappingTestHelper.createIndexWithMapping(client(), TARGET_INDEX, "{\"properties\": {}}", logger);
+        }
+
         // Create a new search configuration via the plugin API.
         // This triggers the actual auto-migration: updateMappingSync adds description field
         // to the mapping, then the document is written with description.
@@ -123,7 +130,9 @@ public class SearchConfigMappingBWCIT extends AbstractSearchRelevanceRollingUpgr
             "{"
                 + "\"name\": \"bwc-upgraded-config\","
                 + "\"description\": \"Created after upgrade to test auto-migration\","
-                + "\"index\": \"test-index\","
+                + "\"index\": \""
+                + TARGET_INDEX
+                + "\","
                 + "\"query\": \"{\\\"match_all\\\": {}}\""
                 + "}"
         );


### PR DESCRIPTION
### Description
The BWC tests `SearchConfigMappingBWCIT` and `SearchConfigMappingRestartIT` create a search configuration referencing `test-index` in the upgraded-cluster phase, but never create that index. This was harmless until #360 added referential-integrity validation requiring the referenced index to exist, after which the search-config PUT returns `400` and the BWC jobs fail. This creates `test-index` before the PUT in both tests' upgraded-cluster phase (guarded by an existence check) and wipes it afterwards. 

### Issues Resolved
Resolves #496

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
