### PR TITLE
Use opensearch managed thread pool in MLAccessor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,19 +8,12 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### Features
 
-- Add experiment execution time input signatures (SHA-256 fingerprints of query set, judgments, and search configurations) and `GET /_plugins/_search_relevance/experiments/{id}/validate` for VALID / DRIFTED / UNAVAILABLE drift checks ([#456](https://github.com/opensearch-project/search-relevance/pull/456))
-
 ### Enhancements
-- Optimize Rank-Biased Overlap (RBO) calculation from O(n²) to O(n) by maintaining prefix sets incrementally ([#499](https://github.com/opensearch-project/search-relevance/issues/499))
-- Optimize Frequency Weighted similarity calculation by replacing the O(n²) `listB.contains` scan with HashSet membership and single-pass union/intersection accumulation ([#502](https://github.com/opensearch-project/search-relevance/pull/502))
 
 ### Bug Fixes
-- Implement referential integrity validation for search configurations, experiments, and judgments ([#360](https://github.com/opensearch-project/search-relevance/pull/360))
-- Preserve the original query structure when building experiment search requests so search pipeline request processors can resolve field paths instead of failing on a wrapped query ([#490](https://github.com/opensearch-project/search-relevance/pull/490))
+- Use opensearch managed thread pool in MLAccessor ([#503](https://github.com/opensearch-project/search-relevance/pull/503))
 
 ### Infrastructure
-- Update updateVersion task and fix BWC version properties ([#475](https://github.com/opensearch-project/search-relevance/pull/475))
-- Fix BWC tests by creating the referenced index before creating the search configuration ([#497](https://github.com/opensearch-project/search-relevance/pull/497))
 
 ### Documentation
 

--- a/src/main/java/org/opensearch/searchrelevance/ml/MLAccessor.java
+++ b/src/main/java/org/opensearch/searchrelevance/ml/MLAccessor.java
@@ -10,15 +10,15 @@ package org.opensearch.searchrelevance.ml;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.TimeUnit;
 
+import org.opensearch.common.unit.TimeValue;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.ml.client.MachineLearningNodeClient;
 import org.opensearch.ml.common.dataset.remote.RemoteInferenceInputDataSet;
 import org.opensearch.ml.common.input.MLInput;
 import org.opensearch.searchrelevance.model.LLMJudgmentRatingType;
 import org.opensearch.searchrelevance.utils.RatingOutputProcessor;
+import org.opensearch.threadpool.ThreadPool;
 
 import lombok.extern.log4j.Log4j2;
 
@@ -29,13 +29,15 @@ import lombok.extern.log4j.Log4j2;
 public class MLAccessor {
     private final MachineLearningNodeClient mlClient;
     private final MLInputOutputTransformer transformer;
+    private final ThreadPool threadPool;
 
     private static final int MAX_RETRY_NUMBER = 3;
     private static final long RETRY_DELAY_MS = 1000;
 
-    public MLAccessor(MachineLearningNodeClient mlClient) {
+    public MLAccessor(MachineLearningNodeClient mlClient, ThreadPool threadPool) {
         this.mlClient = mlClient;
         this.transformer = new MLInputOutputTransformer();
+        this.threadPool = threadPool;
     }
 
     public void predict(
@@ -192,7 +194,7 @@ public class MLAccessor {
     }
 
     private void scheduleRetry(Runnable runnable, long delayMs) {
-        CompletableFuture.delayedExecutor(delayMs, TimeUnit.MILLISECONDS).execute(runnable);
+        threadPool.schedule(runnable, TimeValue.timeValueMillis(delayMs), ThreadPool.Names.GENERIC);
     }
 
     public void predictSingleChunk(String modelId, MLInput mlInput, ActionListener<String> listener) {

--- a/src/main/java/org/opensearch/searchrelevance/plugin/SearchRelevancePlugin.java
+++ b/src/main/java/org/opensearch/searchrelevance/plugin/SearchRelevancePlugin.java
@@ -219,7 +219,7 @@ public class SearchRelevancePlugin extends Plugin
         this.scheduledJobsDao = new ScheduledJobsDao(searchRelevanceIndicesManager);
         this.scheduledExperimentHistoryDao = new ScheduledExperimentHistoryDao(searchRelevanceIndicesManager);
         MachineLearningNodeClient mlClient = new MachineLearningNodeClient(client);
-        this.mlAccessor = new MLAccessor(mlClient);
+        this.mlAccessor = new MLAccessor(mlClient, threadPool);
         SearchRequestBuilder.initialize(xContentRegistry);
         SearchRelevanceExecutor.initialize(threadPool);
         ExperimentTaskManager experimentTaskManager = new ExperimentTaskManager(

--- a/src/test/java/org/opensearch/searchrelevance/ml/MLAccessorIntegrationTests.java
+++ b/src/test/java/org/opensearch/searchrelevance/ml/MLAccessorIntegrationTests.java
@@ -30,6 +30,8 @@ import org.opensearch.ml.common.output.model.ModelTensorOutput;
 import org.opensearch.ml.common.output.model.ModelTensors;
 import org.opensearch.searchrelevance.model.LLMJudgmentRatingType;
 import org.opensearch.test.OpenSearchTestCase;
+import org.opensearch.threadpool.TestThreadPool;
+import org.opensearch.threadpool.ThreadPool;
 
 /**
  * Integration tests for MLAccessor focusing on:
@@ -48,9 +50,21 @@ import org.opensearch.test.OpenSearchTestCase;
  */
 public class MLAccessorIntegrationTests extends OpenSearchTestCase {
 
+    private ThreadPool threadPool;
+
+    public void setUp() throws Exception {
+        super.setUp();
+        threadPool = new TestThreadPool("test-thread-pool");
+    }
+
+    @Override
+    public void tearDown() throws Exception {
+        super.tearDown();
+        ThreadPool.terminate(threadPool, 10, TimeUnit.SECONDS);
+    }
+
     /**
      * Note: GPT-3.5 fallback testing is documented in TESTING_GPT35_FALLBACK.md as "Scenario 2"
-     * This scenario requires triggering scheduleRetry which creates CompletableFuture threads that leak.
      * Coverage is provided by:
      * - Unit tests: MLInputOutputTransformerTests verifies response_format parameter handling
      * - Manual tests: Real OpenAI GPT-3.5 API integration testing
@@ -62,7 +76,7 @@ public class MLAccessorIntegrationTests extends OpenSearchTestCase {
      */
     public void testFirstAttemptSuccess_WhenModelSupportsResponseFormat() throws Exception {
         MachineLearningNodeClient mlClient = mock(MachineLearningNodeClient.class);
-        MLAccessor mlAccessor = new MLAccessor(mlClient);
+        MLAccessor mlAccessor = new MLAccessor(mlClient, threadPool);
 
         AtomicInteger attemptCount = new AtomicInteger(0);
         CountDownLatch latch = new CountDownLatch(1);

--- a/src/test/java/org/opensearch/searchrelevance/ml/MLAccessorIntegrationTests.java
+++ b/src/test/java/org/opensearch/searchrelevance/ml/MLAccessorIntegrationTests.java
@@ -38,12 +38,7 @@ import org.opensearch.threadpool.ThreadPool;
  * - First attempt success with response_format (GPT-4o scenario)
  * - Response processing with structured outputs
  *
- * Note: Tests for retry logic and fallback behavior (GPT-3.5 compatibility) are documented
- * in TESTING_GPT35_FALLBACK.md as manual tests because they require delayed retries which
- * create thread leaks in the OpenSearch test framework. The retry mechanism uses
- * CompletableFuture.delayedExecutor which creates daemon threads that cannot be properly
- * cleaned up within test execution.
- *
+ * TODO: Tests for retry logic and fallback behavior (GPT-3.5 compatibility) are documented in TESTING_GPT35_FALLBACK.md
  * Covered by unit tests:
  * - MLInputOutputTransformerTests: Verifies response_format parameter is correctly included/excluded
  * - RatingOutputProcessorTests: Verifies both structured and unstructured response parsing
@@ -52,6 +47,7 @@ public class MLAccessorIntegrationTests extends OpenSearchTestCase {
 
     private ThreadPool threadPool;
 
+    @Override
     public void setUp() throws Exception {
         super.setUp();
         threadPool = new TestThreadPool("test-thread-pool");
@@ -133,18 +129,14 @@ public class MLAccessorIntegrationTests extends OpenSearchTestCase {
 
     /**
      * Note: Binary rating (RELEVANT/IRRELEVANT) fallback testing is documented in
-     * TESTING_GPT35_FALLBACK.md as "Scenario 3". This test would trigger scheduleRetry
-     * creating thread leaks. Coverage is provided by:
+     * TESTING_GPT35_FALLBACK.md as "Scenario 3". Coverage is provided by:
      * - Unit tests: MLInputOutputTransformerTests.testCreateMLInput_BinaryRatingWithoutResponseFormat
      * - Unit tests: RatingOutputProcessorTests verifies RELEVANT→1.0, IRRELEVANT→0.0 conversion
      * - Manual tests: Real OpenAI API integration testing
      */
 
     /**
-     * Note: Testing retry exhaustion (all attempts fail) is documented in TESTING_GPT35_FALLBACK.md
-     * as a manual test scenario because it requires delayed retries which create thread leaks in tests.
-     * The retry logic with exponential backoff uses CompletableFuture.delayedExecutor which creates
-     * daemon threads that cannot be properly cleaned up in the OpenSearch test framework.
+     * TODO: Testing retry exhaustion (all attempts fail) is documented in TESTING_GPT35_FALLBACK.md
      */
 
     // ============================================


### PR DESCRIPTION
### Description

Replace `CompletableFuture.delayedExecutor` with managed thread pool via inject and update tests.

### Issues Resolved
This closes https://github.com/opensearch-project/search-relevance/issues/312#issue 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
