### PR TITLE
[AB Test][Part 1] -  ADD 'Create' and 'Update' ABTest APIs for Team Draft Interleaving

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Features
 
 - Add experiment execution time input signatures (SHA-256 fingerprints of query set, judgments, and search configurations) and `GET /_plugins/_search_relevance/experiments/{id}/validate` for VALID / DRIFTED / UNAVAILABLE drift checks ([#456](https://github.com/opensearch-project/search-relevance/pull/456))
+- Add Create and Update AB Test APIs for Team Draft Interleaving evaluation ([#498](https://github.com/opensearch-project/search-relevance/pull/498))
 
 ### Enhancements
 

--- a/src/main/java/org/opensearch/searchrelevance/common/PluginConstants.java
+++ b/src/main/java/org/opensearch/searchrelevance/common/PluginConstants.java
@@ -108,6 +108,7 @@ public class PluginConstants {
      * AB Test constants
      */
     public static final String AB_TESTS_URL = SEARCH_RELEVANCE_BASE_URI + "/ab_tests";
+    public static final String AB_TEST_UPDATE_URL = AB_TESTS_URL + "/{id}/_update";
     public static final String AB_TEST_INDEX = ".plugins-search-relevance-ab-test";
     public static final String AB_TEST_INDEX_MAPPING = "mappings/ab_test.json";
 

--- a/src/main/java/org/opensearch/searchrelevance/common/PluginConstants.java
+++ b/src/main/java/org/opensearch/searchrelevance/common/PluginConstants.java
@@ -103,4 +103,24 @@ public class PluginConstants {
     public static final String PROCEED = "proceed";
     public static final String ABORT = "abort";
     public static final int BATCH_SIZE_FOR_DELETE_BY_QUERY = 1000;
+
+    /**
+     * AB Test constants
+     */
+    public static final String AB_TESTS_URL = SEARCH_RELEVANCE_BASE_URI + "/ab_tests";
+    public static final String AB_TEST_INDEX = ".plugins-search-relevance-ab-test";
+    public static final String AB_TEST_INDEX_MAPPING = "mappings/ab_test.json";
+
+    public static final String TEST_ID = "test_id";
+    public static final String SEARCH_CONFIGURATION_A = "search_configuration_a";
+    public static final String SEARCH_CONFIGURATION_B = "search_configuration_b";
+    public static final String CONFIG_A_UUID = "config_a_uuid";
+    public static final String CONFIG_B_UUID = "config_b_uuid";
+    public static final String ENABLED = "enabled";
+    public static final String VERSION = "version";
+    public static final String CREATED_AT = "created_at";
+    public static final String UPDATED_AT = "updated_at";
+    public static final String RECORD = "record";
+    public static final String CREATED = "created";
+    public static final String DOC_ID = "doc_id";
 }

--- a/src/main/java/org/opensearch/searchrelevance/dao/ABTestDao.java
+++ b/src/main/java/org/opensearch/searchrelevance/dao/ABTestDao.java
@@ -60,23 +60,6 @@ public class ABTestDao {
         }
     }
 
-    public void updateABTest(final ABTest abTest, final ActionListener listener) {
-        if (abTest == null) {
-            listener.onFailure(new SearchRelevanceException("ABTest cannot be null", RestStatus.BAD_REQUEST));
-            return;
-        }
-        try {
-            searchRelevanceIndicesManager.updateDoc(
-                abTest.getTestId(),
-                abTest.toXContent(XContentFactory.jsonBuilder(), ToXContent.EMPTY_PARAMS),
-                AB_TEST,
-                listener
-            );
-        } catch (IOException e) {
-            throw new SearchRelevanceException("Failed to update ABTest", e, RestStatus.INTERNAL_SERVER_ERROR);
-        }
-    }
-
     @SuppressWarnings("unchecked")
     public void updateABTestWithConcurrencyControl(
         final ABTest abTest,
@@ -132,6 +115,33 @@ public class ABTestDao {
             return;
         }
         searchRelevanceIndicesManager.getDocByDocId(testId, AB_TEST, listener);
+    }
+
+    public void getABTestWithSeqNo(String testId, ActionListener<SearchResponse> listener) {
+        if (testId == null || testId.isEmpty()) {
+            listener.onFailure(new SearchRelevanceException("testId must not be null or empty", RestStatus.BAD_REQUEST));
+            return;
+        }
+        org.opensearch.action.search.SearchRequest searchRequest = new org.opensearch.action.search.SearchRequest(AB_TEST.getIndexName());
+        org.opensearch.search.builder.SearchSourceBuilder sourceBuilder = new org.opensearch.search.builder.SearchSourceBuilder().query(
+            org.opensearch.index.query.QueryBuilders.termQuery("_id", testId)
+        ).size(1).seqNoAndPrimaryTerm(true);
+        searchRequest.source(sourceBuilder);
+        StashedThreadContext.run(client, () -> client.search(searchRequest, new ActionListener<SearchResponse>() {
+            @Override
+            public void onResponse(SearchResponse response) {
+                if (response.getHits().getTotalHits().value() == 0) {
+                    listener.onFailure(new org.opensearch.ResourceNotFoundException("Document not found: " + testId, RestStatus.NOT_FOUND));
+                } else {
+                    listener.onResponse(response);
+                }
+            }
+
+            @Override
+            public void onFailure(Exception e) {
+                listener.onFailure(e);
+            }
+        }));
     }
 
     public void deleteABTest(String testId, ActionListener<org.opensearch.action.delete.DeleteResponse> listener) {

--- a/src/main/java/org/opensearch/searchrelevance/dao/ABTestDao.java
+++ b/src/main/java/org/opensearch/searchrelevance/dao/ABTestDao.java
@@ -149,7 +149,7 @@ public class ABTestDao {
         deleteRequest.setQuery(
             org.opensearch.index.query.QueryBuilders.boolQuery()
                 .must(org.opensearch.index.query.QueryBuilders.termQuery("test_id", testId))
-                .must(org.opensearch.index.query.QueryBuilders.existsQuery("doc_id"))
+                .must(org.opensearch.index.query.QueryBuilders.termQuery("doc_type", "snapshot"))
         );
         StashedThreadContext.run(
             client,

--- a/src/main/java/org/opensearch/searchrelevance/dao/ABTestDao.java
+++ b/src/main/java/org/opensearch/searchrelevance/dao/ABTestDao.java
@@ -11,10 +11,11 @@ import static org.opensearch.searchrelevance.indices.SearchRelevanceIndices.AB_T
 
 import java.io.IOException;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
+import org.opensearch.action.DocWriteRequest.OpType;
 import org.opensearch.action.StepListener;
+import org.opensearch.action.index.IndexResponse;
 import org.opensearch.action.search.SearchResponse;
+import org.opensearch.action.support.WriteRequest;
 import org.opensearch.common.inject.Inject;
 import org.opensearch.common.xcontent.XContentFactory;
 import org.opensearch.core.action.ActionListener;
@@ -24,15 +25,18 @@ import org.opensearch.searchrelevance.exception.SearchRelevanceException;
 import org.opensearch.searchrelevance.indices.SearchRelevanceIndicesManager;
 import org.opensearch.searchrelevance.model.ABTest;
 import org.opensearch.searchrelevance.model.ABTestSnapshot;
+import org.opensearch.searchrelevance.shared.StashedThreadContext;
+import org.opensearch.transport.client.Client;
 
 public class ABTestDao {
-    private static final Logger LOGGER = LogManager.getLogger(ABTestDao.class);
 
     private final SearchRelevanceIndicesManager searchRelevanceIndicesManager;
+    private final Client client;
 
     @Inject
-    public ABTestDao(SearchRelevanceIndicesManager searchRelevanceIndicesManager) {
+    public ABTestDao(SearchRelevanceIndicesManager searchRelevanceIndicesManager, Client client) {
         this.searchRelevanceIndicesManager = searchRelevanceIndicesManager;
+        this.client = client;
     }
 
     public void createIndexIfAbsent(final StepListener<Void> stepListener) {
@@ -73,6 +77,38 @@ public class ABTestDao {
         }
     }
 
+    @SuppressWarnings("unchecked")
+    public void updateABTestWithConcurrencyControl(
+        final ABTest abTest,
+        final long seqNo,
+        final long primaryTerm,
+        final ActionListener listener
+    ) {
+        if (abTest == null) {
+            listener.onFailure(new SearchRelevanceException("ABTest cannot be null", RestStatus.BAD_REQUEST));
+            return;
+        }
+        try {
+            org.opensearch.core.xcontent.XContentBuilder xContent = abTest.toXContent(
+                XContentFactory.jsonBuilder(),
+                ToXContent.EMPTY_PARAMS
+            );
+            StashedThreadContext.run(
+                client,
+                () -> client.prepareIndex(AB_TEST.getIndexName())
+                    .setId(abTest.getTestId())
+                    .setOpType(OpType.INDEX)
+                    .setIfSeqNo(seqNo)
+                    .setIfPrimaryTerm(primaryTerm)
+                    .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE)
+                    .setSource(xContent)
+                    .execute((ActionListener<IndexResponse>) listener)
+            );
+        } catch (IOException e) {
+            throw new SearchRelevanceException("Failed to update ABTest", e, RestStatus.INTERNAL_SERVER_ERROR);
+        }
+    }
+
     public void putSnapshot(final ABTestSnapshot snapshot, final ActionListener listener) {
         if (snapshot == null) {
             listener.onFailure(new SearchRelevanceException("ABTestSnapshot cannot be null", RestStatus.BAD_REQUEST));
@@ -107,6 +143,17 @@ public class ABTestDao {
     }
 
     public void deleteSnapshotsByTestId(String testId, ActionListener<org.opensearch.index.reindex.BulkByScrollResponse> listener) {
-        searchRelevanceIndicesManager.deleteByQuery(testId, "test_id", AB_TEST, listener);
+        org.opensearch.index.reindex.DeleteByQueryRequest deleteRequest = new org.opensearch.index.reindex.DeleteByQueryRequest(
+            AB_TEST.getIndexName()
+        );
+        deleteRequest.setQuery(
+            org.opensearch.index.query.QueryBuilders.boolQuery()
+                .must(org.opensearch.index.query.QueryBuilders.termQuery("test_id", testId))
+                .must(org.opensearch.index.query.QueryBuilders.existsQuery("doc_id"))
+        );
+        StashedThreadContext.run(
+            client,
+            () -> client.execute(org.opensearch.index.reindex.DeleteByQueryAction.INSTANCE, deleteRequest, listener)
+        );
     }
 }

--- a/src/main/java/org/opensearch/searchrelevance/dao/ABTestDao.java
+++ b/src/main/java/org/opensearch/searchrelevance/dao/ABTestDao.java
@@ -10,7 +10,6 @@ package org.opensearch.searchrelevance.dao;
 import static org.opensearch.searchrelevance.indices.SearchRelevanceIndices.AB_TEST;
 
 import java.io.IOException;
-import java.util.Map;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -24,6 +23,7 @@ import org.opensearch.core.xcontent.ToXContent;
 import org.opensearch.searchrelevance.exception.SearchRelevanceException;
 import org.opensearch.searchrelevance.indices.SearchRelevanceIndicesManager;
 import org.opensearch.searchrelevance.model.ABTest;
+import org.opensearch.searchrelevance.model.ABTestSnapshot;
 
 public class ABTestDao {
     private static final Logger LOGGER = LogManager.getLogger(ABTestDao.class);
@@ -73,21 +73,18 @@ public class ABTestDao {
         }
     }
 
-    public void putSnapshot(
-        final String snapshotId,
-        final String testId,
-        final Map<String, Object> record,
-        final String created,
-        final ActionListener listener
-    ) {
+    public void putSnapshot(final ABTestSnapshot snapshot, final ActionListener listener) {
+        if (snapshot == null) {
+            listener.onFailure(new SearchRelevanceException("ABTestSnapshot cannot be null", RestStatus.BAD_REQUEST));
+            return;
+        }
         try {
-            org.opensearch.core.xcontent.XContentBuilder builder = XContentFactory.jsonBuilder().startObject();
-            builder.field("doc_id", snapshotId);
-            builder.field("test_id", testId);
-            builder.field("record", record);
-            builder.field("created", created);
-            builder.endObject();
-            searchRelevanceIndicesManager.updateDoc(snapshotId, builder, AB_TEST, listener);
+            searchRelevanceIndicesManager.updateDoc(
+                snapshot.getDocId(),
+                snapshot.toXContent(XContentFactory.jsonBuilder(), ToXContent.EMPTY_PARAMS),
+                AB_TEST,
+                listener
+            );
         } catch (IOException e) {
             throw new SearchRelevanceException("Failed to store snapshot", e, RestStatus.INTERNAL_SERVER_ERROR);
         }
@@ -101,18 +98,15 @@ public class ABTestDao {
         searchRelevanceIndicesManager.getDocByDocId(testId, AB_TEST, listener);
     }
 
-    private ABTest convertToABTest(SearchResponse response) {
-        Map<String, Object> source = response.getHits().getHits()[0].getSourceAsMap();
-        return new ABTest(
-            (String) source.get(ABTest.TEST_ID),
-            (String) source.get(ABTest.SEARCH_CONFIGURATION_A),
-            (String) source.get(ABTest.SEARCH_CONFIGURATION_B),
-            (String) source.get(ABTest.CONFIG_A_UUID),
-            (String) source.get(ABTest.CONFIG_B_UUID),
-            (Boolean) source.get(ABTest.ENABLED),
-            (Integer) source.get(ABTest.VERSION),
-            (String) source.get(ABTest.CREATED_AT),
-            (String) source.get(ABTest.UPDATED_AT)
-        );
+    public void deleteABTest(String testId, ActionListener<org.opensearch.action.delete.DeleteResponse> listener) {
+        if (testId == null || testId.isEmpty()) {
+            listener.onFailure(new SearchRelevanceException("testId must not be null or empty", RestStatus.BAD_REQUEST));
+            return;
+        }
+        searchRelevanceIndicesManager.deleteDocByDocId(testId, AB_TEST, listener);
+    }
+
+    public void deleteSnapshotsByTestId(String testId, ActionListener<org.opensearch.index.reindex.BulkByScrollResponse> listener) {
+        searchRelevanceIndicesManager.deleteByQuery(testId, "test_id", AB_TEST, listener);
     }
 }

--- a/src/main/java/org/opensearch/searchrelevance/dao/ABTestDao.java
+++ b/src/main/java/org/opensearch/searchrelevance/dao/ABTestDao.java
@@ -1,0 +1,118 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+package org.opensearch.searchrelevance.dao;
+
+import static org.opensearch.searchrelevance.indices.SearchRelevanceIndices.AB_TEST;
+
+import java.io.IOException;
+import java.util.Map;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.opensearch.action.StepListener;
+import org.opensearch.action.search.SearchResponse;
+import org.opensearch.common.inject.Inject;
+import org.opensearch.common.xcontent.XContentFactory;
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.core.rest.RestStatus;
+import org.opensearch.core.xcontent.ToXContent;
+import org.opensearch.searchrelevance.exception.SearchRelevanceException;
+import org.opensearch.searchrelevance.indices.SearchRelevanceIndicesManager;
+import org.opensearch.searchrelevance.model.ABTest;
+
+public class ABTestDao {
+    private static final Logger LOGGER = LogManager.getLogger(ABTestDao.class);
+
+    private final SearchRelevanceIndicesManager searchRelevanceIndicesManager;
+
+    @Inject
+    public ABTestDao(SearchRelevanceIndicesManager searchRelevanceIndicesManager) {
+        this.searchRelevanceIndicesManager = searchRelevanceIndicesManager;
+    }
+
+    public void createIndexIfAbsent(final StepListener<Void> stepListener) {
+        searchRelevanceIndicesManager.createIndexIfAbsent(AB_TEST, stepListener);
+    }
+
+    public void putABTest(final ABTest abTest, final ActionListener listener) {
+        if (abTest == null) {
+            listener.onFailure(new SearchRelevanceException("ABTest cannot be null", RestStatus.BAD_REQUEST));
+            return;
+        }
+        try {
+            searchRelevanceIndicesManager.putDoc(
+                abTest.getTestId(),
+                abTest.toXContent(XContentFactory.jsonBuilder(), ToXContent.EMPTY_PARAMS),
+                AB_TEST,
+                listener
+            );
+        } catch (IOException e) {
+            throw new SearchRelevanceException("Failed to store ABTest", e, RestStatus.INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    public void updateABTest(final ABTest abTest, final ActionListener listener) {
+        if (abTest == null) {
+            listener.onFailure(new SearchRelevanceException("ABTest cannot be null", RestStatus.BAD_REQUEST));
+            return;
+        }
+        try {
+            searchRelevanceIndicesManager.updateDoc(
+                abTest.getTestId(),
+                abTest.toXContent(XContentFactory.jsonBuilder(), ToXContent.EMPTY_PARAMS),
+                AB_TEST,
+                listener
+            );
+        } catch (IOException e) {
+            throw new SearchRelevanceException("Failed to update ABTest", e, RestStatus.INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    public void putSnapshot(
+        final String snapshotId,
+        final String testId,
+        final Map<String, Object> record,
+        final String created,
+        final ActionListener listener
+    ) {
+        try {
+            org.opensearch.core.xcontent.XContentBuilder builder = XContentFactory.jsonBuilder().startObject();
+            builder.field("doc_id", snapshotId);
+            builder.field("test_id", testId);
+            builder.field("record", record);
+            builder.field("created", created);
+            builder.endObject();
+            searchRelevanceIndicesManager.updateDoc(snapshotId, builder, AB_TEST, listener);
+        } catch (IOException e) {
+            throw new SearchRelevanceException("Failed to store snapshot", e, RestStatus.INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    public void getABTest(String testId, ActionListener<SearchResponse> listener) {
+        if (testId == null || testId.isEmpty()) {
+            listener.onFailure(new SearchRelevanceException("testId must not be null or empty", RestStatus.BAD_REQUEST));
+            return;
+        }
+        searchRelevanceIndicesManager.getDocByDocId(testId, AB_TEST, listener);
+    }
+
+    private ABTest convertToABTest(SearchResponse response) {
+        Map<String, Object> source = response.getHits().getHits()[0].getSourceAsMap();
+        return new ABTest(
+            (String) source.get(ABTest.TEST_ID),
+            (String) source.get(ABTest.SEARCH_CONFIGURATION_A),
+            (String) source.get(ABTest.SEARCH_CONFIGURATION_B),
+            (String) source.get(ABTest.CONFIG_A_UUID),
+            (String) source.get(ABTest.CONFIG_B_UUID),
+            (Boolean) source.get(ABTest.ENABLED),
+            (Integer) source.get(ABTest.VERSION),
+            (String) source.get(ABTest.CREATED_AT),
+            (String) source.get(ABTest.UPDATED_AT)
+        );
+    }
+}

--- a/src/main/java/org/opensearch/searchrelevance/indices/SearchRelevanceIndices.java
+++ b/src/main/java/org/opensearch/searchrelevance/indices/SearchRelevanceIndices.java
@@ -7,6 +7,8 @@
  */
 package org.opensearch.searchrelevance.indices;
 
+import static org.opensearch.searchrelevance.common.PluginConstants.AB_TEST_INDEX;
+import static org.opensearch.searchrelevance.common.PluginConstants.AB_TEST_INDEX_MAPPING;
 import static org.opensearch.searchrelevance.common.PluginConstants.EVALUATION_RESULT_INDEX;
 import static org.opensearch.searchrelevance.common.PluginConstants.EVALUATION_RESULT_INDEX_MAPPING;
 import static org.opensearch.searchrelevance.common.PluginConstants.EXPERIMENT_INDEX;
@@ -83,7 +85,12 @@ public enum SearchRelevanceIndices {
     /**
      * Scheduled Experiment History Index
      */
-    SCHEDULED_EXPERIMENT_HISTORY(SCHEDULED_EXPERIMENT_HISTORY_INDEX, SCHEDULED_EXPERIMENT_HISTORY_INDEX_MAPPING, false);
+    SCHEDULED_EXPERIMENT_HISTORY(SCHEDULED_EXPERIMENT_HISTORY_INDEX, SCHEDULED_EXPERIMENT_HISTORY_INDEX_MAPPING, false),
+
+    /**
+     * AB Test Index
+     */
+    AB_TEST(AB_TEST_INDEX, AB_TEST_INDEX_MAPPING, true);
 
     /**
      * Key for schema_version in the _meta section of index mappings

--- a/src/main/java/org/opensearch/searchrelevance/model/ABTest.java
+++ b/src/main/java/org/opensearch/searchrelevance/model/ABTest.java
@@ -22,6 +22,8 @@ import lombok.Getter;
 @AllArgsConstructor
 @Getter
 public class ABTest implements ToXContentObject {
+    public static final String DOC_TYPE = "doc_type";
+    public static final String DOC_TYPE_VALUE = "ab_test";
     public static final String TEST_ID = "test_id";
     public static final String SEARCH_CONFIGURATION_A = "search_configuration_a";
     public static final String SEARCH_CONFIGURATION_B = "search_configuration_b";
@@ -45,6 +47,7 @@ public class ABTest implements ToXContentObject {
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         XContentBuilder xContentBuilder = builder.startObject();
+        xContentBuilder.field(DOC_TYPE, DOC_TYPE_VALUE);
         xContentBuilder.field(TEST_ID, this.testId);
         xContentBuilder.field(SEARCH_CONFIGURATION_A, this.searchConfigurationA);
         xContentBuilder.field(SEARCH_CONFIGURATION_B, this.searchConfigurationB);

--- a/src/main/java/org/opensearch/searchrelevance/model/ABTest.java
+++ b/src/main/java/org/opensearch/searchrelevance/model/ABTest.java
@@ -1,0 +1,59 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+package org.opensearch.searchrelevance.model;
+
+import java.io.IOException;
+
+import org.opensearch.core.xcontent.ToXContentObject;
+import org.opensearch.core.xcontent.XContentBuilder;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+/**
+ * ABTest represents a system index object that stores the configuration for an A/B test
+ * pairing two search configurations for Team Draft Interleaving evaluation.
+ */
+@AllArgsConstructor
+@Getter
+public class ABTest implements ToXContentObject {
+    public static final String TEST_ID = "test_id";
+    public static final String SEARCH_CONFIGURATION_A = "search_configuration_a";
+    public static final String SEARCH_CONFIGURATION_B = "search_configuration_b";
+    public static final String CONFIG_A_UUID = "config_a_uuid";
+    public static final String CONFIG_B_UUID = "config_b_uuid";
+    public static final String ENABLED = "enabled";
+    public static final String VERSION = "version";
+    public static final String CREATED_AT = "created_at";
+    public static final String UPDATED_AT = "updated_at";
+
+    private final String testId;
+    private final String searchConfigurationA;
+    private final String searchConfigurationB;
+    private final String configAUuid;
+    private final String configBUuid;
+    private final boolean enabled;
+    private final int version;
+    private final String createdAt;
+    private final String updatedAt;
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        XContentBuilder xContentBuilder = builder.startObject();
+        xContentBuilder.field(TEST_ID, this.testId);
+        xContentBuilder.field(SEARCH_CONFIGURATION_A, this.searchConfigurationA);
+        xContentBuilder.field(SEARCH_CONFIGURATION_B, this.searchConfigurationB);
+        xContentBuilder.field(CONFIG_A_UUID, this.configAUuid);
+        xContentBuilder.field(CONFIG_B_UUID, this.configBUuid);
+        xContentBuilder.field(ENABLED, this.enabled);
+        xContentBuilder.field(VERSION, this.version);
+        xContentBuilder.field(CREATED_AT, this.createdAt);
+        xContentBuilder.field(UPDATED_AT, this.updatedAt);
+        return xContentBuilder.endObject();
+    }
+}

--- a/src/main/java/org/opensearch/searchrelevance/model/ABTestSnapshot.java
+++ b/src/main/java/org/opensearch/searchrelevance/model/ABTestSnapshot.java
@@ -1,0 +1,45 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+package org.opensearch.searchrelevance.model;
+
+import java.io.IOException;
+import java.util.Map;
+
+import org.opensearch.core.xcontent.ToXContentObject;
+import org.opensearch.core.xcontent.XContentBuilder;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+/**
+ * ABTestSnapshot represents a versioned snapshot of an AB test's state
+ * before an update, stored for audit trail purposes.
+ */
+@AllArgsConstructor
+@Getter
+public class ABTestSnapshot implements ToXContentObject {
+    public static final String DOC_ID = "doc_id";
+    public static final String TEST_ID = "test_id";
+    public static final String RECORD = "record";
+    public static final String CREATED = "created";
+
+    private final String docId;
+    private final String testId;
+    private final Map<String, Object> record;
+    private final String created;
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        XContentBuilder xContentBuilder = builder.startObject();
+        xContentBuilder.field(DOC_ID, this.docId);
+        xContentBuilder.field(TEST_ID, this.testId);
+        xContentBuilder.field(RECORD, this.record);
+        xContentBuilder.field(CREATED, this.created);
+        return xContentBuilder.endObject();
+    }
+}

--- a/src/main/java/org/opensearch/searchrelevance/model/ABTestSnapshot.java
+++ b/src/main/java/org/opensearch/searchrelevance/model/ABTestSnapshot.java
@@ -23,6 +23,8 @@ import lombok.Getter;
 @AllArgsConstructor
 @Getter
 public class ABTestSnapshot implements ToXContentObject {
+    public static final String DOC_TYPE = "doc_type";
+    public static final String DOC_TYPE_VALUE = "snapshot";
     public static final String DOC_ID = "doc_id";
     public static final String TEST_ID = "test_id";
     public static final String RECORD = "record";
@@ -36,6 +38,7 @@ public class ABTestSnapshot implements ToXContentObject {
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         XContentBuilder xContentBuilder = builder.startObject();
+        xContentBuilder.field(DOC_TYPE, DOC_TYPE_VALUE);
         xContentBuilder.field(DOC_ID, this.docId);
         xContentBuilder.field(TEST_ID, this.testId);
         xContentBuilder.field(RECORD, this.record);

--- a/src/main/java/org/opensearch/searchrelevance/plugin/SearchRelevancePlugin.java
+++ b/src/main/java/org/opensearch/searchrelevance/plugin/SearchRelevancePlugin.java
@@ -75,6 +75,7 @@ import org.opensearch.searchrelevance.metrics.MetricsHelper;
 import org.opensearch.searchrelevance.ml.MLAccessor;
 import org.opensearch.searchrelevance.model.ScheduledJob;
 import org.opensearch.searchrelevance.rest.RestCreateQuerySetAction;
+import org.opensearch.searchrelevance.rest.RestDeleteABTestAction;
 import org.opensearch.searchrelevance.rest.RestDeleteExperimentAction;
 import org.opensearch.searchrelevance.rest.RestDeleteJudgmentAction;
 import org.opensearch.searchrelevance.rest.RestDeleteQuerySetAction;
@@ -97,6 +98,7 @@ import org.opensearch.searchrelevance.rest.RestSearchJudgmentAction;
 import org.opensearch.searchrelevance.rest.RestSearchQuerySetAction;
 import org.opensearch.searchrelevance.rest.RestSearchRelevanceStatsAction;
 import org.opensearch.searchrelevance.rest.RestSearchSearchConfigurationAction;
+import org.opensearch.searchrelevance.rest.RestUpdateABTestAction;
 import org.opensearch.searchrelevance.rest.RestValidateExperimentAction;
 import org.opensearch.searchrelevance.scheduler.ScheduledExperimentRunnerManager;
 import org.opensearch.searchrelevance.scheduler.SearchRelevanceJobParameters;
@@ -104,6 +106,8 @@ import org.opensearch.searchrelevance.scheduler.SearchRelevanceJobRunner;
 import org.opensearch.searchrelevance.settings.SearchRelevanceSettingsAccessor;
 import org.opensearch.searchrelevance.stats.events.EventStatsManager;
 import org.opensearch.searchrelevance.stats.info.InfoStatsManager;
+import org.opensearch.searchrelevance.transport.abTest.DeleteABTestAction;
+import org.opensearch.searchrelevance.transport.abTest.DeleteABTestTransportAction;
 import org.opensearch.searchrelevance.transport.abTest.PutABTestAction;
 import org.opensearch.searchrelevance.transport.abTest.PutABTestTransportAction;
 import org.opensearch.searchrelevance.transport.abTest.UpdateABTestAction;
@@ -322,7 +326,9 @@ public class SearchRelevancePlugin extends Plugin
             new RestPostScheduledExperimentAction(settingsAccessor, cronUtil),
             new RestDeleteScheduledExperimentAction(settingsAccessor),
             new RestGetScheduledExperimentAction(settingsAccessor),
-            new RestPutABTestAction(settingsAccessor)
+            new RestPutABTestAction(settingsAccessor),
+            new RestUpdateABTestAction(settingsAccessor),
+            new RestDeleteABTestAction(settingsAccessor)
         );
     }
 
@@ -353,7 +359,8 @@ public class SearchRelevancePlugin extends Plugin
             new ActionHandler<>(DeleteScheduledExperimentAction.INSTANCE, DeleteScheduledExperimentTransportAction.class),
             new ActionHandler<>(GetScheduledExperimentAction.INSTANCE, GetScheduledExperimentTransportAction.class),
             new ActionHandler<>(PutABTestAction.INSTANCE, PutABTestTransportAction.class),
-            new ActionHandler<>(UpdateABTestAction.INSTANCE, UpdateABTestTransportAction.class)
+            new ActionHandler<>(UpdateABTestAction.INSTANCE, UpdateABTestTransportAction.class),
+            new ActionHandler<>(DeleteABTestAction.INSTANCE, DeleteABTestTransportAction.class)
         );
     }
 

--- a/src/main/java/org/opensearch/searchrelevance/plugin/SearchRelevancePlugin.java
+++ b/src/main/java/org/opensearch/searchrelevance/plugin/SearchRelevancePlugin.java
@@ -230,7 +230,7 @@ public class SearchRelevancePlugin extends Plugin
         this.judgmentCacheDao = new JudgmentCacheDao(searchRelevanceIndicesManager);
         this.scheduledJobsDao = new ScheduledJobsDao(searchRelevanceIndicesManager);
         this.scheduledExperimentHistoryDao = new ScheduledExperimentHistoryDao(searchRelevanceIndicesManager);
-        this.abTestDao = new ABTestDao(searchRelevanceIndicesManager);
+        this.abTestDao = new ABTestDao(searchRelevanceIndicesManager, client);
         MachineLearningNodeClient mlClient = new MachineLearningNodeClient(client);
         this.mlAccessor = new MLAccessor(mlClient);
         SearchRelevanceExecutor.initialize(threadPool);

--- a/src/main/java/org/opensearch/searchrelevance/plugin/SearchRelevancePlugin.java
+++ b/src/main/java/org/opensearch/searchrelevance/plugin/SearchRelevancePlugin.java
@@ -7,6 +7,7 @@
  */
 package org.opensearch.searchrelevance.plugin;
 
+import static org.opensearch.searchrelevance.common.PluginConstants.AB_TEST_INDEX;
 import static org.opensearch.searchrelevance.common.PluginConstants.EXPERIMENT_INDEX;
 import static org.opensearch.searchrelevance.common.PluginConstants.JUDGMENT_CACHE_INDEX;
 import static org.opensearch.searchrelevance.common.PluginConstants.SCHEDULED_JOBS_INDEX;
@@ -54,6 +55,7 @@ import org.opensearch.repositories.RepositoriesService;
 import org.opensearch.rest.RestController;
 import org.opensearch.rest.RestHandler;
 import org.opensearch.script.ScriptService;
+import org.opensearch.searchrelevance.dao.ABTestDao;
 import org.opensearch.searchrelevance.dao.EvaluationResultDao;
 import org.opensearch.searchrelevance.dao.ExperimentDao;
 import org.opensearch.searchrelevance.dao.ExperimentVariantDao;
@@ -85,6 +87,7 @@ import org.opensearch.searchrelevance.rest.RestGetScheduledExperimentAction;
 import org.opensearch.searchrelevance.rest.RestGetSearchConfigurationAction;
 import org.opensearch.searchrelevance.rest.RestPatchExperimentAction;
 import org.opensearch.searchrelevance.rest.RestPostScheduledExperimentAction;
+import org.opensearch.searchrelevance.rest.RestPutABTestAction;
 import org.opensearch.searchrelevance.rest.RestPutExperimentAction;
 import org.opensearch.searchrelevance.rest.RestPutJudgmentAction;
 import org.opensearch.searchrelevance.rest.RestPutQuerySetAction;
@@ -101,6 +104,10 @@ import org.opensearch.searchrelevance.scheduler.SearchRelevanceJobRunner;
 import org.opensearch.searchrelevance.settings.SearchRelevanceSettingsAccessor;
 import org.opensearch.searchrelevance.stats.events.EventStatsManager;
 import org.opensearch.searchrelevance.stats.info.InfoStatsManager;
+import org.opensearch.searchrelevance.transport.abTest.PutABTestAction;
+import org.opensearch.searchrelevance.transport.abTest.PutABTestTransportAction;
+import org.opensearch.searchrelevance.transport.abTest.UpdateABTestAction;
+import org.opensearch.searchrelevance.transport.abTest.UpdateABTestTransportAction;
 import org.opensearch.searchrelevance.transport.experiment.DeleteExperimentAction;
 import org.opensearch.searchrelevance.transport.experiment.DeleteExperimentTransportAction;
 import org.opensearch.searchrelevance.transport.experiment.GetExperimentAction;
@@ -176,6 +183,7 @@ public class SearchRelevancePlugin extends Plugin
     private JudgmentCacheDao judgmentCacheDao;
     private ScheduledJobsDao scheduledJobsDao;
     private ScheduledExperimentHistoryDao scheduledExperimentHistoryDao;
+    private ABTestDao abTestDao;
     private MLAccessor mlAccessor;
     private MetricsHelper metricsHelper;
     private SearchRelevanceSettingsAccessor settingsAccessor;
@@ -187,7 +195,8 @@ public class SearchRelevancePlugin extends Plugin
     public Collection<SystemIndexDescriptor> getSystemIndexDescriptors(Settings settings) {
         return List.of(
             new SystemIndexDescriptor(EXPERIMENT_INDEX, "System index used for experiment data"),
-            new SystemIndexDescriptor(JUDGMENT_CACHE_INDEX, "System index used for judgment cache data")
+            new SystemIndexDescriptor(JUDGMENT_CACHE_INDEX, "System index used for judgment cache data"),
+            new SystemIndexDescriptor(AB_TEST_INDEX, "System index used for AB test data")
         );
     }
 
@@ -217,6 +226,7 @@ public class SearchRelevancePlugin extends Plugin
         this.judgmentCacheDao = new JudgmentCacheDao(searchRelevanceIndicesManager);
         this.scheduledJobsDao = new ScheduledJobsDao(searchRelevanceIndicesManager);
         this.scheduledExperimentHistoryDao = new ScheduledExperimentHistoryDao(searchRelevanceIndicesManager);
+        this.abTestDao = new ABTestDao(searchRelevanceIndicesManager);
         MachineLearningNodeClient mlClient = new MachineLearningNodeClient(client);
         this.mlAccessor = new MLAccessor(mlClient);
         SearchRelevanceExecutor.initialize(threadPool);
@@ -268,6 +278,7 @@ public class SearchRelevancePlugin extends Plugin
             judgmentCacheDao,
             scheduledJobsDao,
             scheduledExperimentHistoryDao,
+            abTestDao,
             mlAccessor,
             metricsHelper,
             infoStatsManager,
@@ -310,7 +321,8 @@ public class SearchRelevancePlugin extends Plugin
             new RestSearchRelevanceStatsAction(settingsAccessor, clusterUtil),
             new RestPostScheduledExperimentAction(settingsAccessor, cronUtil),
             new RestDeleteScheduledExperimentAction(settingsAccessor),
-            new RestGetScheduledExperimentAction(settingsAccessor)
+            new RestGetScheduledExperimentAction(settingsAccessor),
+            new RestPutABTestAction(settingsAccessor)
         );
     }
 
@@ -339,7 +351,9 @@ public class SearchRelevancePlugin extends Plugin
             new ActionHandler<>(SearchRelevanceStatsAction.INSTANCE, SearchRelevanceStatsTransportAction.class),
             new ActionHandler<>(PostScheduledExperimentAction.INSTANCE, PostScheduledExperimentTransportAction.class),
             new ActionHandler<>(DeleteScheduledExperimentAction.INSTANCE, DeleteScheduledExperimentTransportAction.class),
-            new ActionHandler<>(GetScheduledExperimentAction.INSTANCE, GetScheduledExperimentTransportAction.class)
+            new ActionHandler<>(GetScheduledExperimentAction.INSTANCE, GetScheduledExperimentTransportAction.class),
+            new ActionHandler<>(PutABTestAction.INSTANCE, PutABTestTransportAction.class),
+            new ActionHandler<>(UpdateABTestAction.INSTANCE, UpdateABTestTransportAction.class)
         );
     }
 

--- a/src/main/java/org/opensearch/searchrelevance/rest/RestDeleteABTestAction.java
+++ b/src/main/java/org/opensearch/searchrelevance/rest/RestDeleteABTestAction.java
@@ -8,17 +8,16 @@
 package org.opensearch.searchrelevance.rest;
 
 import static java.util.Collections.singletonList;
-import static org.opensearch.rest.RestRequest.Method.PUT;
+import static org.opensearch.rest.RestRequest.Method.DELETE;
 import static org.opensearch.searchrelevance.common.PluginConstants.AB_TESTS_URL;
 
 import java.io.IOException;
 import java.util.List;
-import java.util.Map;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.opensearch.ExceptionsHelper;
-import org.opensearch.action.index.IndexResponse;
+import org.opensearch.action.delete.DeleteResponse;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.rest.RestStatus;
 import org.opensearch.core.xcontent.XContentBuilder;
@@ -26,26 +25,26 @@ import org.opensearch.rest.BaseRestHandler;
 import org.opensearch.rest.BytesRestResponse;
 import org.opensearch.rest.RestRequest;
 import org.opensearch.searchrelevance.settings.SearchRelevanceSettingsAccessor;
-import org.opensearch.searchrelevance.transport.abTest.PutABTestAction;
-import org.opensearch.searchrelevance.transport.abTest.PutABTestRequest;
+import org.opensearch.searchrelevance.transport.abTest.DeleteABTestAction;
+import org.opensearch.searchrelevance.transport.abTest.DeleteABTestRequest;
 import org.opensearch.transport.client.node.NodeClient;
 
 import lombok.AllArgsConstructor;
 
 @AllArgsConstructor
-public class RestPutABTestAction extends BaseRestHandler {
-    private static final Logger LOGGER = LogManager.getLogger(RestPutABTestAction.class);
-    private static final String PUT_AB_TEST_ACTION = "put_ab_test_action";
+public class RestDeleteABTestAction extends BaseRestHandler {
+    private static final Logger LOGGER = LogManager.getLogger(RestDeleteABTestAction.class);
+    private static final String DELETE_AB_TEST_ACTION = "delete_ab_test_action";
     private SearchRelevanceSettingsAccessor settingsAccessor;
 
     @Override
     public String getName() {
-        return PUT_AB_TEST_ACTION;
+        return DELETE_AB_TEST_ACTION;
     }
 
     @Override
     public List<Route> routes() {
-        return singletonList(new Route(PUT, AB_TESTS_URL + "/{id}"));
+        return singletonList(new Route(DELETE, AB_TESTS_URL + "/{id}"));
     }
 
     @Override
@@ -59,29 +58,11 @@ public class RestPutABTestAction extends BaseRestHandler {
             return channel -> channel.sendResponse(new BytesRestResponse(RestStatus.BAD_REQUEST, "test id is required in URL path"));
         }
 
-        Map<String, Object> source = request.contentParser().map();
+        DeleteABTestRequest deleteRequest = new DeleteABTestRequest(testId);
 
-        String searchConfigurationA = (String) source.get("search_configuration_a");
-        String searchConfigurationB = (String) source.get("search_configuration_b");
-        Boolean enabled = source.containsKey("enabled") ? (Boolean) source.get("enabled") : null;
-
-        if (searchConfigurationA == null || searchConfigurationB == null) {
-            return channel -> channel.sendResponse(
-                new BytesRestResponse(RestStatus.BAD_REQUEST, "Both search_configuration_a and search_configuration_b are required")
-            );
-        }
-
-        if (searchConfigurationA.equals(searchConfigurationB)) {
-            return channel -> channel.sendResponse(
-                new BytesRestResponse(RestStatus.BAD_REQUEST, "search_configuration_a and search_configuration_b must be different")
-            );
-        }
-
-        PutABTestRequest putRequest = new PutABTestRequest(testId, searchConfigurationA, searchConfigurationB, enabled);
-
-        return channel -> client.execute(PutABTestAction.INSTANCE, putRequest, new ActionListener<IndexResponse>() {
+        return channel -> client.execute(DeleteABTestAction.INSTANCE, deleteRequest, new ActionListener<DeleteResponse>() {
             @Override
-            public void onResponse(IndexResponse response) {
+            public void onResponse(DeleteResponse response) {
                 try {
                     XContentBuilder builder = channel.newBuilder();
                     builder.startObject();

--- a/src/main/java/org/opensearch/searchrelevance/rest/RestPutABTestAction.java
+++ b/src/main/java/org/opensearch/searchrelevance/rest/RestPutABTestAction.java
@@ -1,0 +1,184 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+package org.opensearch.searchrelevance.rest;
+
+import static java.util.Collections.singletonList;
+import static org.opensearch.rest.RestRequest.Method.PUT;
+import static org.opensearch.searchrelevance.common.PluginConstants.AB_TESTS_URL;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.opensearch.ExceptionsHelper;
+import org.opensearch.action.index.IndexResponse;
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.core.rest.RestStatus;
+import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.rest.BaseRestHandler;
+import org.opensearch.rest.BytesRestResponse;
+import org.opensearch.rest.RestChannel;
+import org.opensearch.rest.RestRequest;
+import org.opensearch.searchrelevance.settings.SearchRelevanceSettingsAccessor;
+import org.opensearch.searchrelevance.transport.abTest.PutABTestAction;
+import org.opensearch.searchrelevance.transport.abTest.PutABTestRequest;
+import org.opensearch.searchrelevance.transport.abTest.UpdateABTestAction;
+import org.opensearch.searchrelevance.transport.abTest.UpdateABTestRequest;
+import org.opensearch.transport.client.node.NodeClient;
+
+import lombok.AllArgsConstructor;
+
+@AllArgsConstructor
+public class RestPutABTestAction extends BaseRestHandler {
+    private static final Logger LOGGER = LogManager.getLogger(RestPutABTestAction.class);
+    private static final String PUT_AB_TEST_ACTION = "put_ab_test_action";
+    private SearchRelevanceSettingsAccessor settingsAccessor;
+
+    @Override
+    public String getName() {
+        return PUT_AB_TEST_ACTION;
+    }
+
+    @Override
+    public List<Route> routes() {
+        return singletonList(new Route(PUT, AB_TESTS_URL + "/{id}"));
+    }
+
+    @Override
+    protected RestChannelConsumer prepareRequest(RestRequest request, NodeClient client) throws IOException {
+        if (!settingsAccessor.isWorkbenchEnabled()) {
+            return channel -> channel.sendResponse(new BytesRestResponse(RestStatus.FORBIDDEN, "Search Relevance Workbench is disabled"));
+        }
+
+        String testId = request.param("id");
+        if (testId == null || testId.isEmpty()) {
+            return channel -> channel.sendResponse(new BytesRestResponse(RestStatus.BAD_REQUEST, "test id is required in URL path"));
+        }
+
+        Map<String, Object> source = request.contentParser().map();
+
+        String searchConfigurationA = (String) source.get("search_configuration_a");
+        String searchConfigurationB = (String) source.get("search_configuration_b");
+        Boolean enabled = source.containsKey("enabled") ? (Boolean) source.get("enabled") : null;
+
+        // Validate: empty body
+        if (searchConfigurationA == null && searchConfigurationB == null && enabled == null) {
+            return channel -> channel.sendResponse(new BytesRestResponse(RestStatus.BAD_REQUEST, "Request body cannot be empty"));
+        }
+
+        // Validate: both configs are always mandatory (except for enable/disable toggle)
+        if (searchConfigurationA == null || searchConfigurationB == null) {
+            // Only exception: enable/disable toggle (no configs needed)
+            if (enabled != null && searchConfigurationA == null && searchConfigurationB == null) {
+                UpdateABTestRequest updateRequest = new UpdateABTestRequest(testId, enabled, null, null);
+                return channel -> client.execute(UpdateABTestAction.INSTANCE, updateRequest, createResponseListener(channel));
+            }
+            return channel -> channel.sendResponse(
+                new BytesRestResponse(RestStatus.BAD_REQUEST, "Both search_configuration_a and search_configuration_b are required")
+            );
+        }
+
+        // Validate: both configs must be different
+        if (searchConfigurationA.equals(searchConfigurationB)) {
+            return channel -> channel.sendResponse(
+                new BytesRestResponse(RestStatus.BAD_REQUEST, "search_configuration_a and search_configuration_b must be different")
+            );
+        }
+
+        // Both configs present: try CREATE first, fallback to UPDATE if test already exists
+        PutABTestRequest putRequest = new PutABTestRequest(testId, searchConfigurationA, searchConfigurationB);
+
+        return channel -> client.execute(PutABTestAction.INSTANCE, putRequest, new ActionListener<IndexResponse>() {
+            @Override
+            public void onResponse(IndexResponse response) {
+                try {
+                    XContentBuilder builder = channel.newBuilder();
+                    builder.startObject();
+                    builder.endObject();
+                    channel.sendResponse(new BytesRestResponse(RestStatus.OK, builder));
+                } catch (IOException e) {
+                    onFailure(e);
+                }
+            }
+
+            @Override
+            public void onFailure(Exception e) {
+                if (e.getMessage() != null && e.getMessage().contains("version conflict")) {
+                    // Test already exists → try UPDATE, return error if nothing changed
+                    UpdateABTestRequest updateRequest = new UpdateABTestRequest(
+                        testId,
+                        enabled,
+                        searchConfigurationA,
+                        searchConfigurationB
+                    );
+                    client.execute(UpdateABTestAction.INSTANCE, updateRequest, new ActionListener<IndexResponse>() {
+                        @Override
+                        public void onResponse(IndexResponse response) {
+                            try {
+                                if (response == null) {
+                                    // Nothing changed → return the version conflict error as-is
+                                    channel.sendResponse(new BytesRestResponse(channel, ExceptionsHelper.status(e), e));
+                                } else {
+                                    // Updated successfully
+                                    XContentBuilder builder = channel.newBuilder();
+                                    builder.startObject();
+                                    builder.endObject();
+                                    channel.sendResponse(new BytesRestResponse(RestStatus.OK, builder));
+                                }
+                            } catch (IOException ex) {
+                                LOGGER.error("Failed to send response", ex);
+                            }
+                        }
+
+                        @Override
+                        public void onFailure(Exception ex) {
+                            try {
+                                channel.sendResponse(new BytesRestResponse(channel, ExceptionsHelper.status(ex), ex));
+                            } catch (IOException ioEx) {
+                                LOGGER.error("Failed to send error response", ioEx);
+                            }
+                        }
+                    });
+                } else {
+                    try {
+                        channel.sendResponse(new BytesRestResponse(channel, ExceptionsHelper.status(e), e));
+                    } catch (IOException ex) {
+                        LOGGER.error("Failed to send error response", ex);
+                    }
+                }
+            }
+        });
+    }
+
+    private ActionListener<IndexResponse> createResponseListener(RestChannel channel) {
+        return new ActionListener<IndexResponse>() {
+            @Override
+            public void onResponse(IndexResponse response) {
+                try {
+                    XContentBuilder builder = channel.newBuilder();
+                    builder.startObject();
+                    builder.endObject();
+                    channel.sendResponse(new BytesRestResponse(RestStatus.OK, builder));
+                } catch (IOException e) {
+                    onFailure(e);
+                }
+            }
+
+            @Override
+            public void onFailure(Exception e) {
+                try {
+                    channel.sendResponse(new BytesRestResponse(channel, ExceptionsHelper.status(e), e));
+                } catch (IOException ex) {
+                    LOGGER.error("Failed to send error response", ex);
+                }
+            }
+        };
+    }
+}

--- a/src/main/java/org/opensearch/searchrelevance/rest/RestPutABTestAction.java
+++ b/src/main/java/org/opensearch/searchrelevance/rest/RestPutABTestAction.java
@@ -61,9 +61,31 @@ public class RestPutABTestAction extends BaseRestHandler {
 
         Map<String, Object> source = request.contentParser().map();
 
-        String searchConfigurationA = (String) source.get("search_configuration_a");
-        String searchConfigurationB = (String) source.get("search_configuration_b");
-        Boolean enabled = source.containsKey("enabled") ? (Boolean) source.get("enabled") : null;
+        if (source == null || source.isEmpty()) {
+            return channel -> channel.sendResponse(new BytesRestResponse(RestStatus.BAD_REQUEST, "Request body must not be empty"));
+        }
+
+        Object configAObj = source.get("search_configuration_a");
+        Object configBObj = source.get("search_configuration_b");
+        Object enabledObj = source.get("enabled");
+
+        if (configAObj != null && !(configAObj instanceof String)) {
+            return channel -> channel.sendResponse(
+                new BytesRestResponse(RestStatus.BAD_REQUEST, "search_configuration_a must be a string")
+            );
+        }
+        if (configBObj != null && !(configBObj instanceof String)) {
+            return channel -> channel.sendResponse(
+                new BytesRestResponse(RestStatus.BAD_REQUEST, "search_configuration_b must be a string")
+            );
+        }
+        if (enabledObj != null && !(enabledObj instanceof Boolean)) {
+            return channel -> channel.sendResponse(new BytesRestResponse(RestStatus.BAD_REQUEST, "enabled must be a boolean"));
+        }
+
+        String searchConfigurationA = (String) configAObj;
+        String searchConfigurationB = (String) configBObj;
+        Boolean enabled = (Boolean) enabledObj;
 
         if (searchConfigurationA == null || searchConfigurationB == null) {
             return channel -> channel.sendResponse(

--- a/src/main/java/org/opensearch/searchrelevance/rest/RestUpdateABTestAction.java
+++ b/src/main/java/org/opensearch/searchrelevance/rest/RestUpdateABTestAction.java
@@ -9,7 +9,7 @@ package org.opensearch.searchrelevance.rest;
 
 import static java.util.Collections.singletonList;
 import static org.opensearch.rest.RestRequest.Method.PUT;
-import static org.opensearch.searchrelevance.common.PluginConstants.AB_TESTS_URL;
+import static org.opensearch.searchrelevance.common.PluginConstants.AB_TEST_UPDATE_URL;
 
 import java.io.IOException;
 import java.util.List;
@@ -26,26 +26,26 @@ import org.opensearch.rest.BaseRestHandler;
 import org.opensearch.rest.BytesRestResponse;
 import org.opensearch.rest.RestRequest;
 import org.opensearch.searchrelevance.settings.SearchRelevanceSettingsAccessor;
-import org.opensearch.searchrelevance.transport.abTest.PutABTestAction;
-import org.opensearch.searchrelevance.transport.abTest.PutABTestRequest;
+import org.opensearch.searchrelevance.transport.abTest.UpdateABTestAction;
+import org.opensearch.searchrelevance.transport.abTest.UpdateABTestRequest;
 import org.opensearch.transport.client.node.NodeClient;
 
 import lombok.AllArgsConstructor;
 
 @AllArgsConstructor
-public class RestPutABTestAction extends BaseRestHandler {
-    private static final Logger LOGGER = LogManager.getLogger(RestPutABTestAction.class);
-    private static final String PUT_AB_TEST_ACTION = "put_ab_test_action";
+public class RestUpdateABTestAction extends BaseRestHandler {
+    private static final Logger LOGGER = LogManager.getLogger(RestUpdateABTestAction.class);
+    private static final String UPDATE_AB_TEST_ACTION = "update_ab_test_action";
     private SearchRelevanceSettingsAccessor settingsAccessor;
 
     @Override
     public String getName() {
-        return PUT_AB_TEST_ACTION;
+        return UPDATE_AB_TEST_ACTION;
     }
 
     @Override
     public List<Route> routes() {
-        return singletonList(new Route(PUT, AB_TESTS_URL + "/{id}"));
+        return singletonList(new Route(PUT, AB_TEST_UPDATE_URL));
     }
 
     @Override
@@ -65,21 +65,13 @@ public class RestPutABTestAction extends BaseRestHandler {
         String searchConfigurationB = (String) source.get("search_configuration_b");
         Boolean enabled = source.containsKey("enabled") ? (Boolean) source.get("enabled") : null;
 
-        if (searchConfigurationA == null || searchConfigurationB == null) {
-            return channel -> channel.sendResponse(
-                new BytesRestResponse(RestStatus.BAD_REQUEST, "Both search_configuration_a and search_configuration_b are required")
-            );
+        if (searchConfigurationA == null && searchConfigurationB == null && enabled == null) {
+            return channel -> channel.sendResponse(new BytesRestResponse(RestStatus.BAD_REQUEST, "Request body cannot be empty"));
         }
 
-        if (searchConfigurationA.equals(searchConfigurationB)) {
-            return channel -> channel.sendResponse(
-                new BytesRestResponse(RestStatus.BAD_REQUEST, "search_configuration_a and search_configuration_b must be different")
-            );
-        }
+        UpdateABTestRequest updateRequest = new UpdateABTestRequest(testId, enabled, searchConfigurationA, searchConfigurationB);
 
-        PutABTestRequest putRequest = new PutABTestRequest(testId, searchConfigurationA, searchConfigurationB, enabled);
-
-        return channel -> client.execute(PutABTestAction.INSTANCE, putRequest, new ActionListener<IndexResponse>() {
+        return channel -> client.execute(UpdateABTestAction.INSTANCE, updateRequest, new ActionListener<IndexResponse>() {
             @Override
             public void onResponse(IndexResponse response) {
                 try {

--- a/src/main/java/org/opensearch/searchrelevance/rest/RestUpdateABTestAction.java
+++ b/src/main/java/org/opensearch/searchrelevance/rest/RestUpdateABTestAction.java
@@ -61,12 +61,36 @@ public class RestUpdateABTestAction extends BaseRestHandler {
 
         Map<String, Object> source = request.contentParser().map();
 
-        String searchConfigurationA = (String) source.get("search_configuration_a");
-        String searchConfigurationB = (String) source.get("search_configuration_b");
-        Boolean enabled = source.containsKey("enabled") ? (Boolean) source.get("enabled") : null;
+        if (source == null || source.isEmpty()) {
+            return channel -> channel.sendResponse(new BytesRestResponse(RestStatus.BAD_REQUEST, "Request body must not be empty"));
+        }
+
+        Object configAObj = source.get("search_configuration_a");
+        Object configBObj = source.get("search_configuration_b");
+        Object enabledObj = source.get("enabled");
+
+        if (configAObj != null && !(configAObj instanceof String)) {
+            return channel -> channel.sendResponse(
+                new BytesRestResponse(RestStatus.BAD_REQUEST, "search_configuration_a must be a string")
+            );
+        }
+        if (configBObj != null && !(configBObj instanceof String)) {
+            return channel -> channel.sendResponse(
+                new BytesRestResponse(RestStatus.BAD_REQUEST, "search_configuration_b must be a string")
+            );
+        }
+        if (enabledObj != null && !(enabledObj instanceof Boolean)) {
+            return channel -> channel.sendResponse(new BytesRestResponse(RestStatus.BAD_REQUEST, "enabled must be a boolean"));
+        }
+
+        String searchConfigurationA = (String) configAObj;
+        String searchConfigurationB = (String) configBObj;
+        Boolean enabled = (Boolean) enabledObj;
 
         if (searchConfigurationA == null && searchConfigurationB == null && enabled == null) {
-            return channel -> channel.sendResponse(new BytesRestResponse(RestStatus.BAD_REQUEST, "Request body cannot be empty"));
+            return channel -> channel.sendResponse(
+                new BytesRestResponse(RestStatus.BAD_REQUEST, "At least one field must be provided for update")
+            );
         }
 
         UpdateABTestRequest updateRequest = new UpdateABTestRequest(testId, enabled, searchConfigurationA, searchConfigurationB);

--- a/src/main/java/org/opensearch/searchrelevance/transport/abTest/DeleteABTestAction.java
+++ b/src/main/java/org/opensearch/searchrelevance/transport/abTest/DeleteABTestAction.java
@@ -1,0 +1,22 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+package org.opensearch.searchrelevance.transport.abTest;
+
+import static org.opensearch.searchrelevance.common.PluginConstants.TRANSPORT_ACTION_NAME_PREFIX;
+
+import org.opensearch.action.ActionType;
+import org.opensearch.action.delete.DeleteResponse;
+
+public class DeleteABTestAction extends ActionType<DeleteResponse> {
+    public static final String NAME = TRANSPORT_ACTION_NAME_PREFIX + "ab_test/delete";
+    public static final DeleteABTestAction INSTANCE = new DeleteABTestAction();
+
+    private DeleteABTestAction() {
+        super(NAME, DeleteResponse::new);
+    }
+}

--- a/src/main/java/org/opensearch/searchrelevance/transport/abTest/DeleteABTestRequest.java
+++ b/src/main/java/org/opensearch/searchrelevance/transport/abTest/DeleteABTestRequest.java
@@ -17,34 +17,22 @@ import org.opensearch.core.common.io.stream.StreamOutput;
 import lombok.Getter;
 
 @Getter
-public class PutABTestRequest extends ActionRequest {
+public class DeleteABTestRequest extends ActionRequest {
     private final String testId;
-    private final String searchConfigurationA;
-    private final String searchConfigurationB;
-    private final Boolean enabled;
 
-    public PutABTestRequest(String testId, String searchConfigurationA, String searchConfigurationB, Boolean enabled) {
+    public DeleteABTestRequest(String testId) {
         this.testId = testId;
-        this.searchConfigurationA = searchConfigurationA;
-        this.searchConfigurationB = searchConfigurationB;
-        this.enabled = enabled;
     }
 
-    public PutABTestRequest(StreamInput in) throws IOException {
+    public DeleteABTestRequest(StreamInput in) throws IOException {
         super(in);
         this.testId = in.readString();
-        this.searchConfigurationA = in.readString();
-        this.searchConfigurationB = in.readString();
-        this.enabled = in.readOptionalBoolean();
     }
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
         out.writeString(testId);
-        out.writeString(searchConfigurationA);
-        out.writeString(searchConfigurationB);
-        out.writeOptionalBoolean(enabled);
     }
 
     @Override

--- a/src/main/java/org/opensearch/searchrelevance/transport/abTest/DeleteABTestTransportAction.java
+++ b/src/main/java/org/opensearch/searchrelevance/transport/abTest/DeleteABTestTransportAction.java
@@ -1,0 +1,49 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+package org.opensearch.searchrelevance.transport.abTest;
+
+import org.opensearch.action.delete.DeleteResponse;
+import org.opensearch.action.support.ActionFilters;
+import org.opensearch.action.support.HandledTransportAction;
+import org.opensearch.common.inject.Inject;
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.core.rest.RestStatus;
+import org.opensearch.searchrelevance.dao.ABTestDao;
+import org.opensearch.searchrelevance.exception.SearchRelevanceException;
+import org.opensearch.tasks.Task;
+import org.opensearch.transport.TransportService;
+
+public class DeleteABTestTransportAction extends HandledTransportAction<DeleteABTestRequest, DeleteResponse> {
+
+    private final ABTestDao abTestDao;
+
+    @Inject
+    public DeleteABTestTransportAction(TransportService transportService, ActionFilters actionFilters, ABTestDao abTestDao) {
+        super(DeleteABTestAction.NAME, transportService, actionFilters, DeleteABTestRequest::new);
+        this.abTestDao = abTestDao;
+    }
+
+    @Override
+    protected void doExecute(Task task, DeleteABTestRequest request, ActionListener<DeleteResponse> listener) {
+        if (request == null || request.getTestId() == null) {
+            listener.onFailure(new SearchRelevanceException("Request and testId cannot be null", RestStatus.BAD_REQUEST));
+            return;
+        }
+
+        String testId = request.getTestId();
+
+        // Verify test exists before deleting
+        abTestDao.getABTest(testId, ActionListener.wrap(searchResponse -> {
+            // Test exists — delete snapshots first, then live doc
+            abTestDao.deleteSnapshotsByTestId(
+                testId,
+                ActionListener.wrap(bulkResponse -> abTestDao.deleteABTest(testId, listener), listener::onFailure)
+            );
+        }, e -> listener.onFailure(new SearchRelevanceException("AB test '" + testId + "' not found", RestStatus.NOT_FOUND))));
+    }
+}

--- a/src/main/java/org/opensearch/searchrelevance/transport/abTest/PutABTestAction.java
+++ b/src/main/java/org/opensearch/searchrelevance/transport/abTest/PutABTestAction.java
@@ -1,0 +1,22 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+package org.opensearch.searchrelevance.transport.abTest;
+
+import static org.opensearch.searchrelevance.common.PluginConstants.TRANSPORT_ACTION_NAME_PREFIX;
+
+import org.opensearch.action.ActionType;
+import org.opensearch.action.index.IndexResponse;
+
+public class PutABTestAction extends ActionType<IndexResponse> {
+    public static final String NAME = TRANSPORT_ACTION_NAME_PREFIX + "ab_test/create";
+    public static final PutABTestAction INSTANCE = new PutABTestAction();
+
+    private PutABTestAction() {
+        super(NAME, IndexResponse::new);
+    }
+}

--- a/src/main/java/org/opensearch/searchrelevance/transport/abTest/PutABTestRequest.java
+++ b/src/main/java/org/opensearch/searchrelevance/transport/abTest/PutABTestRequest.java
@@ -1,0 +1,50 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+package org.opensearch.searchrelevance.transport.abTest;
+
+import java.io.IOException;
+
+import org.opensearch.action.ActionRequest;
+import org.opensearch.action.ActionRequestValidationException;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.common.io.stream.StreamOutput;
+
+import lombok.Getter;
+
+@Getter
+public class PutABTestRequest extends ActionRequest {
+    private final String testId;
+    private final String searchConfigurationA;
+    private final String searchConfigurationB;
+
+    public PutABTestRequest(String testId, String searchConfigurationA, String searchConfigurationB) {
+        this.testId = testId;
+        this.searchConfigurationA = searchConfigurationA;
+        this.searchConfigurationB = searchConfigurationB;
+    }
+
+    public PutABTestRequest(StreamInput in) throws IOException {
+        super(in);
+        this.testId = in.readString();
+        this.searchConfigurationA = in.readString();
+        this.searchConfigurationB = in.readString();
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        super.writeTo(out);
+        out.writeString(testId);
+        out.writeString(searchConfigurationA);
+        out.writeString(searchConfigurationB);
+    }
+
+    @Override
+    public ActionRequestValidationException validate() {
+        return null;
+    }
+}

--- a/src/main/java/org/opensearch/searchrelevance/transport/abTest/PutABTestTransportAction.java
+++ b/src/main/java/org/opensearch/searchrelevance/transport/abTest/PutABTestTransportAction.java
@@ -13,6 +13,7 @@ import org.opensearch.action.StepListener;
 import org.opensearch.action.index.IndexResponse;
 import org.opensearch.action.search.SearchResponse;
 import org.opensearch.action.support.ActionFilters;
+import org.opensearch.action.support.GroupedActionListener;
 import org.opensearch.action.support.HandledTransportAction;
 import org.opensearch.common.inject.Inject;
 import org.opensearch.core.action.ActionListener;
@@ -56,47 +57,33 @@ public class PutABTestTransportAction extends HandledTransportAction<PutABTestRe
             return;
         }
 
-        // Validate config A exists
-        searchConfigurationDao.getSearchConfiguration(request.getSearchConfigurationA(), new ActionListener<SearchResponse>() {
-            @Override
-            public void onResponse(SearchResponse responseA) {
-                // Validate config B exists
-                searchConfigurationDao.getSearchConfiguration(request.getSearchConfigurationB(), new ActionListener<SearchResponse>() {
-                    @Override
-                    public void onResponse(SearchResponse responseB) {
-                        // Both configs exist → proceed with creation
-                        createABTest(request, listener);
-                    }
+        // Validate both configs exist in parallel
+        GroupedActionListener<SearchResponse> groupedListener = new GroupedActionListener<>(
+            ActionListener.wrap(responses -> createABTest(request, listener), e -> {
+                if (e instanceof org.opensearch.ResourceNotFoundException) {
+                    listener.onFailure(new SearchRelevanceException("One or more search configurations not found", RestStatus.BAD_REQUEST));
+                } else {
+                    listener.onFailure(e);
+                }
+            }),
+            2
+        );
 
-                    @Override
-                    public void onFailure(Exception e) {
-                        listener.onFailure(
-                            new SearchRelevanceException(
-                                "search_configuration_b '" + request.getSearchConfigurationB() + "' not found",
-                                RestStatus.BAD_REQUEST
-                            )
-                        );
-                    }
-                });
-            }
+        searchConfigurationDao.getSearchConfiguration(request.getSearchConfigurationA(), groupedListener);
+        searchConfigurationDao.getSearchConfiguration(request.getSearchConfigurationB(), groupedListener);
+    }
 
-            @Override
-            public void onFailure(Exception e) {
-                listener.onFailure(
-                    new SearchRelevanceException(
-                        "search_configuration_a '" + request.getSearchConfigurationA() + "' not found",
-                        RestStatus.BAD_REQUEST
-                    )
-                );
-            }
-        });
+    private String generateUuid() {
+        return UUID.randomUUID().toString();
     }
 
     private void createABTest(PutABTestRequest request, ActionListener<IndexResponse> listener) {
         String testId = request.getTestId();
-        String configAUuid = UUID.randomUUID().toString();
-        String configBUuid = UUID.randomUUID().toString();
+        String configAUuid = generateUuid();
+        String configBUuid = generateUuid();
         String timestamp = TimeUtils.getTimestamp();
+
+        boolean enabled = request.getEnabled() != null ? request.getEnabled() : true;
 
         ABTest abTest = new ABTest(
             testId,
@@ -104,7 +91,7 @@ public class PutABTestTransportAction extends HandledTransportAction<PutABTestRe
             request.getSearchConfigurationB(),
             configAUuid,
             configBUuid,
-            true,
+            enabled,
             0,
             timestamp,
             timestamp

--- a/src/main/java/org/opensearch/searchrelevance/transport/abTest/PutABTestTransportAction.java
+++ b/src/main/java/org/opensearch/searchrelevance/transport/abTest/PutABTestTransportAction.java
@@ -1,0 +1,117 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+package org.opensearch.searchrelevance.transport.abTest;
+
+import java.util.UUID;
+
+import org.opensearch.action.StepListener;
+import org.opensearch.action.index.IndexResponse;
+import org.opensearch.action.search.SearchResponse;
+import org.opensearch.action.support.ActionFilters;
+import org.opensearch.action.support.HandledTransportAction;
+import org.opensearch.common.inject.Inject;
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.core.rest.RestStatus;
+import org.opensearch.searchrelevance.dao.ABTestDao;
+import org.opensearch.searchrelevance.dao.SearchConfigurationDao;
+import org.opensearch.searchrelevance.exception.SearchRelevanceException;
+import org.opensearch.searchrelevance.model.ABTest;
+import org.opensearch.searchrelevance.utils.TimeUtils;
+import org.opensearch.tasks.Task;
+import org.opensearch.transport.TransportService;
+
+public class PutABTestTransportAction extends HandledTransportAction<PutABTestRequest, IndexResponse> {
+
+    private final ABTestDao abTestDao;
+    private final SearchConfigurationDao searchConfigurationDao;
+
+    @Inject
+    public PutABTestTransportAction(
+        TransportService transportService,
+        ActionFilters actionFilters,
+        ABTestDao abTestDao,
+        SearchConfigurationDao searchConfigurationDao
+    ) {
+        super(PutABTestAction.NAME, transportService, actionFilters, PutABTestRequest::new);
+        this.abTestDao = abTestDao;
+        this.searchConfigurationDao = searchConfigurationDao;
+    }
+
+    @Override
+    protected void doExecute(Task task, PutABTestRequest request, ActionListener<IndexResponse> listener) {
+        if (request == null) {
+            listener.onFailure(new SearchRelevanceException("Request cannot be null", RestStatus.BAD_REQUEST));
+            return;
+        }
+
+        if (request.getSearchConfigurationA().equals(request.getSearchConfigurationB())) {
+            listener.onFailure(
+                new SearchRelevanceException("search_configuration_a and search_configuration_b must be different", RestStatus.BAD_REQUEST)
+            );
+            return;
+        }
+
+        // Validate config A exists
+        searchConfigurationDao.getSearchConfiguration(request.getSearchConfigurationA(), new ActionListener<SearchResponse>() {
+            @Override
+            public void onResponse(SearchResponse responseA) {
+                // Validate config B exists
+                searchConfigurationDao.getSearchConfiguration(request.getSearchConfigurationB(), new ActionListener<SearchResponse>() {
+                    @Override
+                    public void onResponse(SearchResponse responseB) {
+                        // Both configs exist → proceed with creation
+                        createABTest(request, listener);
+                    }
+
+                    @Override
+                    public void onFailure(Exception e) {
+                        listener.onFailure(
+                            new SearchRelevanceException(
+                                "search_configuration_b '" + request.getSearchConfigurationB() + "' not found",
+                                RestStatus.BAD_REQUEST
+                            )
+                        );
+                    }
+                });
+            }
+
+            @Override
+            public void onFailure(Exception e) {
+                listener.onFailure(
+                    new SearchRelevanceException(
+                        "search_configuration_a '" + request.getSearchConfigurationA() + "' not found",
+                        RestStatus.BAD_REQUEST
+                    )
+                );
+            }
+        });
+    }
+
+    private void createABTest(PutABTestRequest request, ActionListener<IndexResponse> listener) {
+        String testId = request.getTestId();
+        String configAUuid = UUID.randomUUID().toString();
+        String configBUuid = UUID.randomUUID().toString();
+        String timestamp = TimeUtils.getTimestamp();
+
+        ABTest abTest = new ABTest(
+            testId,
+            request.getSearchConfigurationA(),
+            request.getSearchConfigurationB(),
+            configAUuid,
+            configBUuid,
+            true,
+            0,
+            timestamp,
+            timestamp
+        );
+
+        StepListener<Void> createIndexStep = new StepListener<>();
+        abTestDao.createIndexIfAbsent(createIndexStep);
+        createIndexStep.whenComplete(v -> abTestDao.putABTest(abTest, listener), listener::onFailure);
+    }
+}

--- a/src/main/java/org/opensearch/searchrelevance/transport/abTest/UpdateABTestAction.java
+++ b/src/main/java/org/opensearch/searchrelevance/transport/abTest/UpdateABTestAction.java
@@ -1,0 +1,22 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+package org.opensearch.searchrelevance.transport.abTest;
+
+import static org.opensearch.searchrelevance.common.PluginConstants.TRANSPORT_ACTION_NAME_PREFIX;
+
+import org.opensearch.action.ActionType;
+import org.opensearch.action.index.IndexResponse;
+
+public class UpdateABTestAction extends ActionType<IndexResponse> {
+    public static final String NAME = TRANSPORT_ACTION_NAME_PREFIX + "ab_test/update";
+    public static final UpdateABTestAction INSTANCE = new UpdateABTestAction();
+
+    private UpdateABTestAction() {
+        super(NAME, IndexResponse::new);
+    }
+}

--- a/src/main/java/org/opensearch/searchrelevance/transport/abTest/UpdateABTestRequest.java
+++ b/src/main/java/org/opensearch/searchrelevance/transport/abTest/UpdateABTestRequest.java
@@ -1,0 +1,54 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+package org.opensearch.searchrelevance.transport.abTest;
+
+import java.io.IOException;
+
+import org.opensearch.action.ActionRequest;
+import org.opensearch.action.ActionRequestValidationException;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.common.io.stream.StreamOutput;
+
+import lombok.Getter;
+
+@Getter
+public class UpdateABTestRequest extends ActionRequest {
+    private final String testId;
+    private final Boolean enabled;
+    private final String searchConfigurationA;
+    private final String searchConfigurationB;
+
+    public UpdateABTestRequest(String testId, Boolean enabled, String searchConfigurationA, String searchConfigurationB) {
+        this.testId = testId;
+        this.enabled = enabled;
+        this.searchConfigurationA = searchConfigurationA;
+        this.searchConfigurationB = searchConfigurationB;
+    }
+
+    public UpdateABTestRequest(StreamInput in) throws IOException {
+        super(in);
+        this.testId = in.readString();
+        this.enabled = in.readOptionalBoolean();
+        this.searchConfigurationA = in.readOptionalString();
+        this.searchConfigurationB = in.readOptionalString();
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        super.writeTo(out);
+        out.writeString(testId);
+        out.writeOptionalBoolean(enabled);
+        out.writeOptionalString(searchConfigurationA);
+        out.writeOptionalString(searchConfigurationB);
+    }
+
+    @Override
+    public ActionRequestValidationException validate() {
+        return null;
+    }
+}

--- a/src/main/java/org/opensearch/searchrelevance/transport/abTest/UpdateABTestTransportAction.java
+++ b/src/main/java/org/opensearch/searchrelevance/transport/abTest/UpdateABTestTransportAction.java
@@ -1,0 +1,214 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+package org.opensearch.searchrelevance.transport.abTest;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.opensearch.action.index.IndexResponse;
+import org.opensearch.action.search.SearchResponse;
+import org.opensearch.action.support.ActionFilters;
+import org.opensearch.action.support.HandledTransportAction;
+import org.opensearch.common.inject.Inject;
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.core.rest.RestStatus;
+import org.opensearch.searchrelevance.dao.ABTestDao;
+import org.opensearch.searchrelevance.dao.SearchConfigurationDao;
+import org.opensearch.searchrelevance.exception.SearchRelevanceException;
+import org.opensearch.searchrelevance.model.ABTest;
+import org.opensearch.searchrelevance.utils.TimeUtils;
+import org.opensearch.tasks.Task;
+import org.opensearch.transport.TransportService;
+
+public class UpdateABTestTransportAction extends HandledTransportAction<UpdateABTestRequest, IndexResponse> {
+
+    private final ABTestDao abTestDao;
+    private final SearchConfigurationDao searchConfigurationDao;
+
+    @Inject
+    public UpdateABTestTransportAction(
+        TransportService transportService,
+        ActionFilters actionFilters,
+        ABTestDao abTestDao,
+        SearchConfigurationDao searchConfigurationDao
+    ) {
+        super(UpdateABTestAction.NAME, transportService, actionFilters, UpdateABTestRequest::new);
+        this.abTestDao = abTestDao;
+        this.searchConfigurationDao = searchConfigurationDao;
+    }
+
+    @Override
+    protected void doExecute(Task task, UpdateABTestRequest request, ActionListener<IndexResponse> listener) {
+        if (request == null || request.getTestId() == null) {
+            listener.onFailure(new SearchRelevanceException("Request and testId cannot be null", RestStatus.BAD_REQUEST));
+            return;
+        }
+
+        // Validate config IDs if they are being changed
+        if (request.getSearchConfigurationA() != null || request.getSearchConfigurationB() != null) {
+            validateAndUpdate(request, listener);
+        } else {
+            // Only enabled toggle — no config validation needed
+            performUpdate(request, listener);
+        }
+    }
+
+    private void validateAndUpdate(UpdateABTestRequest request, ActionListener<IndexResponse> listener) {
+        ActionListener<SearchResponse> afterValidation = ActionListener.wrap(
+            response -> performUpdate(request, listener),
+            listener::onFailure
+        );
+
+        if (request.getSearchConfigurationA() != null && request.getSearchConfigurationB() != null) {
+            // Both configs changing — validate A then B
+            searchConfigurationDao.getSearchConfiguration(request.getSearchConfigurationA(), new ActionListener<SearchResponse>() {
+                @Override
+                public void onResponse(SearchResponse responseA) {
+                    searchConfigurationDao.getSearchConfiguration(request.getSearchConfigurationB(), new ActionListener<SearchResponse>() {
+                        @Override
+                        public void onResponse(SearchResponse responseB) {
+                            performUpdate(request, listener);
+                        }
+
+                        @Override
+                        public void onFailure(Exception e) {
+                            listener.onFailure(
+                                new SearchRelevanceException(
+                                    "search_configuration_b '" + request.getSearchConfigurationB() + "' not found",
+                                    RestStatus.BAD_REQUEST
+                                )
+                            );
+                        }
+                    });
+                }
+
+                @Override
+                public void onFailure(Exception e) {
+                    listener.onFailure(
+                        new SearchRelevanceException(
+                            "search_configuration_a '" + request.getSearchConfigurationA() + "' not found",
+                            RestStatus.BAD_REQUEST
+                        )
+                    );
+                }
+            });
+        } else if (request.getSearchConfigurationA() != null) {
+            searchConfigurationDao.getSearchConfiguration(request.getSearchConfigurationA(), new ActionListener<SearchResponse>() {
+                @Override
+                public void onResponse(SearchResponse response) {
+                    performUpdate(request, listener);
+                }
+
+                @Override
+                public void onFailure(Exception e) {
+                    listener.onFailure(
+                        new SearchRelevanceException(
+                            "search_configuration_a '" + request.getSearchConfigurationA() + "' not found",
+                            RestStatus.BAD_REQUEST
+                        )
+                    );
+                }
+            });
+        } else {
+            searchConfigurationDao.getSearchConfiguration(request.getSearchConfigurationB(), new ActionListener<SearchResponse>() {
+                @Override
+                public void onResponse(SearchResponse response) {
+                    performUpdate(request, listener);
+                }
+
+                @Override
+                public void onFailure(Exception e) {
+                    listener.onFailure(
+                        new SearchRelevanceException(
+                            "search_configuration_b '" + request.getSearchConfigurationB() + "' not found",
+                            RestStatus.BAD_REQUEST
+                        )
+                    );
+                }
+            });
+        }
+    }
+
+    private void performUpdate(UpdateABTestRequest request, ActionListener<IndexResponse> listener) {
+        abTestDao.getABTest(request.getTestId(), new ActionListener<SearchResponse>() {
+            @Override
+            public void onResponse(SearchResponse searchResponse) {
+                try {
+                    Map<String, Object> source = searchResponse.getHits().getHits()[0].getSourceAsMap();
+                    ABTest currentTest = new ABTest(
+                        (String) source.get(ABTest.TEST_ID),
+                        (String) source.get(ABTest.SEARCH_CONFIGURATION_A),
+                        (String) source.get(ABTest.SEARCH_CONFIGURATION_B),
+                        (String) source.get(ABTest.CONFIG_A_UUID),
+                        (String) source.get(ABTest.CONFIG_B_UUID),
+                        (Boolean) source.get(ABTest.ENABLED),
+                        (Integer) source.get(ABTest.VERSION),
+                        (String) source.get(ABTest.CREATED_AT),
+                        (String) source.get(ABTest.UPDATED_AT)
+                    );
+
+                    // Apply updates
+                    boolean newEnabled = request.getEnabled() != null ? request.getEnabled() : currentTest.isEnabled();
+                    String newConfigA = request.getSearchConfigurationA() != null
+                        ? request.getSearchConfigurationA()
+                        : currentTest.getSearchConfigurationA();
+                    String newConfigB = request.getSearchConfigurationB() != null
+                        ? request.getSearchConfigurationB()
+                        : currentTest.getSearchConfigurationB();
+
+                    // Skip if nothing changed
+                    if (newEnabled == currentTest.isEnabled()
+                        && newConfigA.equals(currentTest.getSearchConfigurationA())
+                        && newConfigB.equals(currentTest.getSearchConfigurationB())) {
+                        listener.onResponse((IndexResponse) null);
+                        return;
+                    }
+
+                    // Save snapshot of current state before updating
+                    Map<String, Object> record = new HashMap<>();
+                    record.put(ABTest.SEARCH_CONFIGURATION_A, currentTest.getSearchConfigurationA());
+                    record.put(ABTest.SEARCH_CONFIGURATION_B, currentTest.getSearchConfigurationB());
+                    record.put(ABTest.CONFIG_A_UUID, currentTest.getConfigAUuid());
+                    record.put(ABTest.CONFIG_B_UUID, currentTest.getConfigBUuid());
+                    record.put(ABTest.ENABLED, currentTest.isEnabled());
+
+                    String snapshotId = currentTest.getTestId() + "_" + currentTest.getVersion();
+                    String now = TimeUtils.getTimestamp();
+
+                    ABTest updatedTest = new ABTest(
+                        currentTest.getTestId(),
+                        newConfigA,
+                        newConfigB,
+                        currentTest.getConfigAUuid(),
+                        currentTest.getConfigBUuid(),
+                        newEnabled,
+                        currentTest.getVersion() + 1,
+                        currentTest.getCreatedAt(),
+                        now
+                    );
+
+                    // Save snapshot then update live doc
+                    abTestDao.putSnapshot(
+                        snapshotId,
+                        currentTest.getTestId(),
+                        record,
+                        now,
+                        ActionListener.wrap(snapshotResponse -> abTestDao.updateABTest(updatedTest, listener), listener::onFailure)
+                    );
+                } catch (Exception e) {
+                    listener.onFailure(new SearchRelevanceException("Failed to update ABTest", e, RestStatus.INTERNAL_SERVER_ERROR));
+                }
+            }
+
+            @Override
+            public void onFailure(Exception e) {
+                listener.onFailure(new SearchRelevanceException("Failed to retrieve ABTest", e, RestStatus.INTERNAL_SERVER_ERROR));
+            }
+        });
+    }
+}

--- a/src/main/java/org/opensearch/searchrelevance/transport/abTest/UpdateABTestTransportAction.java
+++ b/src/main/java/org/opensearch/searchrelevance/transport/abTest/UpdateABTestTransportAction.java
@@ -13,6 +13,7 @@ import java.util.Map;
 import org.opensearch.action.index.IndexResponse;
 import org.opensearch.action.search.SearchResponse;
 import org.opensearch.action.support.ActionFilters;
+import org.opensearch.action.support.GroupedActionListener;
 import org.opensearch.action.support.HandledTransportAction;
 import org.opensearch.common.inject.Inject;
 import org.opensearch.core.action.ActionListener;
@@ -21,6 +22,7 @@ import org.opensearch.searchrelevance.dao.ABTestDao;
 import org.opensearch.searchrelevance.dao.SearchConfigurationDao;
 import org.opensearch.searchrelevance.exception.SearchRelevanceException;
 import org.opensearch.searchrelevance.model.ABTest;
+import org.opensearch.searchrelevance.model.ABTestSnapshot;
 import org.opensearch.searchrelevance.utils.TimeUtils;
 import org.opensearch.tasks.Task;
 import org.opensearch.transport.TransportService;
@@ -59,78 +61,27 @@ public class UpdateABTestTransportAction extends HandledTransportAction<UpdateAB
     }
 
     private void validateAndUpdate(UpdateABTestRequest request, ActionListener<IndexResponse> listener) {
-        ActionListener<SearchResponse> afterValidation = ActionListener.wrap(
-            response -> performUpdate(request, listener),
-            listener::onFailure
+        java.util.List<String> configsToValidate = new java.util.ArrayList<>();
+        if (request.getSearchConfigurationA() != null) {
+            configsToValidate.add(request.getSearchConfigurationA());
+        }
+        if (request.getSearchConfigurationB() != null) {
+            configsToValidate.add(request.getSearchConfigurationB());
+        }
+
+        GroupedActionListener<SearchResponse> groupedListener = new GroupedActionListener<>(
+            ActionListener.wrap(responses -> performUpdate(request, listener), e -> {
+                if (e instanceof org.opensearch.ResourceNotFoundException) {
+                    listener.onFailure(new SearchRelevanceException("One or more search configurations not found", RestStatus.BAD_REQUEST));
+                } else {
+                    listener.onFailure(e);
+                }
+            }),
+            configsToValidate.size()
         );
 
-        if (request.getSearchConfigurationA() != null && request.getSearchConfigurationB() != null) {
-            // Both configs changing — validate A then B
-            searchConfigurationDao.getSearchConfiguration(request.getSearchConfigurationA(), new ActionListener<SearchResponse>() {
-                @Override
-                public void onResponse(SearchResponse responseA) {
-                    searchConfigurationDao.getSearchConfiguration(request.getSearchConfigurationB(), new ActionListener<SearchResponse>() {
-                        @Override
-                        public void onResponse(SearchResponse responseB) {
-                            performUpdate(request, listener);
-                        }
-
-                        @Override
-                        public void onFailure(Exception e) {
-                            listener.onFailure(
-                                new SearchRelevanceException(
-                                    "search_configuration_b '" + request.getSearchConfigurationB() + "' not found",
-                                    RestStatus.BAD_REQUEST
-                                )
-                            );
-                        }
-                    });
-                }
-
-                @Override
-                public void onFailure(Exception e) {
-                    listener.onFailure(
-                        new SearchRelevanceException(
-                            "search_configuration_a '" + request.getSearchConfigurationA() + "' not found",
-                            RestStatus.BAD_REQUEST
-                        )
-                    );
-                }
-            });
-        } else if (request.getSearchConfigurationA() != null) {
-            searchConfigurationDao.getSearchConfiguration(request.getSearchConfigurationA(), new ActionListener<SearchResponse>() {
-                @Override
-                public void onResponse(SearchResponse response) {
-                    performUpdate(request, listener);
-                }
-
-                @Override
-                public void onFailure(Exception e) {
-                    listener.onFailure(
-                        new SearchRelevanceException(
-                            "search_configuration_a '" + request.getSearchConfigurationA() + "' not found",
-                            RestStatus.BAD_REQUEST
-                        )
-                    );
-                }
-            });
-        } else {
-            searchConfigurationDao.getSearchConfiguration(request.getSearchConfigurationB(), new ActionListener<SearchResponse>() {
-                @Override
-                public void onResponse(SearchResponse response) {
-                    performUpdate(request, listener);
-                }
-
-                @Override
-                public void onFailure(Exception e) {
-                    listener.onFailure(
-                        new SearchRelevanceException(
-                            "search_configuration_b '" + request.getSearchConfigurationB() + "' not found",
-                            RestStatus.BAD_REQUEST
-                        )
-                    );
-                }
-            });
+        for (String configId : configsToValidate) {
+            searchConfigurationDao.getSearchConfiguration(configId, groupedListener);
         }
     }
 
@@ -161,6 +112,17 @@ public class UpdateABTestTransportAction extends HandledTransportAction<UpdateAB
                         ? request.getSearchConfigurationB()
                         : currentTest.getSearchConfigurationB();
 
+                    // Validate: resulting configs must be different
+                    if (newConfigA.equals(newConfigB)) {
+                        listener.onFailure(
+                            new SearchRelevanceException(
+                                "search_configuration_a and search_configuration_b must be different",
+                                RestStatus.BAD_REQUEST
+                            )
+                        );
+                        return;
+                    }
+
                     // Skip if nothing changed
                     if (newEnabled == currentTest.isEnabled()
                         && newConfigA.equals(currentTest.getSearchConfigurationA())
@@ -170,6 +132,9 @@ public class UpdateABTestTransportAction extends HandledTransportAction<UpdateAB
                     }
 
                     // Save snapshot of current state before updating
+                    String snapshotId = currentTest.getTestId() + "_" + currentTest.getVersion();
+                    String now = TimeUtils.getTimestamp();
+
                     Map<String, Object> record = new HashMap<>();
                     record.put(ABTest.SEARCH_CONFIGURATION_A, currentTest.getSearchConfigurationA());
                     record.put(ABTest.SEARCH_CONFIGURATION_B, currentTest.getSearchConfigurationB());
@@ -177,8 +142,7 @@ public class UpdateABTestTransportAction extends HandledTransportAction<UpdateAB
                     record.put(ABTest.CONFIG_B_UUID, currentTest.getConfigBUuid());
                     record.put(ABTest.ENABLED, currentTest.isEnabled());
 
-                    String snapshotId = currentTest.getTestId() + "_" + currentTest.getVersion();
-                    String now = TimeUtils.getTimestamp();
+                    ABTestSnapshot snapshot = new ABTestSnapshot(snapshotId, currentTest.getTestId(), record, now);
 
                     ABTest updatedTest = new ABTest(
                         currentTest.getTestId(),
@@ -194,10 +158,7 @@ public class UpdateABTestTransportAction extends HandledTransportAction<UpdateAB
 
                     // Save snapshot then update live doc
                     abTestDao.putSnapshot(
-                        snapshotId,
-                        currentTest.getTestId(),
-                        record,
-                        now,
+                        snapshot,
                         ActionListener.wrap(snapshotResponse -> abTestDao.updateABTest(updatedTest, listener), listener::onFailure)
                     );
                 } catch (Exception e) {
@@ -207,7 +168,11 @@ public class UpdateABTestTransportAction extends HandledTransportAction<UpdateAB
 
             @Override
             public void onFailure(Exception e) {
-                listener.onFailure(new SearchRelevanceException("Failed to retrieve ABTest", e, RestStatus.INTERNAL_SERVER_ERROR));
+                if (e instanceof org.opensearch.ResourceNotFoundException) {
+                    listener.onFailure(new SearchRelevanceException("AB test not found", RestStatus.NOT_FOUND));
+                } else {
+                    listener.onFailure(new SearchRelevanceException("Failed to retrieve ABTest", e, RestStatus.INTERNAL_SERVER_ERROR));
+                }
             }
         });
     }

--- a/src/main/java/org/opensearch/searchrelevance/transport/abTest/UpdateABTestTransportAction.java
+++ b/src/main/java/org/opensearch/searchrelevance/transport/abTest/UpdateABTestTransportAction.java
@@ -92,7 +92,7 @@ public class UpdateABTestTransportAction extends HandledTransportAction<UpdateAB
     }
 
     private void performUpdateWithRetry(UpdateABTestRequest request, ActionListener<IndexResponse> listener, int attempt) {
-        abTestDao.getABTest(request.getTestId(), new ActionListener<SearchResponse>() {
+        abTestDao.getABTestWithSeqNo(request.getTestId(), new ActionListener<SearchResponse>() {
             @Override
             public void onResponse(SearchResponse searchResponse) {
                 try {

--- a/src/main/java/org/opensearch/searchrelevance/transport/abTest/UpdateABTestTransportAction.java
+++ b/src/main/java/org/opensearch/searchrelevance/transport/abTest/UpdateABTestTransportAction.java
@@ -85,12 +85,22 @@ public class UpdateABTestTransportAction extends HandledTransportAction<UpdateAB
         }
     }
 
+    private static final int MAX_RETRIES = 3;
+
     private void performUpdate(UpdateABTestRequest request, ActionListener<IndexResponse> listener) {
+        performUpdateWithRetry(request, listener, 0);
+    }
+
+    private void performUpdateWithRetry(UpdateABTestRequest request, ActionListener<IndexResponse> listener, int attempt) {
         abTestDao.getABTest(request.getTestId(), new ActionListener<SearchResponse>() {
             @Override
             public void onResponse(SearchResponse searchResponse) {
                 try {
-                    Map<String, Object> source = searchResponse.getHits().getHits()[0].getSourceAsMap();
+                    org.opensearch.search.SearchHit hit = searchResponse.getHits().getHits()[0];
+                    long seqNo = hit.getSeqNo();
+                    long primaryTerm = hit.getPrimaryTerm();
+                    Map<String, Object> source = hit.getSourceAsMap();
+
                     ABTest currentTest = new ABTest(
                         (String) source.get(ABTest.TEST_ID),
                         (String) source.get(ABTest.SEARCH_CONFIGURATION_A),
@@ -156,10 +166,33 @@ public class UpdateABTestTransportAction extends HandledTransportAction<UpdateAB
                         now
                     );
 
-                    // Save snapshot then update live doc
+                    // Save snapshot then update live doc with optimistic concurrency
+                    ActionListener<IndexResponse> concurrencyListener = new ActionListener<IndexResponse>() {
+                        @Override
+                        public void onResponse(IndexResponse response) {
+                            listener.onResponse(response);
+                        }
+
+                        @Override
+                        public void onFailure(Exception e) {
+                            if (e instanceof org.opensearch.index.engine.VersionConflictEngineException && attempt < MAX_RETRIES) {
+                                performUpdateWithRetry(request, listener, attempt + 1);
+                            } else {
+                                listener.onFailure(e);
+                            }
+                        }
+                    };
                     abTestDao.putSnapshot(
                         snapshot,
-                        ActionListener.wrap(snapshotResponse -> abTestDao.updateABTest(updatedTest, listener), listener::onFailure)
+                        ActionListener.wrap(
+                            snapshotResponse -> abTestDao.updateABTestWithConcurrencyControl(
+                                updatedTest,
+                                seqNo,
+                                primaryTerm,
+                                concurrencyListener
+                            ),
+                            listener::onFailure
+                        )
                     );
                 } catch (Exception e) {
                     listener.onFailure(new SearchRelevanceException("Failed to update ABTest", e, RestStatus.INTERNAL_SERVER_ERROR));

--- a/src/main/resources/mappings/ab_test.json
+++ b/src/main/resources/mappings/ab_test.json
@@ -1,0 +1,19 @@
+{
+  "_meta": {
+    "schema_version": 0
+  },
+  "properties": {
+    "test_id": { "type": "keyword" },
+    "search_configuration_a": { "type": "keyword" },
+    "search_configuration_b": { "type": "keyword" },
+    "config_a_uuid": { "type": "keyword" },
+    "config_b_uuid": { "type": "keyword" },
+    "enabled": { "type": "boolean" },
+    "version": { "type": "integer" },
+    "created_at": { "type": "date", "format": "strict_date_time" },
+    "updated_at": { "type": "date", "format": "strict_date_time" },
+    "doc_id": { "type": "keyword" },
+    "record": { "type": "object", "dynamic": true },
+    "created": { "type": "date", "format": "strict_date_time" }
+  }
+}

--- a/src/main/resources/mappings/ab_test.json
+++ b/src/main/resources/mappings/ab_test.json
@@ -3,6 +3,7 @@
     "schema_version": 0
   },
   "properties": {
+    "doc_type": { "type": "keyword" },
     "test_id": { "type": "keyword" },
     "search_configuration_a": { "type": "keyword" },
     "search_configuration_b": { "type": "keyword" },

--- a/src/test/java/org/opensearch/searchrelevance/plugin/SearchRelevancePluginTests.java
+++ b/src/test/java/org/opensearch/searchrelevance/plugin/SearchRelevancePluginTests.java
@@ -204,7 +204,7 @@ public class SearchRelevancePluginTests extends OpenSearchTestCase {
     }
 
     public void testTotalRestHandlers() {
-        assertEquals(24, plugin.getRestHandlers(Settings.EMPTY, null, null, null, null, null, null).size());
+        assertEquals(26, plugin.getRestHandlers(Settings.EMPTY, null, null, null, null, null, null).size());
     }
 
     public void testQuerySetTransportIsAdded() {

--- a/src/test/java/org/opensearch/searchrelevance/plugin/SearchRelevancePluginTests.java
+++ b/src/test/java/org/opensearch/searchrelevance/plugin/SearchRelevancePluginTests.java
@@ -9,6 +9,7 @@ package org.opensearch.searchrelevance.plugin;
 
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static org.opensearch.searchrelevance.common.PluginConstants.AB_TEST_INDEX;
 import static org.opensearch.searchrelevance.common.PluginConstants.EXPERIMENT_INDEX;
 import static org.opensearch.searchrelevance.common.PluginConstants.JUDGMENT_CACHE_INDEX;
 import static org.opensearch.searchrelevance.settings.SearchRelevanceSettings.SEARCH_RELEVANCE_QUERY_SET_MAX_LIMIT;
@@ -104,7 +105,7 @@ public class SearchRelevancePluginTests extends OpenSearchTestCase {
     private NodeEnvironment nodeEnvironment;
     private SearchRelevancePlugin plugin;
 
-    public static final Set<String> SUPPORTED_SYSTEM_INDEX_PATTERN = Set.of(EXPERIMENT_INDEX, JUDGMENT_CACHE_INDEX);
+    public static final Set<String> SUPPORTED_SYSTEM_INDEX_PATTERN = Set.of(EXPERIMENT_INDEX, JUDGMENT_CACHE_INDEX, AB_TEST_INDEX);
 
     private final Set<Class> SUPPORTED_COMPONENTS = Set.of(
         SearchRelevanceIndicesManager.class,
@@ -117,6 +118,7 @@ public class SearchRelevancePluginTests extends OpenSearchTestCase {
         JudgmentCacheDao.class,
         ScheduledJobsDao.class,
         ScheduledExperimentHistoryDao.class,
+        org.opensearch.searchrelevance.dao.ABTestDao.class,
         MLAccessor.class,
         MetricsHelper.class,
         InfoStatsManager.class,
@@ -202,7 +204,7 @@ public class SearchRelevancePluginTests extends OpenSearchTestCase {
     }
 
     public void testTotalRestHandlers() {
-        assertEquals(23, plugin.getRestHandlers(Settings.EMPTY, null, null, null, null, null, null).size());
+        assertEquals(24, plugin.getRestHandlers(Settings.EMPTY, null, null, null, null, null, null).size());
     }
 
     public void testQuerySetTransportIsAdded() {

--- a/src/test/java/org/opensearch/searchrelevance/transport/abTest/DeleteABTestTransportActionTests.java
+++ b/src/test/java/org/opensearch/searchrelevance/transport/abTest/DeleteABTestTransportActionTests.java
@@ -1,0 +1,181 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+package org.opensearch.searchrelevance.transport.abTest;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import java.util.Collections;
+
+import org.apache.lucene.search.TotalHits;
+import org.junit.Before;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.opensearch.ResourceNotFoundException;
+import org.opensearch.action.delete.DeleteResponse;
+import org.opensearch.action.search.SearchResponse;
+import org.opensearch.action.support.ActionFilters;
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.core.rest.RestStatus;
+import org.opensearch.index.reindex.BulkByScrollResponse;
+import org.opensearch.search.SearchHit;
+import org.opensearch.search.SearchHits;
+import org.opensearch.searchrelevance.dao.ABTestDao;
+import org.opensearch.searchrelevance.exception.SearchRelevanceException;
+import org.opensearch.test.OpenSearchTestCase;
+import org.opensearch.transport.TransportService;
+
+public class DeleteABTestTransportActionTests extends OpenSearchTestCase {
+
+    @Mock
+    private TransportService transportService;
+    @Mock
+    private ActionFilters actionFilters;
+    @Mock
+    private ABTestDao abTestDao;
+
+    private DeleteABTestTransportAction transportAction;
+
+    @Before
+    public void setup() {
+        MockitoAnnotations.openMocks(this);
+        transportAction = new DeleteABTestTransportAction(transportService, actionFilters, abTestDao);
+    }
+
+    private void mockGetABTestExists() {
+        doAnswer(invocation -> {
+            ActionListener<SearchResponse> listener = invocation.getArgument(1);
+            SearchHit hit = new SearchHit(1, "my-test", Collections.emptyMap(), Collections.emptyMap());
+            SearchHits hits = new SearchHits(new SearchHit[] { hit }, new TotalHits(1, TotalHits.Relation.EQUAL_TO), 1.0f);
+            SearchResponse response = mock(SearchResponse.class);
+            org.mockito.Mockito.when(response.getHits()).thenReturn(hits);
+            listener.onResponse(response);
+            return null;
+        }).when(abTestDao).getABTest(any(String.class), any(ActionListener.class));
+    }
+
+    private void mockGetABTestNotFound() {
+        doAnswer(invocation -> {
+            ActionListener<SearchResponse> listener = invocation.getArgument(1);
+            listener.onFailure(new ResourceNotFoundException("Document not found: my-test", RestStatus.NOT_FOUND));
+            return null;
+        }).when(abTestDao).getABTest(any(String.class), any(ActionListener.class));
+    }
+
+    private void mockDeleteSnapshots() {
+        doAnswer(invocation -> {
+            ActionListener<BulkByScrollResponse> listener = invocation.getArgument(1);
+            BulkByScrollResponse mockResponse = mock(BulkByScrollResponse.class);
+            listener.onResponse(mockResponse);
+            return null;
+        }).when(abTestDao).deleteSnapshotsByTestId(any(String.class), any(ActionListener.class));
+    }
+
+    private void mockDeleteABTest() {
+        doAnswer(invocation -> {
+            ActionListener<DeleteResponse> listener = invocation.getArgument(1);
+            DeleteResponse mockResponse = mock(DeleteResponse.class);
+            listener.onResponse(mockResponse);
+            return null;
+        }).when(abTestDao).deleteABTest(any(String.class), any(ActionListener.class));
+    }
+
+    /**
+     * Happy path: test exists, deletes snapshots then live doc
+     */
+    @SuppressWarnings("unchecked")
+    public void testHappyPath() {
+        mockGetABTestExists();
+        mockDeleteSnapshots();
+        mockDeleteABTest();
+
+        DeleteABTestRequest request = new DeleteABTestRequest("my-test");
+        ActionListener<DeleteResponse> listener = mock(ActionListener.class);
+
+        transportAction.doExecute(null, request, listener);
+
+        verify(abTestDao).deleteSnapshotsByTestId(eq("my-test"), any(ActionListener.class));
+        verify(abTestDao).deleteABTest(eq("my-test"), any(ActionListener.class));
+        verify(listener).onResponse(any(DeleteResponse.class));
+    }
+
+    /**
+     * Test not found returns 404
+     */
+    @SuppressWarnings("unchecked")
+    public void testTestNotFound() {
+        mockGetABTestNotFound();
+
+        DeleteABTestRequest request = new DeleteABTestRequest("non-existent");
+        ActionListener<DeleteResponse> listener = mock(ActionListener.class);
+
+        transportAction.doExecute(null, request, listener);
+
+        ArgumentCaptor<Exception> errorCaptor = ArgumentCaptor.forClass(Exception.class);
+        verify(listener).onFailure(errorCaptor.capture());
+        assertTrue(errorCaptor.getValue().getMessage().contains("not found"));
+        verify(abTestDao, never()).deleteSnapshotsByTestId(any(), any());
+        verify(abTestDao, never()).deleteABTest(any(), any());
+    }
+
+    /**
+     * Null request returns error
+     */
+    @SuppressWarnings("unchecked")
+    public void testNullRequest() {
+        ActionListener<DeleteResponse> listener = mock(ActionListener.class);
+
+        transportAction.doExecute(null, null, listener);
+
+        ArgumentCaptor<Exception> errorCaptor = ArgumentCaptor.forClass(Exception.class);
+        verify(listener).onFailure(errorCaptor.capture());
+        assertTrue(errorCaptor.getValue().getMessage().contains("cannot be null"));
+    }
+
+    /**
+     * Null testId returns error
+     */
+    @SuppressWarnings("unchecked")
+    public void testNullTestId() {
+        DeleteABTestRequest request = new DeleteABTestRequest((String) null);
+        ActionListener<DeleteResponse> listener = mock(ActionListener.class);
+
+        transportAction.doExecute(null, request, listener);
+
+        ArgumentCaptor<Exception> errorCaptor = ArgumentCaptor.forClass(Exception.class);
+        verify(listener).onFailure(errorCaptor.capture());
+        assertTrue(errorCaptor.getValue().getMessage().contains("cannot be null"));
+    }
+
+    /**
+     * Snapshot deletion failure propagates error
+     */
+    @SuppressWarnings("unchecked")
+    public void testSnapshotDeletionFailure() {
+        mockGetABTestExists();
+
+        doAnswer(invocation -> {
+            ActionListener<BulkByScrollResponse> listener = invocation.getArgument(1);
+            listener.onFailure(new SearchRelevanceException("Failed to delete snapshots", RestStatus.INTERNAL_SERVER_ERROR));
+            return null;
+        }).when(abTestDao).deleteSnapshotsByTestId(any(String.class), any(ActionListener.class));
+
+        DeleteABTestRequest request = new DeleteABTestRequest("my-test");
+        ActionListener<DeleteResponse> listener = mock(ActionListener.class);
+
+        transportAction.doExecute(null, request, listener);
+
+        verify(listener).onFailure(any(Exception.class));
+        verify(abTestDao, never()).deleteABTest(any(), any());
+    }
+}

--- a/src/test/java/org/opensearch/searchrelevance/transport/abTest/PutABTestTransportActionTests.java
+++ b/src/test/java/org/opensearch/searchrelevance/transport/abTest/PutABTestTransportActionTests.java
@@ -93,7 +93,7 @@ public class PutABTestTransportActionTests extends OpenSearchTestCase {
         mockIndexCreation();
         mockPutABTest();
 
-        PutABTestRequest request = new PutABTestRequest("my-test", "config-a", "config-b");
+        PutABTestRequest request = new PutABTestRequest("my-test", "config-a", "config-b", null);
         ActionListener<IndexResponse> listener = mock(ActionListener.class);
 
         transportAction.doExecute(null, request, listener);
@@ -134,14 +134,14 @@ public class PutABTestTransportActionTests extends OpenSearchTestCase {
     public void testConfigANotFound() {
         mockConfigNotFound("config-a");
 
-        PutABTestRequest request = new PutABTestRequest("my-test", "config-a", "config-b");
+        PutABTestRequest request = new PutABTestRequest("my-test", "config-a", "config-b", null);
         ActionListener<IndexResponse> listener = mock(ActionListener.class);
 
         transportAction.doExecute(null, request, listener);
 
         ArgumentCaptor<Exception> errorCaptor = ArgumentCaptor.forClass(Exception.class);
         verify(listener).onFailure(errorCaptor.capture());
-        assertTrue(errorCaptor.getValue().getMessage().contains("search_configuration_a"));
+        assertTrue(errorCaptor.getValue().getMessage().contains("not found"));
         assertTrue(errorCaptor.getValue().getMessage().contains("not found"));
     }
 
@@ -162,14 +162,14 @@ public class PutABTestTransportActionTests extends OpenSearchTestCase {
             return null;
         }).when(searchConfigurationDao).getSearchConfiguration(any(String.class), any(ActionListener.class));
 
-        PutABTestRequest request = new PutABTestRequest("my-test", "config-a", "config-b");
+        PutABTestRequest request = new PutABTestRequest("my-test", "config-a", "config-b", null);
         ActionListener<IndexResponse> listener = mock(ActionListener.class);
 
         transportAction.doExecute(null, request, listener);
 
         ArgumentCaptor<Exception> errorCaptor = ArgumentCaptor.forClass(Exception.class);
         verify(listener).onFailure(errorCaptor.capture());
-        assertTrue(errorCaptor.getValue().getMessage().contains("search_configuration_b"));
+        assertTrue(errorCaptor.getValue().getMessage().contains("not found"));
         assertTrue(errorCaptor.getValue().getMessage().contains("not found"));
     }
 
@@ -182,7 +182,7 @@ public class PutABTestTransportActionTests extends OpenSearchTestCase {
         mockIndexCreation();
         mockPutABTest();
 
-        PutABTestRequest request = new PutABTestRequest("my-test", "config-a", "config-b");
+        PutABTestRequest request = new PutABTestRequest("my-test", "config-a", "config-b", null);
         ActionListener<IndexResponse> listener = mock(ActionListener.class);
 
         transportAction.doExecute(null, request, listener);
@@ -207,7 +207,7 @@ public class PutABTestTransportActionTests extends OpenSearchTestCase {
         mockIndexCreation();
         mockPutABTest();
 
-        PutABTestRequest request = new PutABTestRequest("test-123", "sc-001", "sc-002");
+        PutABTestRequest request = new PutABTestRequest("test-123", "sc-001", "sc-002", null);
         ActionListener<IndexResponse> listener = mock(ActionListener.class);
 
         transportAction.doExecute(null, request, listener);
@@ -231,7 +231,7 @@ public class PutABTestTransportActionTests extends OpenSearchTestCase {
      */
     @SuppressWarnings("unchecked")
     public void testSameConfigForBoth() {
-        PutABTestRequest request = new PutABTestRequest("my-test", "same-config-id", "same-config-id");
+        PutABTestRequest request = new PutABTestRequest("my-test", "same-config-id", "same-config-id", null);
         ActionListener<IndexResponse> listener = mock(ActionListener.class);
 
         transportAction.doExecute(null, request, listener);
@@ -239,5 +239,68 @@ public class PutABTestTransportActionTests extends OpenSearchTestCase {
         ArgumentCaptor<Exception> errorCaptor = ArgumentCaptor.forClass(Exception.class);
         verify(listener).onFailure(errorCaptor.capture());
         assertTrue(errorCaptor.getValue().getMessage().contains("must be different"));
+    }
+
+    /**
+     * Create with enabled=false stores test as disabled
+     */
+    @SuppressWarnings("unchecked")
+    public void testCreateWithEnabledFalse() {
+        mockConfigExists("config-a");
+        mockIndexCreation();
+        mockPutABTest();
+
+        PutABTestRequest request = new PutABTestRequest("my-test", "config-a", "config-b", false);
+        ActionListener<IndexResponse> listener = mock(ActionListener.class);
+
+        transportAction.doExecute(null, request, listener);
+
+        ArgumentCaptor<ABTest> abTestCaptor = ArgumentCaptor.forClass(ABTest.class);
+        verify(abTestDao).putABTest(abTestCaptor.capture(), any(ActionListener.class));
+
+        ABTest stored = abTestCaptor.getValue();
+        assertFalse(stored.isEnabled());
+    }
+
+    /**
+     * Create with enabled=true explicitly stores test as enabled
+     */
+    @SuppressWarnings("unchecked")
+    public void testCreateWithEnabledTrue() {
+        mockConfigExists("config-a");
+        mockIndexCreation();
+        mockPutABTest();
+
+        PutABTestRequest request = new PutABTestRequest("my-test", "config-a", "config-b", true);
+        ActionListener<IndexResponse> listener = mock(ActionListener.class);
+
+        transportAction.doExecute(null, request, listener);
+
+        ArgumentCaptor<ABTest> abTestCaptor = ArgumentCaptor.forClass(ABTest.class);
+        verify(abTestDao).putABTest(abTestCaptor.capture(), any(ActionListener.class));
+
+        ABTest stored = abTestCaptor.getValue();
+        assertTrue(stored.isEnabled());
+    }
+
+    /**
+     * Create with enabled=null defaults to true
+     */
+    @SuppressWarnings("unchecked")
+    public void testCreateWithEnabledNullDefaultsTrue() {
+        mockConfigExists("config-a");
+        mockIndexCreation();
+        mockPutABTest();
+
+        PutABTestRequest request = new PutABTestRequest("my-test", "config-a", "config-b", null);
+        ActionListener<IndexResponse> listener = mock(ActionListener.class);
+
+        transportAction.doExecute(null, request, listener);
+
+        ArgumentCaptor<ABTest> abTestCaptor = ArgumentCaptor.forClass(ABTest.class);
+        verify(abTestDao).putABTest(abTestCaptor.capture(), any(ActionListener.class));
+
+        ABTest stored = abTestCaptor.getValue();
+        assertTrue(stored.isEnabled());
     }
 }

--- a/src/test/java/org/opensearch/searchrelevance/transport/abTest/PutABTestTransportActionTests.java
+++ b/src/test/java/org/opensearch/searchrelevance/transport/abTest/PutABTestTransportActionTests.java
@@ -1,0 +1,243 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+package org.opensearch.searchrelevance.transport.abTest;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import org.junit.Before;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.opensearch.action.StepListener;
+import org.opensearch.action.index.IndexResponse;
+import org.opensearch.action.search.SearchResponse;
+import org.opensearch.action.support.ActionFilters;
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.core.rest.RestStatus;
+import org.opensearch.searchrelevance.dao.ABTestDao;
+import org.opensearch.searchrelevance.dao.SearchConfigurationDao;
+import org.opensearch.searchrelevance.exception.SearchRelevanceException;
+import org.opensearch.searchrelevance.model.ABTest;
+import org.opensearch.test.OpenSearchTestCase;
+import org.opensearch.transport.TransportService;
+
+public class PutABTestTransportActionTests extends OpenSearchTestCase {
+
+    @Mock
+    private TransportService transportService;
+    @Mock
+    private ActionFilters actionFilters;
+    @Mock
+    private ABTestDao abTestDao;
+    @Mock
+    private SearchConfigurationDao searchConfigurationDao;
+
+    private PutABTestTransportAction transportAction;
+
+    @Before
+    public void setup() {
+        MockitoAnnotations.openMocks(this);
+        transportAction = new PutABTestTransportAction(transportService, actionFilters, abTestDao, searchConfigurationDao);
+    }
+
+    private void mockConfigExists(String configId) {
+        doAnswer(invocation -> {
+            ActionListener<SearchResponse> listener = invocation.getArgument(1);
+            SearchResponse mockResponse = mock(SearchResponse.class);
+            listener.onResponse(mockResponse);
+            return null;
+
+        }).when(searchConfigurationDao).getSearchConfiguration(any(String.class), any(ActionListener.class));
+    }
+
+    private void mockConfigNotFound(String configId) {
+        doAnswer(invocation -> {
+            String id = invocation.getArgument(0);
+            ActionListener<SearchResponse> listener = invocation.getArgument(1);
+            listener.onFailure(new SearchRelevanceException("Document not found: " + id, RestStatus.NOT_FOUND));
+            return null;
+        }).when(searchConfigurationDao).getSearchConfiguration(any(String.class), any(ActionListener.class));
+    }
+
+    private void mockIndexCreation() {
+        doAnswer(invocation -> {
+            StepListener<Void> stepListener = invocation.getArgument(0);
+            stepListener.onResponse(null);
+            return null;
+        }).when(abTestDao).createIndexIfAbsent(any(StepListener.class));
+    }
+
+    private void mockPutABTest() {
+        doAnswer(invocation -> {
+            ActionListener<IndexResponse> listener = invocation.getArgument(1);
+            IndexResponse mockResponse = mock(IndexResponse.class);
+            listener.onResponse(mockResponse);
+            return null;
+        }).when(abTestDao).putABTest(any(ABTest.class), any(ActionListener.class));
+    }
+
+    /**
+     * Happy path: valid request with both config IDs creates test with enabled=true
+     */
+    @SuppressWarnings("unchecked")
+    public void testHappyPath() {
+        mockConfigExists("config-a");
+        mockIndexCreation();
+        mockPutABTest();
+
+        PutABTestRequest request = new PutABTestRequest("my-test", "config-a", "config-b");
+        ActionListener<IndexResponse> listener = mock(ActionListener.class);
+
+        transportAction.doExecute(null, request, listener);
+
+        // Verify the ABTest was stored
+        ArgumentCaptor<ABTest> abTestCaptor = ArgumentCaptor.forClass(ABTest.class);
+        verify(abTestDao).putABTest(abTestCaptor.capture(), any(ActionListener.class));
+
+        ABTest stored = abTestCaptor.getValue();
+        assertEquals("my-test", stored.getTestId());
+        assertEquals("config-a", stored.getSearchConfigurationA());
+        assertEquals("config-b", stored.getSearchConfigurationB());
+        assertTrue(stored.isEnabled());
+        assertEquals(0, stored.getVersion());
+        assertNotNull(stored.getConfigAUuid());
+        assertNotNull(stored.getConfigBUuid());
+        assertNotEquals(stored.getConfigAUuid(), stored.getConfigBUuid());
+    }
+
+    /**
+     * Null request returns failure
+     */
+    @SuppressWarnings("unchecked")
+    public void testNullRequest() {
+        ActionListener<IndexResponse> listener = mock(ActionListener.class);
+
+        transportAction.doExecute(null, null, listener);
+
+        ArgumentCaptor<Exception> errorCaptor = ArgumentCaptor.forClass(Exception.class);
+        verify(listener).onFailure(errorCaptor.capture());
+        assertTrue(errorCaptor.getValue().getMessage().contains("cannot be null"));
+    }
+
+    /**
+     * Non-existent config_a returns failure with clear message
+     */
+    @SuppressWarnings("unchecked")
+    public void testConfigANotFound() {
+        mockConfigNotFound("config-a");
+
+        PutABTestRequest request = new PutABTestRequest("my-test", "config-a", "config-b");
+        ActionListener<IndexResponse> listener = mock(ActionListener.class);
+
+        transportAction.doExecute(null, request, listener);
+
+        ArgumentCaptor<Exception> errorCaptor = ArgumentCaptor.forClass(Exception.class);
+        verify(listener).onFailure(errorCaptor.capture());
+        assertTrue(errorCaptor.getValue().getMessage().contains("search_configuration_a"));
+        assertTrue(errorCaptor.getValue().getMessage().contains("not found"));
+    }
+
+    /**
+     * Non-existent config_b returns failure with clear message
+     */
+    @SuppressWarnings("unchecked")
+    public void testConfigBNotFound() {
+        // Config A exists
+        doAnswer(invocation -> {
+            String id = invocation.getArgument(0);
+            ActionListener<SearchResponse> listener = invocation.getArgument(1);
+            if (id.equals("config-a")) {
+                listener.onResponse(mock(SearchResponse.class));
+            } else {
+                listener.onFailure(new SearchRelevanceException("Document not found: " + id, RestStatus.NOT_FOUND));
+            }
+            return null;
+        }).when(searchConfigurationDao).getSearchConfiguration(any(String.class), any(ActionListener.class));
+
+        PutABTestRequest request = new PutABTestRequest("my-test", "config-a", "config-b");
+        ActionListener<IndexResponse> listener = mock(ActionListener.class);
+
+        transportAction.doExecute(null, request, listener);
+
+        ArgumentCaptor<Exception> errorCaptor = ArgumentCaptor.forClass(Exception.class);
+        verify(listener).onFailure(errorCaptor.capture());
+        assertTrue(errorCaptor.getValue().getMessage().contains("search_configuration_b"));
+        assertTrue(errorCaptor.getValue().getMessage().contains("not found"));
+    }
+
+    /**
+     * UUID identifiers are unique across calls
+     */
+    @SuppressWarnings("unchecked")
+    public void testUUIDAliasesAreUnique() {
+        mockConfigExists("config-a");
+        mockIndexCreation();
+        mockPutABTest();
+
+        PutABTestRequest request = new PutABTestRequest("my-test", "config-a", "config-b");
+        ActionListener<IndexResponse> listener = mock(ActionListener.class);
+
+        transportAction.doExecute(null, request, listener);
+
+        ArgumentCaptor<ABTest> abTestCaptor = ArgumentCaptor.forClass(ABTest.class);
+        verify(abTestDao).putABTest(abTestCaptor.capture(), any(ActionListener.class));
+
+        ABTest stored = abTestCaptor.getValue();
+        // Aliases should be different from each other
+        assertNotEquals(stored.getConfigAUuid(), stored.getConfigBUuid());
+        // Aliases should be different from the real config IDs
+        assertNotEquals("config-a", stored.getConfigAUuid());
+        assertNotEquals("config-b", stored.getConfigBUuid());
+    }
+
+    /**
+     * Live doc has correct initial values
+     */
+    @SuppressWarnings("unchecked")
+    public void testLiveDocStoredCorrectly() {
+        mockConfigExists("config-a");
+        mockIndexCreation();
+        mockPutABTest();
+
+        PutABTestRequest request = new PutABTestRequest("test-123", "sc-001", "sc-002");
+        ActionListener<IndexResponse> listener = mock(ActionListener.class);
+
+        transportAction.doExecute(null, request, listener);
+
+        ArgumentCaptor<ABTest> abTestCaptor = ArgumentCaptor.forClass(ABTest.class);
+        verify(abTestDao).putABTest(abTestCaptor.capture(), any(ActionListener.class));
+
+        ABTest stored = abTestCaptor.getValue();
+        assertEquals("test-123", stored.getTestId());
+        assertEquals("sc-001", stored.getSearchConfigurationA());
+        assertEquals("sc-002", stored.getSearchConfigurationB());
+        assertTrue(stored.isEnabled());
+        assertEquals(0, stored.getVersion());
+        assertNotNull(stored.getCreatedAt());
+        assertNotNull(stored.getUpdatedAt());
+        assertEquals(stored.getCreatedAt(), stored.getUpdatedAt());
+    }
+
+    /**
+     * Same config for both A and B returns failure
+     */
+    @SuppressWarnings("unchecked")
+    public void testSameConfigForBoth() {
+        PutABTestRequest request = new PutABTestRequest("my-test", "same-config-id", "same-config-id");
+        ActionListener<IndexResponse> listener = mock(ActionListener.class);
+
+        transportAction.doExecute(null, request, listener);
+
+        ArgumentCaptor<Exception> errorCaptor = ArgumentCaptor.forClass(Exception.class);
+        verify(listener).onFailure(errorCaptor.capture());
+        assertTrue(errorCaptor.getValue().getMessage().contains("must be different"));
+    }
+}

--- a/src/test/java/org/opensearch/searchrelevance/transport/abTest/UpdateABTestTransportActionTests.java
+++ b/src/test/java/org/opensearch/searchrelevance/transport/abTest/UpdateABTestTransportActionTests.java
@@ -1,0 +1,315 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+package org.opensearch.searchrelevance.transport.abTest;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.lucene.search.TotalHits;
+import org.junit.Before;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.opensearch.ResourceNotFoundException;
+import org.opensearch.action.index.IndexResponse;
+import org.opensearch.action.search.SearchResponse;
+import org.opensearch.action.support.ActionFilters;
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.core.rest.RestStatus;
+import org.opensearch.search.SearchHit;
+import org.opensearch.search.SearchHits;
+import org.opensearch.searchrelevance.dao.ABTestDao;
+import org.opensearch.searchrelevance.dao.SearchConfigurationDao;
+import org.opensearch.searchrelevance.exception.SearchRelevanceException;
+import org.opensearch.searchrelevance.model.ABTest;
+import org.opensearch.test.OpenSearchTestCase;
+import org.opensearch.transport.TransportService;
+
+public class UpdateABTestTransportActionTests extends OpenSearchTestCase {
+
+    @Mock
+    private TransportService transportService;
+    @Mock
+    private ActionFilters actionFilters;
+    @Mock
+    private ABTestDao abTestDao;
+    @Mock
+    private SearchConfigurationDao searchConfigurationDao;
+
+    private UpdateABTestTransportAction transportAction;
+
+    @Before
+    public void setup() {
+        MockitoAnnotations.openMocks(this);
+        transportAction = new UpdateABTestTransportAction(transportService, actionFilters, abTestDao, searchConfigurationDao);
+    }
+
+    private SearchResponse createABTestSearchResponse(Map<String, Object> source) {
+        SearchHit hit = new SearchHit(1, "test-id", Collections.emptyMap(), Collections.emptyMap());
+        hit.sourceRef(org.opensearch.core.common.bytes.BytesReference.bytes(createXContentFromMap(source)));
+        SearchHits hits = new SearchHits(new SearchHit[] { hit }, new TotalHits(1, TotalHits.Relation.EQUAL_TO), 1.0f);
+        SearchResponse response = mock(SearchResponse.class);
+        org.mockito.Mockito.when(response.getHits()).thenReturn(hits);
+        return response;
+    }
+
+    private org.opensearch.core.xcontent.XContentBuilder createXContentFromMap(Map<String, Object> source) {
+        try {
+            org.opensearch.core.xcontent.XContentBuilder builder = org.opensearch.common.xcontent.XContentFactory.jsonBuilder();
+            builder.map(source);
+            return builder;
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private Map<String, Object> createTestDoc(boolean enabled, int version) {
+        Map<String, Object> source = new HashMap<>();
+        source.put(ABTest.TEST_ID, "my-test");
+        source.put(ABTest.SEARCH_CONFIGURATION_A, "sc-001");
+        source.put(ABTest.SEARCH_CONFIGURATION_B, "sc-002");
+        source.put(ABTest.CONFIG_A_UUID, "alias-a");
+        source.put(ABTest.CONFIG_B_UUID, "alias-b");
+        source.put(ABTest.ENABLED, enabled);
+        source.put(ABTest.VERSION, version);
+        source.put(ABTest.CREATED_AT, "2026-06-10T00:00:00.000Z");
+        source.put(ABTest.UPDATED_AT, "2026-06-10T00:00:00.000Z");
+        return source;
+    }
+
+    private void mockGetABTest(Map<String, Object> source) {
+        doAnswer(invocation -> {
+            ActionListener<SearchResponse> listener = invocation.getArgument(1);
+            listener.onResponse(createABTestSearchResponse(source));
+            return null;
+        }).when(abTestDao).getABTest(any(String.class), any(ActionListener.class));
+    }
+
+    private void mockGetABTestNotFound() {
+        doAnswer(invocation -> {
+            ActionListener<SearchResponse> listener = invocation.getArgument(1);
+            listener.onFailure(new ResourceNotFoundException("Document not found: my-test", RestStatus.NOT_FOUND));
+            return null;
+        }).when(abTestDao).getABTest(any(String.class), any(ActionListener.class));
+    }
+
+    private void mockPutSnapshot() {
+        doAnswer(invocation -> {
+            ActionListener listener = invocation.getArgument(4);
+            IndexResponse mockResponse = mock(IndexResponse.class);
+            listener.onResponse(mockResponse);
+            return null;
+        }).when(abTestDao).putSnapshot(any(String.class), any(String.class), any(Map.class), any(String.class), any(ActionListener.class));
+    }
+
+    private void mockUpdateABTest() {
+        doAnswer(invocation -> {
+            ActionListener listener = invocation.getArgument(1);
+            IndexResponse mockResponse = mock(IndexResponse.class);
+            listener.onResponse(mockResponse);
+            return null;
+        }).when(abTestDao).updateABTest(any(ABTest.class), any(ActionListener.class));
+    }
+
+    private void mockConfigExists() {
+        doAnswer(invocation -> {
+            ActionListener<SearchResponse> listener = invocation.getArgument(1);
+            listener.onResponse(mock(SearchResponse.class));
+            return null;
+        }).when(searchConfigurationDao).getSearchConfiguration(any(String.class), any(ActionListener.class));
+    }
+
+    /**
+     * Happy path: disable test — saves snapshot, updates live doc
+     */
+    @SuppressWarnings("unchecked")
+    public void testDisableTest() {
+        mockGetABTest(createTestDoc(true, 1));
+        mockPutSnapshot();
+        mockUpdateABTest();
+
+        UpdateABTestRequest request = new UpdateABTestRequest("my-test", false, null, null);
+        ActionListener<IndexResponse> listener = mock(ActionListener.class);
+
+        transportAction.doExecute(null, request, listener);
+
+        // Verify snapshot was saved
+        ArgumentCaptor<String> snapshotIdCaptor = ArgumentCaptor.forClass(String.class);
+        verify(abTestDao).putSnapshot(
+            snapshotIdCaptor.capture(),
+            any(String.class),
+            any(Map.class),
+            any(String.class),
+            any(ActionListener.class)
+        );
+        assertEquals("my-test_1", snapshotIdCaptor.getValue());
+
+        // Verify updated test has enabled=false and version=2
+        ArgumentCaptor<ABTest> abTestCaptor = ArgumentCaptor.forClass(ABTest.class);
+        verify(abTestDao).updateABTest(abTestCaptor.capture(), any(ActionListener.class));
+        assertFalse(abTestCaptor.getValue().isEnabled());
+        assertEquals(2, abTestCaptor.getValue().getVersion());
+    }
+
+    /**
+     * Happy path: change config B — saves snapshot, updates live doc, uuid stays same
+     */
+    @SuppressWarnings("unchecked")
+    public void testChangeConfigB() {
+        mockGetABTest(createTestDoc(true, 0));
+        mockPutSnapshot();
+        mockUpdateABTest();
+        mockConfigExists();
+
+        UpdateABTestRequest request = new UpdateABTestRequest("my-test", null, "sc-001", "sc-003");
+        ActionListener<IndexResponse> listener = mock(ActionListener.class);
+
+        transportAction.doExecute(null, request, listener);
+
+        ArgumentCaptor<ABTest> abTestCaptor = ArgumentCaptor.forClass(ABTest.class);
+        verify(abTestDao).updateABTest(abTestCaptor.capture(), any(ActionListener.class));
+
+        ABTest updated = abTestCaptor.getValue();
+        assertEquals("sc-003", updated.getSearchConfigurationB());
+        assertEquals("alias-b", updated.getConfigBUuid()); // uuid stays same
+        assertEquals(1, updated.getVersion());
+    }
+
+    /**
+     * Nothing changed — no snapshot saved, returns null
+     */
+    @SuppressWarnings("unchecked")
+    public void testNothingChanged() {
+        mockGetABTest(createTestDoc(true, 1));
+
+        // Same values as current state
+        UpdateABTestRequest request = new UpdateABTestRequest("my-test", true, "sc-001", "sc-002");
+        ActionListener<IndexResponse> listener = mock(ActionListener.class);
+
+        mockConfigExists();
+        transportAction.doExecute(null, request, listener);
+
+        // Verify no snapshot and no update
+        verify(abTestDao, never()).putSnapshot(any(), any(), any(), any(), any());
+        verify(abTestDao, never()).updateABTest(any(), any());
+
+        // Verify listener received null (nothing changed)
+        ArgumentCaptor<IndexResponse> responseCaptor = ArgumentCaptor.forClass(IndexResponse.class);
+        verify(listener).onResponse(responseCaptor.capture());
+        assertNull(responseCaptor.getValue());
+    }
+
+    /**
+     * Test not found — returns failure
+     */
+    @SuppressWarnings("unchecked")
+    public void testTestNotFound() {
+        mockGetABTestNotFound();
+
+        UpdateABTestRequest request = new UpdateABTestRequest("non-existent", false, null, null);
+        ActionListener<IndexResponse> listener = mock(ActionListener.class);
+
+        transportAction.doExecute(null, request, listener);
+
+        ArgumentCaptor<Exception> errorCaptor = ArgumentCaptor.forClass(Exception.class);
+        verify(listener).onFailure(errorCaptor.capture());
+        assertTrue(errorCaptor.getValue().getMessage().contains("Failed to retrieve ABTest"));
+    }
+
+    /**
+     * Null request returns failure
+     */
+    @SuppressWarnings("unchecked")
+    public void testNullRequest() {
+        ActionListener<IndexResponse> listener = mock(ActionListener.class);
+
+        transportAction.doExecute(null, null, listener);
+
+        ArgumentCaptor<Exception> errorCaptor = ArgumentCaptor.forClass(Exception.class);
+        verify(listener).onFailure(errorCaptor.capture());
+        assertTrue(errorCaptor.getValue().getMessage().contains("cannot be null"));
+    }
+
+    /**
+     * Version increments correctly across updates
+     */
+    @SuppressWarnings("unchecked")
+    public void testVersionIncrements() {
+        mockGetABTest(createTestDoc(true, 5));
+        mockPutSnapshot();
+        mockUpdateABTest();
+
+        UpdateABTestRequest request = new UpdateABTestRequest("my-test", false, null, null);
+        ActionListener<IndexResponse> listener = mock(ActionListener.class);
+
+        transportAction.doExecute(null, request, listener);
+
+        ArgumentCaptor<ABTest> abTestCaptor = ArgumentCaptor.forClass(ABTest.class);
+        verify(abTestDao).updateABTest(abTestCaptor.capture(), any(ActionListener.class));
+        assertEquals(6, abTestCaptor.getValue().getVersion());
+
+        // Snapshot ID should use old version
+        ArgumentCaptor<String> snapshotIdCaptor = ArgumentCaptor.forClass(String.class);
+        verify(abTestDao).putSnapshot(snapshotIdCaptor.capture(), any(), any(), any(), any());
+        assertEquals("my-test_5", snapshotIdCaptor.getValue());
+    }
+
+    /**
+     * Snapshot contains old state before update
+     */
+    @SuppressWarnings("unchecked")
+    public void testSnapshotContainsOldState() {
+        mockGetABTest(createTestDoc(true, 0));
+        mockPutSnapshot();
+        mockUpdateABTest();
+
+        UpdateABTestRequest request = new UpdateABTestRequest("my-test", false, null, null);
+        ActionListener<IndexResponse> listener = mock(ActionListener.class);
+
+        transportAction.doExecute(null, request, listener);
+
+        ArgumentCaptor<Map> recordCaptor = ArgumentCaptor.forClass(Map.class);
+        verify(abTestDao).putSnapshot(any(), any(), recordCaptor.capture(), any(), any());
+
+        Map<String, Object> snapshot = recordCaptor.getValue();
+        assertEquals("sc-001", snapshot.get(ABTest.SEARCH_CONFIGURATION_A));
+        assertEquals("sc-002", snapshot.get(ABTest.SEARCH_CONFIGURATION_B));
+        assertEquals("alias-a", snapshot.get(ABTest.CONFIG_A_UUID));
+        assertEquals("alias-b", snapshot.get(ABTest.CONFIG_B_UUID));
+        assertEquals(true, snapshot.get(ABTest.ENABLED)); // was true before disable
+    }
+
+    /**
+     * Non-existent config ID in update returns failure
+     */
+    @SuppressWarnings("unchecked")
+    public void testNonExistentConfigInUpdate() {
+        doAnswer(invocation -> {
+            String id = invocation.getArgument(0);
+            ActionListener<SearchResponse> listener = invocation.getArgument(1);
+            listener.onFailure(new SearchRelevanceException("Document not found: " + id, RestStatus.NOT_FOUND));
+            return null;
+        }).when(searchConfigurationDao).getSearchConfiguration(any(String.class), any(ActionListener.class));
+
+        UpdateABTestRequest request = new UpdateABTestRequest("my-test", null, "sc-001", "non-existent");
+        ActionListener<IndexResponse> listener = mock(ActionListener.class);
+
+        transportAction.doExecute(null, request, listener);
+
+        ArgumentCaptor<Exception> errorCaptor = ArgumentCaptor.forClass(Exception.class);
+        verify(listener).onFailure(errorCaptor.capture());
+        assertTrue(errorCaptor.getValue().getMessage().contains("not found"));
+    }
+}

--- a/src/test/java/org/opensearch/searchrelevance/transport/abTest/UpdateABTestTransportActionTests.java
+++ b/src/test/java/org/opensearch/searchrelevance/transport/abTest/UpdateABTestTransportActionTests.java
@@ -34,6 +34,7 @@ import org.opensearch.searchrelevance.dao.ABTestDao;
 import org.opensearch.searchrelevance.dao.SearchConfigurationDao;
 import org.opensearch.searchrelevance.exception.SearchRelevanceException;
 import org.opensearch.searchrelevance.model.ABTest;
+import org.opensearch.searchrelevance.model.ABTestSnapshot;
 import org.opensearch.test.OpenSearchTestCase;
 import org.opensearch.transport.TransportService;
 
@@ -107,11 +108,11 @@ public class UpdateABTestTransportActionTests extends OpenSearchTestCase {
 
     private void mockPutSnapshot() {
         doAnswer(invocation -> {
-            ActionListener listener = invocation.getArgument(4);
+            ActionListener listener = invocation.getArgument(1);
             IndexResponse mockResponse = mock(IndexResponse.class);
             listener.onResponse(mockResponse);
             return null;
-        }).when(abTestDao).putSnapshot(any(String.class), any(String.class), any(Map.class), any(String.class), any(ActionListener.class));
+        }).when(abTestDao).putSnapshot(any(ABTestSnapshot.class), any(ActionListener.class));
     }
 
     private void mockUpdateABTest() {
@@ -146,15 +147,11 @@ public class UpdateABTestTransportActionTests extends OpenSearchTestCase {
         transportAction.doExecute(null, request, listener);
 
         // Verify snapshot was saved
-        ArgumentCaptor<String> snapshotIdCaptor = ArgumentCaptor.forClass(String.class);
-        verify(abTestDao).putSnapshot(
-            snapshotIdCaptor.capture(),
-            any(String.class),
-            any(Map.class),
-            any(String.class),
-            any(ActionListener.class)
-        );
-        assertEquals("my-test_1", snapshotIdCaptor.getValue());
+        // Verify snapshot was saved
+        ArgumentCaptor<ABTestSnapshot> snapshotCaptor = ArgumentCaptor.forClass(ABTestSnapshot.class);
+        verify(abTestDao).putSnapshot(snapshotCaptor.capture(), any(ActionListener.class));
+        assertEquals("my-test_1", snapshotCaptor.getValue().getDocId());
+        assertEquals("my-test", snapshotCaptor.getValue().getTestId());
 
         // Verify updated test has enabled=false and version=2
         ArgumentCaptor<ABTest> abTestCaptor = ArgumentCaptor.forClass(ABTest.class);
@@ -202,7 +199,7 @@ public class UpdateABTestTransportActionTests extends OpenSearchTestCase {
         transportAction.doExecute(null, request, listener);
 
         // Verify no snapshot and no update
-        verify(abTestDao, never()).putSnapshot(any(), any(), any(), any(), any());
+        verify(abTestDao, never()).putSnapshot(any(ABTestSnapshot.class), any(ActionListener.class));
         verify(abTestDao, never()).updateABTest(any(), any());
 
         // Verify listener received null (nothing changed)
@@ -256,14 +253,12 @@ public class UpdateABTestTransportActionTests extends OpenSearchTestCase {
 
         transportAction.doExecute(null, request, listener);
 
-        ArgumentCaptor<ABTest> abTestCaptor = ArgumentCaptor.forClass(ABTest.class);
-        verify(abTestDao).updateABTest(abTestCaptor.capture(), any(ActionListener.class));
-        assertEquals(6, abTestCaptor.getValue().getVersion());
+        ArgumentCaptor<ABTestSnapshot> snapshotCaptor = ArgumentCaptor.forClass(ABTestSnapshot.class);
+        verify(abTestDao).putSnapshot(snapshotCaptor.capture(), any(ActionListener.class));
+        assertEquals("my-test_5", snapshotCaptor.getValue().getDocId());
 
-        // Snapshot ID should use old version
-        ArgumentCaptor<String> snapshotIdCaptor = ArgumentCaptor.forClass(String.class);
-        verify(abTestDao).putSnapshot(snapshotIdCaptor.capture(), any(), any(), any(), any());
-        assertEquals("my-test_5", snapshotIdCaptor.getValue());
+        assertEquals("my-test_5", snapshotCaptor.getValue().getDocId());
+
     }
 
     /**
@@ -280,10 +275,11 @@ public class UpdateABTestTransportActionTests extends OpenSearchTestCase {
 
         transportAction.doExecute(null, request, listener);
 
-        ArgumentCaptor<Map> recordCaptor = ArgumentCaptor.forClass(Map.class);
-        verify(abTestDao).putSnapshot(any(), any(), recordCaptor.capture(), any(), any());
+        ArgumentCaptor<ABTestSnapshot> snapCaptor = ArgumentCaptor.forClass(ABTestSnapshot.class);
+        verify(abTestDao).putSnapshot(snapCaptor.capture(), any(ActionListener.class));
 
-        Map<String, Object> snapshot = recordCaptor.getValue();
+        Map<String, Object> snapshot = snapCaptor.getValue().getRecord();
+
         assertEquals("sc-001", snapshot.get(ABTest.SEARCH_CONFIGURATION_A));
         assertEquals("sc-002", snapshot.get(ABTest.SEARCH_CONFIGURATION_B));
         assertEquals("alias-a", snapshot.get(ABTest.CONFIG_A_UUID));

--- a/src/test/java/org/opensearch/searchrelevance/transport/abTest/UpdateABTestTransportActionTests.java
+++ b/src/test/java/org/opensearch/searchrelevance/transport/abTest/UpdateABTestTransportActionTests.java
@@ -97,7 +97,7 @@ public class UpdateABTestTransportActionTests extends OpenSearchTestCase {
             ActionListener<SearchResponse> listener = invocation.getArgument(1);
             listener.onResponse(createABTestSearchResponse(source));
             return null;
-        }).when(abTestDao).getABTest(any(String.class), any(ActionListener.class));
+        }).when(abTestDao).getABTestWithSeqNo(any(String.class), any(ActionListener.class));
     }
 
     private void mockGetABTestNotFound() {
@@ -105,7 +105,7 @@ public class UpdateABTestTransportActionTests extends OpenSearchTestCase {
             ActionListener<SearchResponse> listener = invocation.getArgument(1);
             listener.onFailure(new ResourceNotFoundException("Document not found: my-test", RestStatus.NOT_FOUND));
             return null;
-        }).when(abTestDao).getABTest(any(String.class), any(ActionListener.class));
+        }).when(abTestDao).getABTestWithSeqNo(any(String.class), any(ActionListener.class));
     }
 
     private void mockPutSnapshot() {

--- a/src/test/java/org/opensearch/searchrelevance/transport/abTest/UpdateABTestTransportActionTests.java
+++ b/src/test/java/org/opensearch/searchrelevance/transport/abTest/UpdateABTestTransportActionTests.java
@@ -60,6 +60,8 @@ public class UpdateABTestTransportActionTests extends OpenSearchTestCase {
     private SearchResponse createABTestSearchResponse(Map<String, Object> source) {
         SearchHit hit = new SearchHit(1, "test-id", Collections.emptyMap(), Collections.emptyMap());
         hit.sourceRef(org.opensearch.core.common.bytes.BytesReference.bytes(createXContentFromMap(source)));
+        hit.setSeqNo(1L);
+        hit.setPrimaryTerm(1L);
         SearchHits hits = new SearchHits(new SearchHit[] { hit }, new TotalHits(1, TotalHits.Relation.EQUAL_TO), 1.0f);
         SearchResponse response = mock(SearchResponse.class);
         org.mockito.Mockito.when(response.getHits()).thenReturn(hits);
@@ -115,13 +117,19 @@ public class UpdateABTestTransportActionTests extends OpenSearchTestCase {
         }).when(abTestDao).putSnapshot(any(ABTestSnapshot.class), any(ActionListener.class));
     }
 
-    private void mockUpdateABTest() {
+    private void mockUpdateABTestWithConcurrencyControl() {
         doAnswer(invocation -> {
-            ActionListener listener = invocation.getArgument(1);
+            ActionListener listener = invocation.getArgument(3);
             IndexResponse mockResponse = mock(IndexResponse.class);
             listener.onResponse(mockResponse);
             return null;
-        }).when(abTestDao).updateABTest(any(ABTest.class), any(ActionListener.class));
+        }).when(abTestDao)
+            .updateABTestWithConcurrencyControl(
+                any(ABTest.class),
+                org.mockito.ArgumentMatchers.anyLong(),
+                org.mockito.ArgumentMatchers.anyLong(),
+                any(ActionListener.class)
+            );
     }
 
     private void mockConfigExists() {
@@ -139,7 +147,7 @@ public class UpdateABTestTransportActionTests extends OpenSearchTestCase {
     public void testDisableTest() {
         mockGetABTest(createTestDoc(true, 1));
         mockPutSnapshot();
-        mockUpdateABTest();
+        mockUpdateABTestWithConcurrencyControl();
 
         UpdateABTestRequest request = new UpdateABTestRequest("my-test", false, null, null);
         ActionListener<IndexResponse> listener = mock(ActionListener.class);
@@ -155,7 +163,12 @@ public class UpdateABTestTransportActionTests extends OpenSearchTestCase {
 
         // Verify updated test has enabled=false and version=2
         ArgumentCaptor<ABTest> abTestCaptor = ArgumentCaptor.forClass(ABTest.class);
-        verify(abTestDao).updateABTest(abTestCaptor.capture(), any(ActionListener.class));
+        verify(abTestDao).updateABTestWithConcurrencyControl(
+            abTestCaptor.capture(),
+            org.mockito.ArgumentMatchers.anyLong(),
+            org.mockito.ArgumentMatchers.anyLong(),
+            any(ActionListener.class)
+        );
         assertFalse(abTestCaptor.getValue().isEnabled());
         assertEquals(2, abTestCaptor.getValue().getVersion());
     }
@@ -167,7 +180,7 @@ public class UpdateABTestTransportActionTests extends OpenSearchTestCase {
     public void testChangeConfigB() {
         mockGetABTest(createTestDoc(true, 0));
         mockPutSnapshot();
-        mockUpdateABTest();
+        mockUpdateABTestWithConcurrencyControl();
         mockConfigExists();
 
         UpdateABTestRequest request = new UpdateABTestRequest("my-test", null, "sc-001", "sc-003");
@@ -176,7 +189,12 @@ public class UpdateABTestTransportActionTests extends OpenSearchTestCase {
         transportAction.doExecute(null, request, listener);
 
         ArgumentCaptor<ABTest> abTestCaptor = ArgumentCaptor.forClass(ABTest.class);
-        verify(abTestDao).updateABTest(abTestCaptor.capture(), any(ActionListener.class));
+        verify(abTestDao).updateABTestWithConcurrencyControl(
+            abTestCaptor.capture(),
+            org.mockito.ArgumentMatchers.anyLong(),
+            org.mockito.ArgumentMatchers.anyLong(),
+            any(ActionListener.class)
+        );
 
         ABTest updated = abTestCaptor.getValue();
         assertEquals("sc-003", updated.getSearchConfigurationB());
@@ -200,7 +218,12 @@ public class UpdateABTestTransportActionTests extends OpenSearchTestCase {
 
         // Verify no snapshot and no update
         verify(abTestDao, never()).putSnapshot(any(ABTestSnapshot.class), any(ActionListener.class));
-        verify(abTestDao, never()).updateABTest(any(), any());
+        verify(abTestDao, never()).updateABTestWithConcurrencyControl(
+            any(),
+            org.mockito.ArgumentMatchers.anyLong(),
+            org.mockito.ArgumentMatchers.anyLong(),
+            any()
+        );
 
         // Verify listener received null (nothing changed)
         ArgumentCaptor<IndexResponse> responseCaptor = ArgumentCaptor.forClass(IndexResponse.class);
@@ -222,7 +245,7 @@ public class UpdateABTestTransportActionTests extends OpenSearchTestCase {
 
         ArgumentCaptor<Exception> errorCaptor = ArgumentCaptor.forClass(Exception.class);
         verify(listener).onFailure(errorCaptor.capture());
-        assertTrue(errorCaptor.getValue().getMessage().contains("Failed to retrieve ABTest"));
+        assertTrue(errorCaptor.getValue().getMessage().contains("not found"));
     }
 
     /**
@@ -246,7 +269,7 @@ public class UpdateABTestTransportActionTests extends OpenSearchTestCase {
     public void testVersionIncrements() {
         mockGetABTest(createTestDoc(true, 5));
         mockPutSnapshot();
-        mockUpdateABTest();
+        mockUpdateABTestWithConcurrencyControl();
 
         UpdateABTestRequest request = new UpdateABTestRequest("my-test", false, null, null);
         ActionListener<IndexResponse> listener = mock(ActionListener.class);
@@ -268,7 +291,7 @@ public class UpdateABTestTransportActionTests extends OpenSearchTestCase {
     public void testSnapshotContainsOldState() {
         mockGetABTest(createTestDoc(true, 0));
         mockPutSnapshot();
-        mockUpdateABTest();
+        mockUpdateABTestWithConcurrencyControl();
 
         UpdateABTestRequest request = new UpdateABTestRequest("my-test", false, null, null);
         ActionListener<IndexResponse> listener = mock(ActionListener.class);
@@ -307,5 +330,45 @@ public class UpdateABTestTransportActionTests extends OpenSearchTestCase {
         ArgumentCaptor<Exception> errorCaptor = ArgumentCaptor.forClass(Exception.class);
         verify(listener).onFailure(errorCaptor.capture());
         assertTrue(errorCaptor.getValue().getMessage().contains("not found"));
+    }
+
+    /**
+     * Version conflict triggers retry and succeeds on second attempt
+     */
+    @SuppressWarnings("unchecked")
+    public void testVersionConflictRetries() {
+        mockGetABTest(createTestDoc(true, 1));
+        mockPutSnapshot();
+
+        java.util.concurrent.atomic.AtomicInteger callCount = new java.util.concurrent.atomic.AtomicInteger(0);
+        doAnswer(invocation -> {
+            ActionListener listener = invocation.getArgument(3);
+            if (callCount.getAndIncrement() == 0) {
+                listener.onFailure(
+                    new org.opensearch.index.engine.VersionConflictEngineException(
+                        new org.opensearch.core.index.shard.ShardId("test", "test", 0),
+                        "test-id",
+                        "version conflict"
+                    )
+                );
+            } else {
+                listener.onResponse(mock(IndexResponse.class));
+            }
+            return null;
+        }).when(abTestDao)
+            .updateABTestWithConcurrencyControl(
+                any(ABTest.class),
+                org.mockito.ArgumentMatchers.anyLong(),
+                org.mockito.ArgumentMatchers.anyLong(),
+                any(ActionListener.class)
+            );
+
+        UpdateABTestRequest request = new UpdateABTestRequest("my-test", false, null, null);
+        ActionListener<IndexResponse> listener = mock(ActionListener.class);
+
+        transportAction.doExecute(null, request, listener);
+
+        verify(listener).onResponse(any(IndexResponse.class));
+        assertEquals(2, callCount.get());
     }
 }


### PR DESCRIPTION
 Description:

  ### Description

  This PR implements the foundational Create and Update APIs for A/B testing search configurations using Team Draft Interleaving (TDI). It enables customers to register two competing search configurations, manage their lifecycle with enable/disable toggles, and maintain a
  versioned audit trail of all changes.

  **RFC:** https://github.com/opensearch-project/OpenSearch/issues/18383

  #### New API

  | Method | Endpoint | Purpose |
  |--------|----------|---------|
  | PUT | `/_plugins/_search_relevance/ab_tests/{id}` | Create or Update AB test |

  #### Features
  - User-provided test ID as the document identifier
  - UUID identifiers per config for bias prevention (end users cannot identify which config produced results)
  - Versioned snapshots saved on every update for audit trail
  - Config ID validation (verifies both configs exist in search-config index before storing)
  - Same config validation (config A and config B must be different)
  - Nothing-changed guard (skips update if state is unchanged — no redundant snapshots)
  - Enabled by default on creation
  - System index (`.plugins-search-relevance-ab-test`) with schema versioning

  #### Request Examples

  **Create:**
  ```json
  PUT /_plugins/_search_relevance/ab_tests/bm25-vs-semantic
  {
      "search_configuration_a": "sc-001",
      "search_configuration_b": "sc-002"
  }

  Update (disable):
  PUT /_plugins/_search_relevance/ab_tests/bm25-vs-semantic
  {
      "enabled": false
  }
  
  Update (change configs):
  PUT /_plugins/_search_relevance/ab_tests/bm25-vs-semantic
  {
      "search_configuration_a": "sc-001",
      "search_configuration_b": "sc-003"
  }
  
  Architecture

  Follows the existing 4-layer plugin pattern:
  - REST Handler → Transport Action → DAO → SearchRelevanceIndicesManager
  
  Issues Resolved

  Related: https://github.com/opensearch-project/OpenSearch/issues/18383

  Check List

  - [] New functionality includes unit tests
  - [] New functionality has been documented in PR description
  - [] Commits are signed off per the DCO requirement
  - [] All endpoints gated by existing SEARCH_RELEVANCE_WORKBENCH_ENABLED setting