### PR TITLE
Optimize RBO calculation to avoid O(n²) set rebuilding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Add experiment execution time input signatures (SHA-256 fingerprints of query set, judgments, and search configurations) and `GET /_plugins/_search_relevance/experiments/{id}/validate` for VALID / DRIFTED / UNAVAILABLE drift checks ([#456](https://github.com/opensearch-project/search-relevance/pull/456))
 
 ### Enhancements
+- Optimize Rank-Biased Overlap (RBO) calculation from O(n²) to O(n) by maintaining prefix sets incrementally ([#499](https://github.com/opensearch-project/search-relevance/issues/499))
 
 ### Bug Fixes
 - Implement referential integrity validation for search configurations, experiments, and judgments ([#360](https://github.com/opensearch-project/search-relevance/pull/360))

--- a/src/main/java/org/opensearch/searchrelevance/metrics/calculator/PairComparison.java
+++ b/src/main/java/org/opensearch/searchrelevance/metrics/calculator/PairComparison.java
@@ -55,24 +55,35 @@ public class PairComparison {
             throw new SearchRelevanceException("p must be between 0 and 1", RestStatus.INTERNAL_SERVER_ERROR);
         }
 
-        int maxDepth = Math.max(listA.size(), listB.size());
+        int sizeA = listA.size();
+        int sizeB = listB.size();
+        int maxDepth = Math.max(sizeA, sizeB);
         double sum = 0;
         double weight = 1;
-        double sumWeight = 0;
 
-        // Calculate overlap at each depth
+        // Maintain prefix sets incrementally so overlap is updated in O(1) per depth
+        // instead of rebuilding the sets from scratch at each depth.
+        Set<String> setA = new HashSet<>();
+        Set<String> setB = new HashSet<>();
+        int overlapCount = 0;
+
         for (int d = 0; d < maxDepth; d++) {
-            Set<String> setA = new HashSet<>(listA.subList(0, Math.min(d + 1, listA.size())));
-            Set<String> setB = new HashSet<>(listB.subList(0, Math.min(d + 1, listB.size())));
+            if (d < sizeA) {
+                String itemA = listA.get(d);
+                if (setA.add(itemA) && setB.contains(itemA)) {
+                    overlapCount++;
+                }
+            }
 
-            // Calculate overlap at current depth
-            Set<String> intersection = new HashSet<>(setA);
-            intersection.retainAll(setB);
-            double overlap = intersection.size() / (double) Math.max(setA.size(), setB.size());
+            if (d < sizeB) {
+                String itemB = listB.get(d);
+                if (setB.add(itemB) && setA.contains(itemB)) {
+                    overlapCount++;
+                }
+            }
 
-            // Add weighted overlap to sum
+            double overlap = overlapCount / (double) Math.max(setA.size(), setB.size());
             sum += weight * overlap;
-            sumWeight += weight;
             weight *= p;
         }
 

--- a/src/test/java/org/opensearch/searchrelevance/metrics/calculator/PairComparisonTests.java
+++ b/src/test/java/org/opensearch/searchrelevance/metrics/calculator/PairComparisonTests.java
@@ -1,0 +1,156 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+package org.opensearch.searchrelevance.metrics.calculator;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Random;
+import java.util.Set;
+
+import org.opensearch.core.rest.RestStatus;
+import org.opensearch.searchrelevance.exception.SearchRelevanceException;
+import org.opensearch.test.OpenSearchTestCase;
+
+/**
+ * Tests for {@link PairComparison} metric calculators.
+ */
+public class PairComparisonTests extends OpenSearchTestCase {
+
+    public void testIdenticalListsRboIsOne() {
+        List<String> list = Arrays.asList("a", "b", "c", "d", "e");
+        assertEquals(1.0, PairComparison.calculateRBOSimilarity(list, list, 0.5), 0.001);
+        assertEquals(1.0, PairComparison.calculateRBOSimilarity(list, list, 0.9), 0.001);
+    }
+
+    public void testDisjointListsRboIsZero() {
+        List<String> listA = Arrays.asList("a", "b", "c");
+        List<String> listB = Arrays.asList("d", "e", "f");
+        assertEquals(0.0, PairComparison.calculateRBOSimilarity(listA, listB, 0.5), 0.001);
+        assertEquals(0.0, PairComparison.calculateRBOSimilarity(listA, listB, 0.9), 0.001);
+    }
+
+    public void testPartialOverlap() {
+        List<String> listA = Arrays.asList("a", "b", "c");
+        List<String> listB = Arrays.asList("a", "c", "b");
+        // d=0: overlap=1, d=1: overlap=1/2, d=2: overlap=3/3
+        // sum = 1 + 0.5*0.5 + 0.25*1 = 1.5
+        // rbo = 1.5 * 0.5 / (1 - 0.125) = 0.8571... -> 0.86
+        assertEquals(0.86, PairComparison.calculateRBOSimilarity(listA, listB, 0.5), 0.001);
+    }
+
+    public void testReversedOrder() {
+        List<String> listA = Arrays.asList("a", "b");
+        List<String> listB = Arrays.asList("b", "a");
+        // d=0: overlap=0/1, d=1: overlap=2/2
+        // sum = 0 + 0.5*1 = 0.5
+        // rbo = 0.5 * 0.5 / (1 - 0.25) = 0.3333... -> 0.33
+        assertEquals(0.33, PairComparison.calculateRBOSimilarity(listA, listB, 0.5), 0.001);
+    }
+
+    public void testDifferentLengths() {
+        List<String> listA = Arrays.asList("a", "b", "c", "d");
+        List<String> listB = Arrays.asList("a", "b");
+        // d=0: overlap=1, d=1: overlap=2/2, d=2: overlap=2/3, d=3: overlap=2/4
+        // sum = 1 + 0.5*1 + 0.25*2/3 + 0.125*2/4
+        // = 1 + 0.5 + 0.1667 + 0.0625 = 1.7292
+        // rbo = 1.7292 * 0.5 / (1 - 0.0625) = 0.8646 / 0.9375 = 0.9222 -> 0.92
+        assertEquals(0.92, PairComparison.calculateRBOSimilarity(listA, listB, 0.5), 0.001);
+    }
+
+    public void testDuplicates() {
+        List<String> listA = Arrays.asList("a", "a", "b");
+        List<String> listB = Arrays.asList("a", "b", "b");
+        // d=0: overlap=1, d=1: overlap=1/2, d=2: overlap=2/2
+        // sum = 1 + 0.5*0.5 + 0.25*1 = 1.5
+        // rbo = 1.5 * 0.5 / (1 - 0.125) = 0.8571... -> 0.86
+        assertEquals(0.86, PairComparison.calculateRBOSimilarity(listA, listB, 0.5), 0.001);
+    }
+
+    public void testSingleElementMatch() {
+        List<String> listA = Collections.singletonList("a");
+        List<String> listB = Collections.singletonList("a");
+        assertEquals(1.0, PairComparison.calculateRBOSimilarity(listA, listB, 0.5), 0.001);
+    }
+
+    public void testSingleElementMismatch() {
+        List<String> listA = Collections.singletonList("a");
+        List<String> listB = Collections.singletonList("b");
+        assertEquals(0.0, PairComparison.calculateRBOSimilarity(listA, listB, 0.5), 0.001);
+    }
+
+    public void testInvalidPThrowsException() {
+        List<String> list = Collections.singletonList("a");
+
+        SearchRelevanceException ex = expectThrows(
+            SearchRelevanceException.class,
+            () -> PairComparison.calculateRBOSimilarity(list, list, 0.0)
+        );
+        assertEquals(RestStatus.INTERNAL_SERVER_ERROR, ex.status());
+        assertTrue(ex.getMessage().contains("p must be between 0 and 1"));
+
+        ex = expectThrows(SearchRelevanceException.class, () -> PairComparison.calculateRBOSimilarity(list, list, 1.0));
+        assertEquals(RestStatus.INTERNAL_SERVER_ERROR, ex.status());
+
+        ex = expectThrows(SearchRelevanceException.class, () -> PairComparison.calculateRBOSimilarity(list, list, -0.1));
+        assertEquals(RestStatus.INTERNAL_SERVER_ERROR, ex.status());
+    }
+
+    public void testIncrementalResultMatchesNaiveImplementation() {
+        Random random = random();
+        for (int trial = 0; trial < 100; trial++) {
+            List<String> listA = randomStringList(random, 1 + random.nextInt(50));
+            List<String> listB = randomStringList(random, 1 + random.nextInt(50));
+            double p = 0.1 + random.nextDouble() * 0.89;
+
+            double optimized = PairComparison.calculateRBOSimilarity(listA, listB, p);
+            double naive = calculateRBOSimilarityNaive(listA, listB, p);
+            assertEquals("Mismatch for lists " + listA + " and " + listB + " with p=" + p, naive, optimized, 0.0001);
+        }
+    }
+
+    private List<String> randomStringList(Random random, int size) {
+        String[] tokens = { "a", "b", "c", "d", "e", "f", "g", "h" };
+        List<String> list = new ArrayList<>(size);
+        for (int i = 0; i < size; i++) {
+            list.add(tokens[random.nextInt(tokens.length)]);
+        }
+        return list;
+    }
+
+    /**
+     * Reference implementation that mirrors the original O(n^2) algorithm.
+     * Used only to verify the optimized incremental implementation.
+     */
+    private double calculateRBOSimilarityNaive(List<String> listA, List<String> listB, double p) {
+        if (p <= 0 || p >= 1) {
+            throw new SearchRelevanceException("p must be between 0 and 1", RestStatus.INTERNAL_SERVER_ERROR);
+        }
+
+        int maxDepth = Math.max(listA.size(), listB.size());
+        double sum = 0;
+        double weight = 1;
+
+        for (int d = 0; d < maxDepth; d++) {
+            Set<String> setA = new HashSet<>(listA.subList(0, Math.min(d + 1, listA.size())));
+            Set<String> setB = new HashSet<>(listB.subList(0, Math.min(d + 1, listB.size())));
+
+            Set<String> intersection = new HashSet<>(setA);
+            intersection.retainAll(setB);
+            double overlap = intersection.size() / (double) Math.max(setA.size(), setB.size());
+
+            sum += weight * overlap;
+            weight *= p;
+        }
+
+        double rboSimilarity = sum * (1 - p) / (1 - Math.pow(p, maxDepth));
+        return Math.round(rboSimilarity * 100.0) / 100.0;
+    }
+}


### PR DESCRIPTION
PairComparison.calculateRBOSimilarity rebuilt prefix HashSets at every depth, making RBO computation O(n²). Maintain the prefix sets incrementally and update a running overlap counter, reducing the method to O(n) while preserving the exact same score and rounding behaviour.

Resolves #499
