### PR TITLE
Optimize Frequency Weighted similarity by replacing O(n²) list scan

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Add experiment execution time input signatures (SHA-256 fingerprints of query set, judgments, and search configurations) and `GET /_plugins/_search_relevance/experiments/{id}/validate` for VALID / DRIFTED / UNAVAILABLE drift checks ([#456](https://github.com/opensearch-project/search-relevance/pull/456))
 
 ### Enhancements
+- Optimize Rank-Biased Overlap (RBO) calculation from O(n²) to O(n) by maintaining prefix sets incrementally ([#499](https://github.com/opensearch-project/search-relevance/issues/499))
 
 ### Bug Fixes
 - Implement referential integrity validation for search configurations, experiments, and judgments ([#360](https://github.com/opensearch-project/search-relevance/pull/360))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Add experiment execution time input signatures (SHA-256 fingerprints of query set, judgments, and search configurations) and `GET /_plugins/_search_relevance/experiments/{id}/validate` for VALID / DRIFTED / UNAVAILABLE drift checks ([#456](https://github.com/opensearch-project/search-relevance/pull/456))
 
 ### Enhancements
-- Optimize Frequency Weighted similarity calculation by replacing the O(n²) `listB.contains` scan with HashSet membership and single-pass union/intersection accumulation
+- Optimize Frequency Weighted similarity calculation by replacing the O(n²) `listB.contains` scan with HashSet membership and single-pass union/intersection accumulation ([#502](https://github.com/opensearch-project/search-relevance/pull/502))
 
 ### Bug Fixes
 - Implement referential integrity validation for search configurations, experiments, and judgments ([#360](https://github.com/opensearch-project/search-relevance/pull/360))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Add experiment execution time input signatures (SHA-256 fingerprints of query set, judgments, and search configurations) and `GET /_plugins/_search_relevance/experiments/{id}/validate` for VALID / DRIFTED / UNAVAILABLE drift checks ([#456](https://github.com/opensearch-project/search-relevance/pull/456))
 
 ### Enhancements
+- Optimize Frequency Weighted similarity calculation by replacing the O(n²) `listB.contains` scan with HashSet membership and single-pass union/intersection accumulation
 
 ### Bug Fixes
 - Implement referential integrity validation for search configurations, experiments, and judgments ([#360](https://github.com/opensearch-project/search-relevance/pull/360))

--- a/src/main/java/org/opensearch/searchrelevance/metrics/calculator/PairComparison.java
+++ b/src/main/java/org/opensearch/searchrelevance/metrics/calculator/PairComparison.java
@@ -55,24 +55,35 @@ public class PairComparison {
             throw new SearchRelevanceException("p must be between 0 and 1", RestStatus.INTERNAL_SERVER_ERROR);
         }
 
-        int maxDepth = Math.max(listA.size(), listB.size());
+        int sizeA = listA.size();
+        int sizeB = listB.size();
+        int maxDepth = Math.max(sizeA, sizeB);
         double sum = 0;
         double weight = 1;
-        double sumWeight = 0;
 
-        // Calculate overlap at each depth
+        // Maintain prefix sets incrementally so overlap is updated in O(1) per depth
+        // instead of rebuilding the sets from scratch at each depth.
+        Set<String> setA = new HashSet<>();
+        Set<String> setB = new HashSet<>();
+        int overlapCount = 0;
+
         for (int d = 0; d < maxDepth; d++) {
-            Set<String> setA = new HashSet<>(listA.subList(0, Math.min(d + 1, listA.size())));
-            Set<String> setB = new HashSet<>(listB.subList(0, Math.min(d + 1, listB.size())));
+            if (d < sizeA) {
+                String itemA = listA.get(d);
+                if (setA.add(itemA) && setB.contains(itemA)) {
+                    overlapCount++;
+                }
+            }
 
-            // Calculate overlap at current depth
-            Set<String> intersection = new HashSet<>(setA);
-            intersection.retainAll(setB);
-            double overlap = intersection.size() / (double) Math.max(setA.size(), setB.size());
+            if (d < sizeB) {
+                String itemB = listB.get(d);
+                if (setB.add(itemB) && setA.contains(itemB)) {
+                    overlapCount++;
+                }
+            }
 
-            // Add weighted overlap to sum
+            double overlap = overlapCount / (double) Math.max(setA.size(), setB.size());
             sum += weight * overlap;
-            sumWeight += weight;
             weight *= p;
         }
 

--- a/src/main/java/org/opensearch/searchrelevance/metrics/calculator/PairComparison.java
+++ b/src/main/java/org/opensearch/searchrelevance/metrics/calculator/PairComparison.java
@@ -85,43 +85,31 @@ public class PairComparison {
      * Frequency Weighted similarity
      */
     public static double calculateFrequencyWeightedSimilarity(List<String> listA, List<String> listB) {
-        Map<String, Double> weights = calculateCombinedWeights(listA, listB);
-
-        // Calculate intersection weight
-        double intersectionWeight = 0.0;
-        for (String item : new HashSet<>(listA)) {
-            if (listB.contains(item)) {
-                intersectionWeight += weights.get(item);
-            }
-        }
-
-        // Calculate union weight
-        double unionWeight = weights.values().stream().mapToDouble(Double::doubleValue).sum();
-
-        double frequencyWeightedSimilarity = unionWeight == 0 ? 0 : intersectionWeight / unionWeight;
-        return Math.round(frequencyWeightedSimilarity * 100.0) / 100.0;
-    }
-
-    private static Map<String, Double> calculateCombinedWeights(List<String> listA, List<String> listB) {
         FrequencyStats statsA = calculateFrequencyWeights(listA);
         FrequencyStats statsB = calculateFrequencyWeights(listB);
 
-        // Combine unique items from both lists
-        Map<String, Double> combinedWeights = new HashMap<>();
-
-        // Process all items from both lists
-        Set<String> allItems = new HashSet<>();
-        allItems.addAll(statsA.weights.keySet());
+        // Combine unique items from both lists and compute intersection / union weights
+        // in a single pass. Using HashSet membership avoids the O(|A| × |B|) scan
+        // caused by calling listB.contains(item) for every unique item in A.
+        Set<String> allItems = new HashSet<>(statsA.weights.keySet());
         allItems.addAll(statsB.weights.keySet());
+
+        Set<String> setB = new HashSet<>(statsB.weights.keySet());
+        double intersectionWeight = 0.0;
+        double unionWeight = 0.0;
 
         for (String item : allItems) {
             double weightA = statsA.weights.getOrDefault(item, 0.0);
             double weightB = statsB.weights.getOrDefault(item, 0.0);
-            // Average of weights from both lists
-            combinedWeights.put(item, (weightA + weightB) / 2.0);
+            double combinedWeight = (weightA + weightB) / 2.0;
+            unionWeight += combinedWeight;
+            if (statsA.weights.containsKey(item) && setB.contains(item)) {
+                intersectionWeight += combinedWeight;
+            }
         }
 
-        return combinedWeights;
+        double frequencyWeightedSimilarity = unionWeight == 0 ? 0 : intersectionWeight / unionWeight;
+        return Math.round(frequencyWeightedSimilarity * 100.0) / 100.0;
     }
 
     private static FrequencyStats calculateFrequencyWeights(List<String> list) {

--- a/src/test/java/org/opensearch/searchrelevance/metrics/calculator/PairComparisonTests.java
+++ b/src/test/java/org/opensearch/searchrelevance/metrics/calculator/PairComparisonTests.java
@@ -1,0 +1,156 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+package org.opensearch.searchrelevance.metrics.calculator;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Random;
+import java.util.Set;
+
+import org.opensearch.core.rest.RestStatus;
+import org.opensearch.searchrelevance.exception.SearchRelevanceException;
+import org.opensearch.test.OpenSearchTestCase;
+
+/**
+ * Tests for {@link PairComparison} metric calculators.
+ */
+public class PairComparisonTests extends OpenSearchTestCase {
+
+    public void testIdenticalListsRboIsOne() {
+        List<String> list = Arrays.asList("a", "b", "c", "d", "e");
+        assertEquals(1.0, PairComparison.calculateRBOSimilarity(list, list, 0.5), 0.001);
+        assertEquals(1.0, PairComparison.calculateRBOSimilarity(list, list, 0.9), 0.001);
+    }
+
+    public void testDisjointListsRboIsZero() {
+        List<String> listA = Arrays.asList("a", "b", "c");
+        List<String> listB = Arrays.asList("d", "e", "f");
+        assertEquals(0.0, PairComparison.calculateRBOSimilarity(listA, listB, 0.5), 0.001);
+        assertEquals(0.0, PairComparison.calculateRBOSimilarity(listA, listB, 0.9), 0.001);
+    }
+
+    public void testPartialOverlap() {
+        List<String> listA = Arrays.asList("a", "b", "c");
+        List<String> listB = Arrays.asList("a", "c", "b");
+        // d=0: overlap=1, d=1: overlap=1/2, d=2: overlap=3/3
+        // sum = 1 + 0.5*0.5 + 0.25*1 = 1.5
+        // rbo = 1.5 * 0.5 / (1 - 0.125) = 0.8571... -> 0.86
+        assertEquals(0.86, PairComparison.calculateRBOSimilarity(listA, listB, 0.5), 0.001);
+    }
+
+    public void testReversedOrder() {
+        List<String> listA = Arrays.asList("a", "b");
+        List<String> listB = Arrays.asList("b", "a");
+        // d=0: overlap=0/1, d=1: overlap=2/2
+        // sum = 0 + 0.5*1 = 0.5
+        // rbo = 0.5 * 0.5 / (1 - 0.25) = 0.3333... -> 0.33
+        assertEquals(0.33, PairComparison.calculateRBOSimilarity(listA, listB, 0.5), 0.001);
+    }
+
+    public void testDifferentLengths() {
+        List<String> listA = Arrays.asList("a", "b", "c", "d");
+        List<String> listB = Arrays.asList("a", "b");
+        // d=0: overlap=1, d=1: overlap=2/2, d=2: overlap=2/3, d=3: overlap=2/4
+        // sum = 1 + 0.5*1 + 0.25*2/3 + 0.125*2/4
+        // = 1 + 0.5 + 0.1667 + 0.0625 = 1.7292
+        // rbo = 1.7292 * 0.5 / (1 - 0.0625) = 0.8646 / 0.9375 = 0.9222 -> 0.92
+        assertEquals(0.92, PairComparison.calculateRBOSimilarity(listA, listB, 0.5), 0.001);
+    }
+
+    public void testDuplicates() {
+        List<String> listA = Arrays.asList("a", "a", "b");
+        List<String> listB = Arrays.asList("a", "b", "b");
+        // d=0: overlap=1, d=1: overlap=1/2, d=2: overlap=2/2
+        // sum = 1 + 0.5*0.5 + 0.25*1 = 1.5
+        // rbo = 1.5 * 0.5 / (1 - 0.125) = 0.8571... -> 0.86
+        assertEquals(0.86, PairComparison.calculateRBOSimilarity(listA, listB, 0.5), 0.001);
+    }
+
+    public void testSingleElementMatch() {
+        List<String> listA = Collections.singletonList("a");
+        List<String> listB = Collections.singletonList("a");
+        assertEquals(1.0, PairComparison.calculateRBOSimilarity(listA, listB, 0.5), 0.001);
+    }
+
+    public void testSingleElementMismatch() {
+        List<String> listA = Collections.singletonList("a");
+        List<String> listB = Collections.singletonList("b");
+        assertEquals(0.0, PairComparison.calculateRBOSimilarity(listA, listB, 0.5), 0.001);
+    }
+
+    public void testInvalidPThrowsException() {
+        List<String> list = Collections.singletonList("a");
+
+        SearchRelevanceException ex = expectThrows(
+            SearchRelevanceException.class,
+            () -> PairComparison.calculateRBOSimilarity(list, list, 0.0)
+        );
+        assertEquals(RestStatus.INTERNAL_SERVER_ERROR, ex.status());
+        assertTrue(ex.getMessage().contains("p must be between 0 and 1"));
+
+        ex = expectThrows(SearchRelevanceException.class, () -> PairComparison.calculateRBOSimilarity(list, list, 1.0));
+        assertEquals(RestStatus.INTERNAL_SERVER_ERROR, ex.status());
+
+        ex = expectThrows(SearchRelevanceException.class, () -> PairComparison.calculateRBOSimilarity(list, list, -0.1));
+        assertEquals(RestStatus.INTERNAL_SERVER_ERROR, ex.status());
+    }
+
+    public void testIncrementalResultMatchesNaiveImplementation() {
+        Random random = random();
+        for (int trial = 0; trial < 100; trial++) {
+            List<String> listA = randomStringList(random, 1 + random.nextInt(50));
+            List<String> listB = randomStringList(random, 1 + random.nextInt(50));
+            double p = 0.1 + random.nextDouble() * 0.89;
+
+            double optimized = PairComparison.calculateRBOSimilarity(listA, listB, p);
+            double naive = calculateRBOSimilarityNaive(listA, listB, p);
+            assertEquals("Mismatch for lists " + listA + " and " + listB + " with p=" + p, naive, optimized, 0.0001);
+        }
+    }
+
+    private List<String> randomStringList(Random random, int size) {
+        String[] tokens = { "a", "b", "c", "d", "e", "f", "g", "h" };
+        List<String> list = new ArrayList<>(size);
+        for (int i = 0; i < size; i++) {
+            list.add(tokens[random.nextInt(tokens.length)]);
+        }
+        return list;
+    }
+
+    /**
+     * Reference implementation that mirrors the original O(n^2) algorithm.
+     * Used only to verify the optimized incremental implementation.
+     */
+    private double calculateRBOSimilarityNaive(List<String> listA, List<String> listB, double p) {
+        if (p <= 0 || p >= 1) {
+            throw new SearchRelevanceException("p must be between 0 and 1", RestStatus.INTERNAL_SERVER_ERROR);
+        }
+
+        int maxDepth = Math.max(listA.size(), listB.size());
+        double sum = 0;
+        double weight = 1;
+
+        for (int d = 0; d < maxDepth; d++) {
+            Set<String> setA = new HashSet<>(listA.subList(0, Math.min(d + 1, listA.size())));
+            Set<String> setB = new HashSet<>(listB.subList(0, Math.min(d + 1, listB.size())));
+
+            Set<String> intersection = new HashSet<>(setA);
+            intersection.retainAll(setB);
+            double overlap = intersection.size() / (double) Math.max(setA.size(), setB.size());
+
+            sum += weight * overlap;
+            weight *= p;
+        }
+
+        double rboSimilarity = sum * (1 - p) / (1 - Math.pow(p, maxDepth));
+        return Math.round(rboSimilarity * 100.0) / 100.0;
+    }
+}

--- a/src/test/java/org/opensearch/searchrelevance/metrics/calculator/PairComparisonTests.java
+++ b/src/test/java/org/opensearch/searchrelevance/metrics/calculator/PairComparisonTests.java
@@ -1,0 +1,132 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+package org.opensearch.searchrelevance.metrics.calculator;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Random;
+import java.util.Set;
+
+import org.opensearch.test.OpenSearchTestCase;
+
+/**
+ * Tests for {@link PairComparison} metric calculators.
+ */
+public class PairComparisonTests extends OpenSearchTestCase {
+
+    public void testIdenticalListsFrequencyWeightedSimilarityIsOne() {
+        List<String> list = Arrays.asList("a", "b", "c");
+        assertEquals(1.0, PairComparison.calculateFrequencyWeightedSimilarity(list, list), 0.001);
+    }
+
+    public void testDisjointListsFrequencyWeightedSimilarityIsZero() {
+        List<String> listA = Arrays.asList("a", "b", "c");
+        List<String> listB = Arrays.asList("d", "e", "f");
+        assertEquals(0.0, PairComparison.calculateFrequencyWeightedSimilarity(listA, listB), 0.001);
+    }
+
+    public void testFrequencyWeightedPartialOverlap() {
+        List<String> listA = Arrays.asList("a", "a", "b");
+        List<String> listB = Arrays.asList("a", "c", "c");
+        // freqA: a=2/3, b=1/3
+        // freqB: a=1/3, c=2/3
+        // combined weights: a=0.5, b=1/6, c=1/3
+        // intersection = {a} -> 0.5
+        // union = {a,b,c} -> 0.5 + 1/6 + 1/3 = 1.0
+        // similarity = 0.5
+        assertEquals(0.5, PairComparison.calculateFrequencyWeightedSimilarity(listA, listB), 0.001);
+    }
+
+    public void testFrequencyWeightedWithDuplicates() {
+        List<String> listA = Arrays.asList("a", "a", "b");
+        List<String> listB = Arrays.asList("a", "b", "b");
+        // Both lists contain the same unique items {a,b} with symmetric frequencies,
+        // so the combined weights for a and b sum to 1 and intersection equals union.
+        assertEquals(1.0, PairComparison.calculateFrequencyWeightedSimilarity(listA, listB), 0.001);
+    }
+
+    public void testFrequencyWeightedSingleElementMatch() {
+        List<String> listA = Collections.singletonList("a");
+        List<String> listB = Collections.singletonList("a");
+        assertEquals(1.0, PairComparison.calculateFrequencyWeightedSimilarity(listA, listB), 0.001);
+    }
+
+    public void testFrequencyWeightedSingleElementMismatch() {
+        List<String> listA = Collections.singletonList("a");
+        List<String> listB = Collections.singletonList("b");
+        assertEquals(0.0, PairComparison.calculateFrequencyWeightedSimilarity(listA, listB), 0.001);
+    }
+
+    public void testFrequencyWeightedIncrementalResultMatchesNaiveImplementation() {
+        Random random = random();
+        for (int trial = 0; trial < 100; trial++) {
+            List<String> listA = randomStringList(random, 1 + random.nextInt(50));
+            List<String> listB = randomStringList(random, 1 + random.nextInt(50));
+
+            double optimized = PairComparison.calculateFrequencyWeightedSimilarity(listA, listB);
+            double naive = calculateFrequencyWeightedSimilarityNaive(listA, listB);
+            assertEquals("Mismatch for lists " + listA + " and " + listB, naive, optimized, 0.0001);
+        }
+    }
+
+    private List<String> randomStringList(Random random, int size) {
+        String[] tokens = { "a", "b", "c", "d", "e", "f", "g", "h" };
+        List<String> list = new ArrayList<>(size);
+        for (int i = 0; i < size; i++) {
+            list.add(tokens[random.nextInt(tokens.length)]);
+        }
+        return list;
+    }
+
+    /**
+     * Reference implementation that mirrors the original O(n^2) algorithm.
+     * Used only to verify the optimized implementation.
+     */
+    private double calculateFrequencyWeightedSimilarityNaive(List<String> listA, List<String> listB) {
+        // Reproduce the original computeCombinedWeights logic inline.
+        java.util.Map<String, Double> weightsA = calculateFrequencyWeightsNaive(listA);
+        java.util.Map<String, Double> weightsB = calculateFrequencyWeightsNaive(listB);
+
+        Set<String> allItems = new HashSet<>(weightsA.keySet());
+        allItems.addAll(weightsB.keySet());
+
+        java.util.Map<String, Double> combinedWeights = new java.util.HashMap<>();
+        for (String item : allItems) {
+            double weightA = weightsA.getOrDefault(item, 0.0);
+            double weightB = weightsB.getOrDefault(item, 0.0);
+            combinedWeights.put(item, (weightA + weightB) / 2.0);
+        }
+
+        double intersectionWeight = 0.0;
+        for (String item : new HashSet<>(listA)) {
+            if (listB.contains(item)) {
+                intersectionWeight += combinedWeights.get(item);
+            }
+        }
+
+        double unionWeight = combinedWeights.values().stream().mapToDouble(Double::doubleValue).sum();
+        double similarity = unionWeight == 0 ? 0 : intersectionWeight / unionWeight;
+        return Math.round(similarity * 100.0) / 100.0;
+    }
+
+    private java.util.Map<String, Double> calculateFrequencyWeightsNaive(List<String> list) {
+        java.util.Map<String, Integer> frequencies = new java.util.HashMap<>();
+        for (String item : list) {
+            frequencies.put(item, frequencies.getOrDefault(item, 0) + 1);
+        }
+        double totalFrequency = frequencies.values().stream().mapToInt(Integer::intValue).sum();
+        java.util.Map<String, Double> weights = new java.util.HashMap<>();
+        for (java.util.Map.Entry<String, Integer> entry : frequencies.entrySet()) {
+            weights.put(entry.getKey(), entry.getValue() / totalFrequency);
+        }
+        return weights;
+    }
+}


### PR DESCRIPTION
PairComparison.calculateFrequencyWeightedSimilarity iterated over every unique item in listA and called listB.contains(item) on a List, making the intersection computation O(|uniqueA| × |listB|). Inline the combined weight calculation and use a HashSet for listB membership, computing intersection and union weights in a single pass over the unique items.

This removes the transient combinedWeights map and the quadratic scan while producing the exact same similarity score.

resolves #501 