### PR TITLE
[AB Test][Part 2] Add Search API with Team Draft Interleaving

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 - Add experiment execution time input signatures (SHA-256 fingerprints of query set, judgments, and search configurations) and `GET /_plugins/_search_relevance/experiments/{id}/validate` for VALID / DRIFTED / UNAVAILABLE drift checks ([#456](https://github.com/opensearch-project/search-relevance/pull/456))
 - Add Create and Update AB Test APIs for Team Draft Interleaving evaluation ([#498](https://github.com/opensearch-project/search-relevance/pull/498))
+- Add Search API with TDI interleaving for AB test evaluation ([#TBD](https://github.com/opensearch-project/search-relevance/pull/TBD))
 
 ### Enhancements
 

--- a/src/main/java/org/opensearch/searchrelevance/algorithm/TeamDraftInterleaver.java
+++ b/src/main/java/org/opensearch/searchrelevance/algorithm/TeamDraftInterleaver.java
@@ -25,7 +25,7 @@ import lombok.NoArgsConstructor;
  * "team" (search configuration) each document belongs to. A fair coin flip each round
  * determines which list picks first, ensuring unbiased presentation order.
  *
- * Reference: Radlinski & Craswell, "Optimized Interleaving for Online Retrieval Evaluation" (WSDM 2013)
+ * Reference: Radlinski &amp; Craswell, "Optimized Interleaving for Online Retrieval Evaluation" (WSDM 2013)
  */
 @NoArgsConstructor
 public class TeamDraftInterleaver {
@@ -61,12 +61,14 @@ public class TeamDraftInterleaver {
             while (firstPtr < firstHits.size() && seen.contains(firstHits.get(firstPtr).getId())) {
                 firstPtr++;
             }
+            boolean pickedFirst = false;
             if (firstPtr < firstHits.size()) {
                 SearchHit pick = firstHits.get(firstPtr);
                 interleaved.add(pick);
                 firstTeam.add(pick.getId());
                 seen.add(pick.getId());
                 firstPtr++;
+                pickedFirst = true;
             }
             if (interleaved.size() >= size) {
                 if (aFirst) {
@@ -83,14 +85,16 @@ public class TeamDraftInterleaver {
             while (secondPtr < secondHits.size() && seen.contains(secondHits.get(secondPtr).getId())) {
                 secondPtr++;
             }
+            boolean pickedSecond = false;
             if (secondPtr < secondHits.size()) {
                 SearchHit pick = secondHits.get(secondPtr);
                 interleaved.add(pick);
                 secondTeam.add(pick.getId());
                 seen.add(pick.getId());
                 secondPtr++;
+                pickedSecond = true;
             }
-            // Step 4: Update pointers for next round
+            // Step 4: Update pointers and check termination
             if (aFirst) {
                 ptrA = firstPtr;
                 ptrB = secondPtr;
@@ -98,7 +102,8 @@ public class TeamDraftInterleaver {
                 ptrB = firstPtr;
                 ptrA = secondPtr;
             }
-            if (ptrA >= hitsA.size() && ptrB >= hitsB.size()) {
+            // No progress guard — break if neither team could pick (all docs exhausted/seen)
+            if (!pickedFirst && !pickedSecond) {
                 break;
             }
         }

--- a/src/main/java/org/opensearch/searchrelevance/algorithm/TeamDraftInterleaver.java
+++ b/src/main/java/org/opensearch/searchrelevance/algorithm/TeamDraftInterleaver.java
@@ -15,10 +15,29 @@ import java.util.concurrent.ThreadLocalRandom;
 
 import org.opensearch.search.SearchHit;
 
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * Implements Team Draft Interleaving (TDI) algorithm for A/B testing search configurations.
+ *
+ * TDI merges two ranked result lists into a single interleaved list while tracking which
+ * "team" (search configuration) each document belongs to. A fair coin flip each round
+ * determines which list picks first, ensuring unbiased presentation order.
+ *
+ * Reference: Radlinski & Craswell, "Optimized Interleaving for Online Retrieval Evaluation" (WSDM 2013)
+ */
+@NoArgsConstructor
 public class TeamDraftInterleaver {
 
-    public TeamDraftInterleaver() {}
-
+    /**
+     * Interleaves two ranked hit lists using the Team Draft algorithm.
+     *
+     * @param hitsA ranked results from search configuration A
+     * @param hitsB ranked results from search configuration B
+     * @param size  maximum number of results in the interleaved list
+     * @return Result containing the interleaved list and team membership sets
+     */
     public Result interleave(List<SearchHit> hitsA, List<SearchHit> hitsB, int size) {
         List<SearchHit> interleaved = new ArrayList<>(size);
         Set<String> teamA = new HashSet<>();
@@ -27,7 +46,9 @@ public class TeamDraftInterleaver {
         int ptrA = 0;
         int ptrB = 0;
 
+        // Step 1: Repeat rounds until we have enough results or exhaust both lists
         while (interleaved.size() < size) {
+            // Step 2: Fair coin flip — determines which team picks first this round
             boolean aFirst = ThreadLocalRandom.current().nextBoolean();
             List<SearchHit> firstHits = aFirst ? hitsA : hitsB;
             List<SearchHit> secondHits = aFirst ? hitsB : hitsA;
@@ -36,6 +57,7 @@ public class TeamDraftInterleaver {
             int firstPtr = aFirst ? ptrA : ptrB;
             int secondPtr = aFirst ? ptrB : ptrA;
 
+            // Step 3a: First team picks — skip documents already in the interleaved list
             while (firstPtr < firstHits.size() && seen.contains(firstHits.get(firstPtr).getId())) {
                 firstPtr++;
             }
@@ -57,6 +79,7 @@ public class TeamDraftInterleaver {
                 break;
             }
 
+            // Step 3b: Second team picks — skip documents already in the interleaved list
             while (secondPtr < secondHits.size() && seen.contains(secondHits.get(secondPtr).getId())) {
                 secondPtr++;
             }
@@ -67,6 +90,7 @@ public class TeamDraftInterleaver {
                 seen.add(pick.getId());
                 secondPtr++;
             }
+            // Step 4: Update pointers for next round
             if (aFirst) {
                 ptrA = firstPtr;
                 ptrB = secondPtr;
@@ -81,6 +105,7 @@ public class TeamDraftInterleaver {
         return new Result(interleaved, teamA, teamB);
     }
 
+    @Getter
     public static class Result {
         private final List<SearchHit> interleavedHits;
         private final Set<String> teamA;
@@ -90,18 +115,6 @@ public class TeamDraftInterleaver {
             this.interleavedHits = java.util.Collections.unmodifiableList(interleavedHits);
             this.teamA = java.util.Collections.unmodifiableSet(teamA);
             this.teamB = java.util.Collections.unmodifiableSet(teamB);
-        }
-
-        public List<SearchHit> getInterleavedHits() {
-            return interleavedHits;
-        }
-
-        public Set<String> getTeamA() {
-            return teamA;
-        }
-
-        public Set<String> getTeamB() {
-            return teamB;
         }
     }
 }

--- a/src/main/java/org/opensearch/searchrelevance/algorithm/TeamDraftInterleaver.java
+++ b/src/main/java/org/opensearch/searchrelevance/algorithm/TeamDraftInterleaver.java
@@ -1,0 +1,107 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+package org.opensearch.searchrelevance.algorithm;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.ThreadLocalRandom;
+
+import org.opensearch.search.SearchHit;
+
+public class TeamDraftInterleaver {
+
+    public TeamDraftInterleaver() {}
+
+    public Result interleave(List<SearchHit> hitsA, List<SearchHit> hitsB, int size) {
+        List<SearchHit> interleaved = new ArrayList<>(size);
+        Set<String> teamA = new HashSet<>();
+        Set<String> teamB = new HashSet<>();
+        Set<String> seen = new HashSet<>();
+        int ptrA = 0;
+        int ptrB = 0;
+
+        while (interleaved.size() < size) {
+            boolean aFirst = ThreadLocalRandom.current().nextBoolean();
+            List<SearchHit> firstHits = aFirst ? hitsA : hitsB;
+            List<SearchHit> secondHits = aFirst ? hitsB : hitsA;
+            Set<String> firstTeam = aFirst ? teamA : teamB;
+            Set<String> secondTeam = aFirst ? teamB : teamA;
+            int firstPtr = aFirst ? ptrA : ptrB;
+            int secondPtr = aFirst ? ptrB : ptrA;
+
+            while (firstPtr < firstHits.size() && seen.contains(firstHits.get(firstPtr).getId())) {
+                firstPtr++;
+            }
+            if (firstPtr < firstHits.size()) {
+                SearchHit pick = firstHits.get(firstPtr);
+                interleaved.add(pick);
+                firstTeam.add(pick.getId());
+                seen.add(pick.getId());
+                firstPtr++;
+            }
+            if (interleaved.size() >= size) {
+                if (aFirst) {
+                    ptrA = firstPtr;
+                    ptrB = secondPtr;
+                } else {
+                    ptrB = firstPtr;
+                    ptrA = secondPtr;
+                }
+                break;
+            }
+
+            while (secondPtr < secondHits.size() && seen.contains(secondHits.get(secondPtr).getId())) {
+                secondPtr++;
+            }
+            if (secondPtr < secondHits.size()) {
+                SearchHit pick = secondHits.get(secondPtr);
+                interleaved.add(pick);
+                secondTeam.add(pick.getId());
+                seen.add(pick.getId());
+                secondPtr++;
+            }
+            if (aFirst) {
+                ptrA = firstPtr;
+                ptrB = secondPtr;
+            } else {
+                ptrB = firstPtr;
+                ptrA = secondPtr;
+            }
+            if (ptrA >= hitsA.size() && ptrB >= hitsB.size()) {
+                break;
+            }
+        }
+        return new Result(interleaved, teamA, teamB);
+    }
+
+    public static class Result {
+        private final List<SearchHit> interleavedHits;
+        private final Set<String> teamA;
+        private final Set<String> teamB;
+
+        public Result(List<SearchHit> interleavedHits, Set<String> teamA, Set<String> teamB) {
+            this.interleavedHits = java.util.Collections.unmodifiableList(interleavedHits);
+            this.teamA = java.util.Collections.unmodifiableSet(teamA);
+            this.teamB = java.util.Collections.unmodifiableSet(teamB);
+        }
+
+        public List<SearchHit> getInterleavedHits() {
+            return interleavedHits;
+        }
+
+        public Set<String> getTeamA() {
+            return teamA;
+        }
+
+        public Set<String> getTeamB() {
+            return teamB;
+        }
+    }
+}

--- a/src/main/java/org/opensearch/searchrelevance/common/PluginConstants.java
+++ b/src/main/java/org/opensearch/searchrelevance/common/PluginConstants.java
@@ -109,6 +109,7 @@ public class PluginConstants {
      */
     public static final String AB_TESTS_URL = SEARCH_RELEVANCE_BASE_URI + "/ab_tests";
     public static final String AB_TEST_UPDATE_URL = AB_TESTS_URL + "/{id}/_update";
+    public static final String AB_TEST_SEARCH_URL = AB_TESTS_URL + "/{id}/_search";
     public static final String AB_TEST_INDEX = ".plugins-search-relevance-ab-test";
     public static final String AB_TEST_INDEX_MAPPING = "mappings/ab_test.json";
 

--- a/src/main/java/org/opensearch/searchrelevance/plugin/SearchRelevancePlugin.java
+++ b/src/main/java/org/opensearch/searchrelevance/plugin/SearchRelevancePlugin.java
@@ -75,6 +75,7 @@ import org.opensearch.searchrelevance.metrics.MetricsHelper;
 import org.opensearch.searchrelevance.ml.MLAccessor;
 import org.opensearch.searchrelevance.model.ScheduledJob;
 import org.opensearch.searchrelevance.model.builder.SearchRequestBuilder;
+import org.opensearch.searchrelevance.rest.RestABTestSearchAction;
 import org.opensearch.searchrelevance.rest.RestCreateQuerySetAction;
 import org.opensearch.searchrelevance.rest.RestDeleteABTestAction;
 import org.opensearch.searchrelevance.rest.RestDeleteExperimentAction;
@@ -107,6 +108,8 @@ import org.opensearch.searchrelevance.scheduler.SearchRelevanceJobRunner;
 import org.opensearch.searchrelevance.settings.SearchRelevanceSettingsAccessor;
 import org.opensearch.searchrelevance.stats.events.EventStatsManager;
 import org.opensearch.searchrelevance.stats.info.InfoStatsManager;
+import org.opensearch.searchrelevance.transport.abTest.ABTestSearchAction;
+import org.opensearch.searchrelevance.transport.abTest.ABTestSearchTransportAction;
 import org.opensearch.searchrelevance.transport.abTest.DeleteABTestAction;
 import org.opensearch.searchrelevance.transport.abTest.DeleteABTestTransportAction;
 import org.opensearch.searchrelevance.transport.abTest.PutABTestAction;
@@ -330,7 +333,8 @@ public class SearchRelevancePlugin extends Plugin
             new RestGetScheduledExperimentAction(settingsAccessor),
             new RestPutABTestAction(settingsAccessor),
             new RestUpdateABTestAction(settingsAccessor),
-            new RestDeleteABTestAction(settingsAccessor)
+            new RestDeleteABTestAction(settingsAccessor),
+            new RestABTestSearchAction(settingsAccessor)
         );
     }
 
@@ -362,7 +366,8 @@ public class SearchRelevancePlugin extends Plugin
             new ActionHandler<>(GetScheduledExperimentAction.INSTANCE, GetScheduledExperimentTransportAction.class),
             new ActionHandler<>(PutABTestAction.INSTANCE, PutABTestTransportAction.class),
             new ActionHandler<>(UpdateABTestAction.INSTANCE, UpdateABTestTransportAction.class),
-            new ActionHandler<>(DeleteABTestAction.INSTANCE, DeleteABTestTransportAction.class)
+            new ActionHandler<>(DeleteABTestAction.INSTANCE, DeleteABTestTransportAction.class),
+            new ActionHandler<>(ABTestSearchAction.INSTANCE, ABTestSearchTransportAction.class)
         );
     }
 

--- a/src/main/java/org/opensearch/searchrelevance/plugin/SearchRelevancePlugin.java
+++ b/src/main/java/org/opensearch/searchrelevance/plugin/SearchRelevancePlugin.java
@@ -55,6 +55,7 @@ import org.opensearch.repositories.RepositoriesService;
 import org.opensearch.rest.RestController;
 import org.opensearch.rest.RestHandler;
 import org.opensearch.script.ScriptService;
+import org.opensearch.searchrelevance.algorithm.TeamDraftInterleaver;
 import org.opensearch.searchrelevance.dao.ABTestDao;
 import org.opensearch.searchrelevance.dao.EvaluationResultDao;
 import org.opensearch.searchrelevance.dao.ExperimentDao;
@@ -276,6 +277,8 @@ public class SearchRelevancePlugin extends Plugin
         jobRunner.setSettingsAccessor(settingsAccessor);
         jobRunner.setManager(manager);
 
+        TeamDraftInterleaver teamDraftInterleaver = new TeamDraftInterleaver();
+
         return List.of(
             searchRelevanceIndicesManager,
             querySetDao,
@@ -294,7 +297,7 @@ public class SearchRelevancePlugin extends Plugin
             experimentTaskManager,
             jobRunner,
             experimentRunningManager,
-            new org.opensearch.searchrelevance.algorithm.TeamDraftInterleaver()
+            teamDraftInterleaver
         );
     }
 

--- a/src/main/java/org/opensearch/searchrelevance/plugin/SearchRelevancePlugin.java
+++ b/src/main/java/org/opensearch/searchrelevance/plugin/SearchRelevancePlugin.java
@@ -293,7 +293,8 @@ public class SearchRelevancePlugin extends Plugin
             infoStatsManager,
             experimentTaskManager,
             jobRunner,
-            experimentRunningManager
+            experimentRunningManager,
+            new org.opensearch.searchrelevance.algorithm.TeamDraftInterleaver()
         );
     }
 

--- a/src/main/java/org/opensearch/searchrelevance/rest/RestABTestSearchAction.java
+++ b/src/main/java/org/opensearch/searchrelevance/rest/RestABTestSearchAction.java
@@ -1,0 +1,91 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+package org.opensearch.searchrelevance.rest;
+
+import static java.util.Collections.singletonList;
+import static org.opensearch.rest.RestRequest.Method.POST;
+import static org.opensearch.searchrelevance.common.PluginConstants.AB_TEST_SEARCH_URL;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.opensearch.ExceptionsHelper;
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.core.rest.RestStatus;
+import org.opensearch.rest.BaseRestHandler;
+import org.opensearch.rest.BytesRestResponse;
+import org.opensearch.rest.RestRequest;
+import org.opensearch.searchrelevance.settings.SearchRelevanceSettingsAccessor;
+import org.opensearch.searchrelevance.transport.abTest.ABTestSearchAction;
+import org.opensearch.searchrelevance.transport.abTest.ABTestSearchRequest;
+import org.opensearch.searchrelevance.transport.abTest.ABTestSearchResponse;
+import org.opensearch.transport.client.node.NodeClient;
+
+import lombok.AllArgsConstructor;
+
+@AllArgsConstructor
+public class RestABTestSearchAction extends BaseRestHandler {
+    private static final Logger LOGGER = LogManager.getLogger(RestABTestSearchAction.class);
+    private static final String AB_TEST_SEARCH_ACTION = "ab_test_search_action";
+    private SearchRelevanceSettingsAccessor settingsAccessor;
+
+    @Override
+    public String getName() {
+        return AB_TEST_SEARCH_ACTION;
+    }
+
+    @Override
+    public List<Route> routes() {
+        return singletonList(new Route(POST, AB_TEST_SEARCH_URL));
+    }
+
+    @Override
+    protected RestChannelConsumer prepareRequest(RestRequest request, NodeClient client) throws IOException {
+        if (!settingsAccessor.isWorkbenchEnabled()) {
+            return channel -> channel.sendResponse(new BytesRestResponse(RestStatus.FORBIDDEN, "Search Relevance Workbench is disabled"));
+        }
+        String testId = request.param("id");
+        if (testId == null || testId.isEmpty()) {
+            return channel -> channel.sendResponse(new BytesRestResponse(RestStatus.BAD_REQUEST, "test id is required"));
+        }
+        Map<String, Object> source = request.contentParser().map();
+        @SuppressWarnings("unchecked")
+        Map<String, Object> rawParams = (Map<String, Object>) source.get("query_params");
+        if (rawParams == null || rawParams.isEmpty()) {
+            return channel -> channel.sendResponse(new BytesRestResponse(RestStatus.BAD_REQUEST, "query_params map is required"));
+        }
+        Map<String, String> params = new HashMap<>();
+        for (Map.Entry<String, Object> entry : rawParams.entrySet()) {
+            params.put(entry.getKey(), String.valueOf(entry.getValue()));
+        }
+        ABTestSearchRequest searchRequest = new ABTestSearchRequest(testId, params);
+        return channel -> client.execute(ABTestSearchAction.INSTANCE, searchRequest, new ActionListener<ABTestSearchResponse>() {
+            @Override
+            public void onResponse(ABTestSearchResponse response) {
+                try {
+                    channel.sendResponse(new BytesRestResponse(RestStatus.OK, response.toXContent(channel.newBuilder(), null)));
+                } catch (IOException e) {
+                    onFailure(e);
+                }
+            }
+
+            @Override
+            public void onFailure(Exception e) {
+                try {
+                    channel.sendResponse(new BytesRestResponse(channel, ExceptionsHelper.status(e), e));
+                } catch (IOException ex) {
+                    LOGGER.error("Failed to send error response", ex);
+                }
+            }
+        });
+    }
+}

--- a/src/main/java/org/opensearch/searchrelevance/rest/RestABTestSearchAction.java
+++ b/src/main/java/org/opensearch/searchrelevance/rest/RestABTestSearchAction.java
@@ -32,6 +32,13 @@ import org.opensearch.transport.client.node.NodeClient;
 
 import lombok.AllArgsConstructor;
 
+/**
+ * REST handler for AB test search with Team Draft Interleaving.
+ * Executes both search configurations in parallel, interleaves results using TDI,
+ * and returns a merged result list with team attribution per hit.
+ *
+ * Endpoint: POST /_plugins/_search_relevance/ab_tests/{id}/_search
+ */
 @AllArgsConstructor
 public class RestABTestSearchAction extends BaseRestHandler {
     private static final Logger LOGGER = LogManager.getLogger(RestABTestSearchAction.class);
@@ -53,20 +60,24 @@ public class RestABTestSearchAction extends BaseRestHandler {
         if (!settingsAccessor.isWorkbenchEnabled()) {
             return channel -> channel.sendResponse(new BytesRestResponse(RestStatus.FORBIDDEN, "Search Relevance Workbench is disabled"));
         }
+
         String testId = request.param("id");
-        if (testId == null || testId.isEmpty()) {
-            return channel -> channel.sendResponse(new BytesRestResponse(RestStatus.BAD_REQUEST, "test id is required"));
-        }
         Map<String, Object> source = request.contentParser().map();
         @SuppressWarnings("unchecked")
+        // TODO: Currently only SearchText is supported for substitution. Future iterations will
+        // support additional query_params (e.g., filters, boost values, pagination parameters).
         Map<String, Object> rawParams = (Map<String, Object>) source.get("query_params");
-        if (rawParams == null || rawParams.isEmpty()) {
-            return channel -> channel.sendResponse(new BytesRestResponse(RestStatus.BAD_REQUEST, "query_params map is required"));
+
+        String validationError = validateInput(testId, rawParams);
+        if (validationError != null) {
+            return channel -> channel.sendResponse(new BytesRestResponse(RestStatus.BAD_REQUEST, validationError));
         }
+
         Map<String, String> params = new HashMap<>();
         for (Map.Entry<String, Object> entry : rawParams.entrySet()) {
             params.put(entry.getKey(), String.valueOf(entry.getValue()));
         }
+
         ABTestSearchRequest searchRequest = new ABTestSearchRequest(testId, params);
         return channel -> client.execute(ABTestSearchAction.INSTANCE, searchRequest, new ActionListener<ABTestSearchResponse>() {
             @Override
@@ -87,5 +98,28 @@ public class RestABTestSearchAction extends BaseRestHandler {
                 }
             }
         });
+    }
+
+    /**
+     * Validates test id and query_params values.
+     * Returns an error message if validation fails, or null if all inputs are valid.
+     */
+    private String validateInput(String testId, Map<String, Object> rawParams) {
+        if (testId == null || testId.isEmpty()) {
+            return "test id is required";
+        }
+        if (rawParams == null || rawParams.isEmpty()) {
+            return "query_params map is required";
+        }
+        for (Map.Entry<String, Object> entry : rawParams.entrySet()) {
+            String value = String.valueOf(entry.getValue());
+            if (value.length() > 1024) {
+                return "query_params value exceeds maximum length of 1024 characters";
+            }
+            if (value.chars().anyMatch(c -> c < 0x20 && c != '\t' && c != '\n' && c != '\r')) {
+                return "query_params value contains invalid control characters";
+            }
+        }
+        return null;
     }
 }

--- a/src/main/java/org/opensearch/searchrelevance/transport/abTest/ABTestSearchAction.java
+++ b/src/main/java/org/opensearch/searchrelevance/transport/abTest/ABTestSearchAction.java
@@ -1,0 +1,21 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+package org.opensearch.searchrelevance.transport.abTest;
+
+import static org.opensearch.searchrelevance.common.PluginConstants.TRANSPORT_ACTION_NAME_PREFIX;
+
+import org.opensearch.action.ActionType;
+
+public class ABTestSearchAction extends ActionType<ABTestSearchResponse> {
+    public static final String NAME = TRANSPORT_ACTION_NAME_PREFIX + "ab_test/search";
+    public static final ABTestSearchAction INSTANCE = new ABTestSearchAction();
+
+    private ABTestSearchAction() {
+        super(NAME, ABTestSearchResponse::new);
+    }
+}

--- a/src/main/java/org/opensearch/searchrelevance/transport/abTest/ABTestSearchRequest.java
+++ b/src/main/java/org/opensearch/searchrelevance/transport/abTest/ABTestSearchRequest.java
@@ -1,0 +1,47 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+package org.opensearch.searchrelevance.transport.abTest;
+
+import java.io.IOException;
+import java.util.Map;
+
+import org.opensearch.action.ActionRequest;
+import org.opensearch.action.ActionRequestValidationException;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.common.io.stream.StreamOutput;
+
+import lombok.Getter;
+
+@Getter
+public class ABTestSearchRequest extends ActionRequest {
+    private final String testId;
+    private final Map<String, String> params;
+
+    public ABTestSearchRequest(String testId, Map<String, String> params) {
+        this.testId = testId;
+        this.params = params;
+    }
+
+    public ABTestSearchRequest(StreamInput in) throws IOException {
+        super(in);
+        this.testId = in.readString();
+        this.params = in.readMap(StreamInput::readString, StreamInput::readString);
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        super.writeTo(out);
+        out.writeString(testId);
+        out.writeMap(params, StreamOutput::writeString, StreamOutput::writeString);
+    }
+
+    @Override
+    public ActionRequestValidationException validate() {
+        return null;
+    }
+}

--- a/src/main/java/org/opensearch/searchrelevance/transport/abTest/ABTestSearchResponse.java
+++ b/src/main/java/org/opensearch/searchrelevance/transport/abTest/ABTestSearchResponse.java
@@ -1,0 +1,70 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+package org.opensearch.searchrelevance.transport.abTest;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import org.opensearch.core.action.ActionResponse;
+import org.opensearch.core.common.io.stream.StreamInput;
+import org.opensearch.core.common.io.stream.StreamOutput;
+import org.opensearch.core.xcontent.ToXContentObject;
+import org.opensearch.core.xcontent.XContentBuilder;
+
+import lombok.Getter;
+
+@Getter
+public class ABTestSearchResponse extends ActionResponse implements ToXContentObject {
+    private final String testId;
+    private final boolean interleaved;
+    private final List<Map<String, Object>> hits;
+
+    public ABTestSearchResponse(String testId, boolean interleaved, List<Map<String, Object>> hits) {
+        this.testId = testId;
+        this.interleaved = interleaved;
+        this.hits = hits;
+    }
+
+    @SuppressWarnings("unchecked")
+    public ABTestSearchResponse(StreamInput in) throws IOException {
+        super(in);
+        this.testId = in.readString();
+        this.interleaved = in.readBoolean();
+        int size = in.readVInt();
+        this.hits = new ArrayList<>(size);
+        for (int i = 0; i < size; i++) {
+            this.hits.add(in.readMap());
+        }
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeString(testId);
+        out.writeBoolean(interleaved);
+        out.writeVInt(hits.size());
+        for (Map<String, Object> hit : hits) {
+            out.writeMap(hit);
+        }
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.startObject();
+        builder.field("test_id", testId);
+        builder.field("interleaved", interleaved);
+        builder.startArray("hits");
+        for (Map<String, Object> hit : hits) {
+            builder.map(hit);
+        }
+        builder.endArray();
+        builder.endObject();
+        return builder;
+    }
+}

--- a/src/main/java/org/opensearch/searchrelevance/transport/abTest/ABTestSearchResponse.java
+++ b/src/main/java/org/opensearch/searchrelevance/transport/abTest/ABTestSearchResponse.java
@@ -20,15 +20,17 @@ import org.opensearch.core.xcontent.XContentBuilder;
 
 import lombok.Getter;
 
+/**
+ * Response for AB test search containing test_id and interleaved hits
+ * with _search_configuration_id per hit for click attribution.
+ */
 @Getter
 public class ABTestSearchResponse extends ActionResponse implements ToXContentObject {
     private final String testId;
-    private final boolean interleaved;
     private final List<Map<String, Object>> hits;
 
-    public ABTestSearchResponse(String testId, boolean interleaved, List<Map<String, Object>> hits) {
+    public ABTestSearchResponse(String testId, List<Map<String, Object>> hits) {
         this.testId = testId;
-        this.interleaved = interleaved;
         this.hits = hits;
     }
 
@@ -36,7 +38,6 @@ public class ABTestSearchResponse extends ActionResponse implements ToXContentOb
     public ABTestSearchResponse(StreamInput in) throws IOException {
         super(in);
         this.testId = in.readString();
-        this.interleaved = in.readBoolean();
         int size = in.readVInt();
         this.hits = new ArrayList<>(size);
         for (int i = 0; i < size; i++) {
@@ -47,7 +48,6 @@ public class ABTestSearchResponse extends ActionResponse implements ToXContentOb
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         out.writeString(testId);
-        out.writeBoolean(interleaved);
         out.writeVInt(hits.size());
         for (Map<String, Object> hit : hits) {
             out.writeMap(hit);
@@ -58,7 +58,6 @@ public class ABTestSearchResponse extends ActionResponse implements ToXContentOb
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         builder.startObject();
         builder.field("test_id", testId);
-        builder.field("interleaved", interleaved);
         builder.startArray("hits");
         for (Map<String, Object> hit : hits) {
             builder.map(hit);

--- a/src/main/java/org/opensearch/searchrelevance/transport/abTest/ABTestSearchTransportAction.java
+++ b/src/main/java/org/opensearch/searchrelevance/transport/abTest/ABTestSearchTransportAction.java
@@ -33,7 +33,6 @@ import org.opensearch.searchrelevance.dao.SearchConfigurationDao;
 import org.opensearch.searchrelevance.exception.SearchRelevanceException;
 import org.opensearch.searchrelevance.model.ABTest;
 import org.opensearch.searchrelevance.model.builder.SearchRequestBuilder;
-import org.opensearch.searchrelevance.shared.StashedThreadContext;
 import org.opensearch.tasks.Task;
 import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.transport.TransportService;
@@ -206,6 +205,14 @@ public class ABTestSearchTransportAction extends HandledTransportAction<ABTestSe
             return;
         }
         Map<String, Object> configBSource = configBResponse.getHits().getHits()[0].getSourceAsMap();
+        String targetIndexB = (String) configBSource.get("index");
+        if (targetIndexB == null || !targetIndexB.equals(targetIndex)) {
+            listener.onFailure(new SearchRelevanceException(
+                "Both search configurations must target the same index. Config A targets [" + targetIndex + "], Config B targets [" + targetIndexB + "]",
+                RestStatus.BAD_REQUEST
+            ));
+            return;
+        }
         String queryB = (String) configBSource.get("query");
         String pipelineB = (String) configBSource.get("searchPipeline");
         int sizeB = configBSource.containsKey("size") ? ((Number) configBSource.get("size")).intValue() : DEFAULT_SEARCH_SIZE;
@@ -251,23 +258,24 @@ public class ABTestSearchTransportAction extends HandledTransportAction<ABTestSe
             }
         };
 
-        StashedThreadContext.run(client, () -> client.search(searchRequestA, ActionListener.wrap(r -> {
+        // Execute searches with caller's security context (no stashing) to preserve FGAC
+        client.search(searchRequestA, ActionListener.wrap(r -> {
             responseA.set(r);
             maybeInterleave.run();
         }, e -> {
             if (failed.compareAndSet(false, true)) {
                 listener.onFailure(new SearchRelevanceException("Search execution failed", e, RestStatus.INTERNAL_SERVER_ERROR));
             }
-        })));
+        }));
 
-        StashedThreadContext.run(client, () -> client.search(searchRequestB, ActionListener.wrap(r -> {
+        client.search(searchRequestB, ActionListener.wrap(r -> {
             responseB.set(r);
             maybeInterleave.run();
         }, e -> {
             if (failed.compareAndSet(false, true)) {
                 listener.onFailure(new SearchRelevanceException("Search execution failed", e, RestStatus.INTERNAL_SERVER_ERROR));
             }
-        })));
+        }));
     }
 
     /**
@@ -280,7 +288,8 @@ public class ABTestSearchTransportAction extends HandledTransportAction<ABTestSe
         String configUuid,
         ActionListener<ABTestSearchResponse> listener
     ) {
-        StashedThreadContext.run(client, () -> client.search(searchRequest, ActionListener.wrap(
+        // Execute search with caller's security context (no stashing) to preserve FGAC
+        client.search(searchRequest, ActionListener.wrap(
             searchResponse -> {
                 List<Map<String, Object>> responseHits = new ArrayList<>();
                 for (SearchHit hit : searchResponse.getHits().getHits()) {
@@ -289,7 +298,7 @@ public class ABTestSearchTransportAction extends HandledTransportAction<ABTestSe
                 listener.onResponse(new ABTestSearchResponse(testId, false, responseHits));
             },
             e -> listener.onFailure(new SearchRelevanceException("Search execution failed", e, RestStatus.INTERNAL_SERVER_ERROR))
-        )));
+        ));
     }
 
     /**

--- a/src/main/java/org/opensearch/searchrelevance/transport/abTest/ABTestSearchTransportAction.java
+++ b/src/main/java/org/opensearch/searchrelevance/transport/abTest/ABTestSearchTransportAction.java
@@ -1,0 +1,408 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+package org.opensearch.searchrelevance.transport.abTest;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.opensearch.action.search.SearchRequest;
+import org.opensearch.action.search.SearchResponse;
+import org.opensearch.action.support.ActionFilters;
+import org.opensearch.action.support.HandledTransportAction;
+import org.opensearch.common.inject.Inject;
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.core.rest.RestStatus;
+import org.opensearch.search.SearchHit;
+import org.opensearch.search.builder.SearchSourceBuilder;
+import org.opensearch.searchrelevance.algorithm.TeamDraftInterleaver;
+import org.opensearch.searchrelevance.dao.ABTestDao;
+import org.opensearch.searchrelevance.dao.SearchConfigurationDao;
+import org.opensearch.searchrelevance.exception.SearchRelevanceException;
+import org.opensearch.searchrelevance.model.ABTest;
+import org.opensearch.searchrelevance.shared.StashedThreadContext;
+import org.opensearch.tasks.Task;
+import org.opensearch.threadpool.ThreadPool;
+import org.opensearch.transport.TransportService;
+import org.opensearch.transport.client.Client;
+
+public class ABTestSearchTransportAction extends HandledTransportAction<ABTestSearchRequest, ABTestSearchResponse> {
+    private static final Logger LOGGER = LogManager.getLogger(ABTestSearchTransportAction.class);
+    private static final int SEARCH_TIMEOUT_SECONDS = 30;
+    private static final String SEARCH_TEXT_PLACEHOLDER = "%SearchText%";
+
+    private final ABTestDao abTestDao;
+    private final SearchConfigurationDao searchConfigurationDao;
+    private final Client client;
+    private final ThreadPool threadPool;
+    private final TeamDraftInterleaver interleaver;
+
+    @Inject
+    public ABTestSearchTransportAction(
+        TransportService transportService,
+        ActionFilters actionFilters,
+        ABTestDao abTestDao,
+        SearchConfigurationDao searchConfigurationDao,
+        Client client,
+        ThreadPool threadPool
+    ) {
+        super(ABTestSearchAction.NAME, transportService, actionFilters, ABTestSearchRequest::new);
+        this.abTestDao = abTestDao;
+        this.searchConfigurationDao = searchConfigurationDao;
+        this.client = client;
+        this.threadPool = threadPool;
+        this.interleaver = new TeamDraftInterleaver();
+    }
+
+    @Override
+    protected void doExecute(Task task, ABTestSearchRequest request, ActionListener<ABTestSearchResponse> listener) {
+        if (request == null || request.getTestId() == null || request.getParams() == null || request.getParams().isEmpty()) {
+            listener.onFailure(new SearchRelevanceException("Request, testId, and params cannot be null", RestStatus.BAD_REQUEST));
+            return;
+        }
+        abTestDao.getABTest(
+            request.getTestId(),
+            ActionListener.wrap(abTestResponse -> handleABTestResponse(abTestResponse, request, listener), e -> {
+                if (e instanceof org.opensearch.ResourceNotFoundException) {
+                    listener.onFailure(new SearchRelevanceException("AB test not found", RestStatus.NOT_FOUND));
+                } else {
+                    listener.onFailure(new SearchRelevanceException("Failed to read AB test", e, RestStatus.INTERNAL_SERVER_ERROR));
+                }
+            })
+        );
+    }
+
+    private void handleABTestResponse(
+        SearchResponse abTestResponse,
+        ABTestSearchRequest request,
+        ActionListener<ABTestSearchResponse> listener
+    ) {
+        try {
+            if (abTestResponse.getHits().getHits().length == 0) {
+                listener.onFailure(new SearchRelevanceException("AB test not found", RestStatus.NOT_FOUND));
+                return;
+            }
+            Map<String, Object> source = abTestResponse.getHits().getHits()[0].getSourceAsMap();
+            boolean enabled = (Boolean) source.get(ABTest.ENABLED);
+            String configAId = (String) source.get(ABTest.SEARCH_CONFIGURATION_A);
+            String configBId = (String) source.get(ABTest.SEARCH_CONFIGURATION_B);
+            String configAUuid = (String) source.get(ABTest.CONFIG_A_UUID);
+            String configBUuid = (String) source.get(ABTest.CONFIG_B_UUID);
+            String testId = (String) source.get(ABTest.TEST_ID);
+
+            searchConfigurationDao.getSearchConfiguration(
+                configAId,
+                ActionListener.wrap(
+                    configAResponse -> handleConfigAResponse(
+                        configAResponse,
+                        configBId,
+                        enabled,
+                        testId,
+                        configAUuid,
+                        configBUuid,
+                        request,
+                        listener
+                    ),
+                    e -> {
+                        if (e instanceof org.opensearch.ResourceNotFoundException) {
+                            listener.onFailure(new SearchRelevanceException("Search configuration A not found", RestStatus.NOT_FOUND));
+                        } else {
+                            listener.onFailure(
+                                new SearchRelevanceException("Failed to read config A", e, RestStatus.INTERNAL_SERVER_ERROR)
+                            );
+                        }
+                    }
+                )
+            );
+        } catch (Exception e) {
+            listener.onFailure(new SearchRelevanceException("ABTestSearch failed", e, RestStatus.INTERNAL_SERVER_ERROR));
+        }
+    }
+
+    private void handleConfigAResponse(
+        SearchResponse configAResponse,
+        String configBId,
+        boolean enabled,
+        String testId,
+        String configAUuid,
+        String configBUuid,
+        ABTestSearchRequest request,
+        ActionListener<ABTestSearchResponse> listener
+    ) {
+        if (configAResponse.getHits().getHits().length == 0) {
+            listener.onFailure(new SearchRelevanceException("Search configuration A not found", RestStatus.NOT_FOUND));
+            return;
+        }
+        Map<String, Object> configASource = configAResponse.getHits().getHits()[0].getSourceAsMap();
+        String queryA;
+        try {
+            queryA = substituteParams((String) configASource.get("query"), request.getParams());
+        } catch (SearchRelevanceException e) {
+            listener.onFailure(e);
+            return;
+        }
+        String pipelineA = (String) configASource.get("searchPipeline");
+        String targetIndex = (String) configASource.get("index");
+
+        if (!enabled) {
+            threadPool.generic().execute(() -> {
+                try {
+                    executeSingleSearch(targetIndex, queryA, pipelineA, testId, configAUuid, listener);
+                } catch (Exception e) {
+                    listener.onFailure(new SearchRelevanceException("ABTestSearch failed", e, RestStatus.INTERNAL_SERVER_ERROR));
+                }
+            });
+            return;
+        }
+
+        searchConfigurationDao.getSearchConfiguration(
+            configBId,
+            ActionListener.wrap(
+                configBResponse -> handleConfigBResponse(
+                    configBResponse,
+                    targetIndex,
+                    queryA,
+                    pipelineA,
+                    testId,
+                    configAUuid,
+                    configBUuid,
+                    request,
+                    listener
+                ),
+                e -> {
+                    if (e instanceof org.opensearch.ResourceNotFoundException) {
+                        listener.onFailure(new SearchRelevanceException("Search configuration B not found", RestStatus.NOT_FOUND));
+                    } else {
+                        listener.onFailure(new SearchRelevanceException("Failed to read config B", e, RestStatus.INTERNAL_SERVER_ERROR));
+                    }
+                }
+            )
+        );
+    }
+
+    private void handleConfigBResponse(
+        SearchResponse configBResponse,
+        String targetIndex,
+        String queryA,
+        String pipelineA,
+        String testId,
+        String configAUuid,
+        String configBUuid,
+        ABTestSearchRequest request,
+        ActionListener<ABTestSearchResponse> listener
+    ) {
+        if (configBResponse.getHits().getHits().length == 0) {
+            listener.onFailure(new SearchRelevanceException("Search configuration B not found", RestStatus.NOT_FOUND));
+            return;
+        }
+        Map<String, Object> configBSource = configBResponse.getHits().getHits()[0].getSourceAsMap();
+        String queryB;
+        try {
+            queryB = substituteParams((String) configBSource.get("query"), request.getParams());
+        } catch (SearchRelevanceException e) {
+            listener.onFailure(e);
+            return;
+        }
+        String pipelineB = (String) configBSource.get("searchPipeline");
+
+        threadPool.generic().execute(() -> {
+            try {
+                executeParallelSearches(targetIndex, queryA, pipelineA, queryB, pipelineB, testId, configAUuid, configBUuid, listener);
+            } catch (Exception e) {
+                listener.onFailure(new SearchRelevanceException("ABTestSearch failed", e, RestStatus.INTERNAL_SERVER_ERROR));
+            }
+        });
+    }
+
+    private void executeParallelSearches(
+        String targetIndex,
+        String queryA,
+        String pipelineA,
+        String queryB,
+        String pipelineB,
+        String testId,
+        String configAUuid,
+        String configBUuid,
+        ActionListener<ABTestSearchResponse> listener
+    ) {
+        SearchRequest searchRequestA = buildSearchRequest(targetIndex, queryA, pipelineA);
+        SearchRequest searchRequestB = buildSearchRequest(targetIndex, queryB, pipelineB);
+        CountDownLatch latch = new CountDownLatch(2);
+        AtomicReference<SearchResponse> responseA = new AtomicReference<>();
+        AtomicReference<SearchResponse> responseB = new AtomicReference<>();
+        AtomicReference<Exception> error = new AtomicReference<>();
+
+        StashedThreadContext.run(client, () -> client.search(searchRequestA, new ActionListener<SearchResponse>() {
+            @Override
+            public void onResponse(SearchResponse r) {
+                responseA.set(r);
+                latch.countDown();
+            }
+
+            @Override
+            public void onFailure(Exception e) {
+                error.compareAndSet(null, e);
+                latch.countDown();
+            }
+        }));
+        StashedThreadContext.run(client, () -> client.search(searchRequestB, new ActionListener<SearchResponse>() {
+            @Override
+            public void onResponse(SearchResponse r) {
+                responseB.set(r);
+                latch.countDown();
+            }
+
+            @Override
+            public void onFailure(Exception e) {
+                error.compareAndSet(null, e);
+                latch.countDown();
+            }
+        }));
+
+        try {
+            if (!latch.await(SEARCH_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
+                listener.onFailure(new SearchRelevanceException("Search timeout", RestStatus.GATEWAY_TIMEOUT));
+                return;
+            }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            listener.onFailure(new SearchRelevanceException("Search interrupted", e, RestStatus.INTERNAL_SERVER_ERROR));
+            return;
+        }
+        if (error.get() != null) {
+            listener.onFailure(new SearchRelevanceException("Search execution failed", error.get(), RestStatus.INTERNAL_SERVER_ERROR));
+            return;
+        }
+
+        List<SearchHit> hitsA = Arrays.asList(responseA.get().getHits().getHits());
+        List<SearchHit> hitsB = Arrays.asList(responseB.get().getHits().getHits());
+        TeamDraftInterleaver.Result tdiResult = interleaver.interleave(hitsA, hitsB, Math.max(hitsA.size(), hitsB.size()));
+
+        List<Map<String, Object>> responseHits = new ArrayList<>();
+        Set<String> teamADocs = tdiResult.getTeamA();
+        for (SearchHit hit : tdiResult.getInterleavedHits()) {
+            String uuid = teamADocs.contains(hit.getId()) ? configAUuid : configBUuid;
+            responseHits.add(mapHit(hit, uuid));
+        }
+        listener.onResponse(new ABTestSearchResponse(testId, true, responseHits));
+    }
+
+    private void executeSingleSearch(
+        String targetIndex,
+        String query,
+        String pipeline,
+        String testId,
+        String configUuid,
+        ActionListener<ABTestSearchResponse> listener
+    ) {
+        SearchRequest searchRequest = buildSearchRequest(targetIndex, query, pipeline);
+        CountDownLatch latch = new CountDownLatch(1);
+        AtomicReference<SearchResponse> responseRef = new AtomicReference<>();
+        AtomicReference<Exception> error = new AtomicReference<>();
+
+        StashedThreadContext.run(client, () -> client.search(searchRequest, new ActionListener<SearchResponse>() {
+            @Override
+            public void onResponse(SearchResponse r) {
+                responseRef.set(r);
+                latch.countDown();
+            }
+
+            @Override
+            public void onFailure(Exception e) {
+                error.set(e);
+                latch.countDown();
+            }
+        }));
+
+        try {
+            if (!latch.await(SEARCH_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
+                listener.onFailure(new SearchRelevanceException("Search timeout", RestStatus.GATEWAY_TIMEOUT));
+                return;
+            }
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            listener.onFailure(new SearchRelevanceException("Search interrupted", e, RestStatus.INTERNAL_SERVER_ERROR));
+            return;
+        }
+        if (error.get() != null) {
+            listener.onFailure(new SearchRelevanceException("Search execution failed", error.get(), RestStatus.INTERNAL_SERVER_ERROR));
+            return;
+        }
+
+        List<Map<String, Object>> responseHits = new ArrayList<>();
+        for (SearchHit hit : responseRef.get().getHits().getHits()) {
+            responseHits.add(mapHit(hit, configUuid));
+        }
+        listener.onResponse(new ABTestSearchResponse(testId, false, responseHits));
+    }
+
+    private Map<String, Object> mapHit(SearchHit hit, String configUuid) {
+        Map<String, Object> hitMap = new HashMap<>();
+        hitMap.put("_index", hit.getIndex());
+        hitMap.put("_id", hit.getId());
+        hitMap.put("_score", hit.getScore());
+        hitMap.put("_source", hit.getSourceAsMap());
+        hitMap.put("_search_configuration_id", configUuid);
+        return hitMap;
+    }
+
+    private SearchRequest buildSearchRequest(String targetIndex, String queryBody, String searchPipeline) {
+        SearchRequest searchRequest = new SearchRequest(targetIndex);
+        SearchSourceBuilder sourceBuilder = new SearchSourceBuilder();
+        try {
+            Map<String, Object> queryMap = org.opensearch.common.xcontent.XContentHelper.convertToMap(
+                org.opensearch.common.xcontent.XContentType.JSON.xContent(),
+                queryBody,
+                false
+            );
+            if (queryMap.containsKey("query")) {
+                @SuppressWarnings("unchecked")
+                Map<String, Object> querySection = (Map<String, Object>) queryMap.get("query");
+                org.opensearch.core.xcontent.XContentBuilder xBuilder = org.opensearch.common.xcontent.XContentFactory.jsonBuilder();
+                xBuilder.map(querySection);
+                sourceBuilder.query(new org.opensearch.index.query.WrapperQueryBuilder(xBuilder.toString()));
+            }
+            if (queryMap.containsKey("size")) {
+                sourceBuilder.size(((Number) queryMap.get("size")).intValue());
+            }
+            if (queryMap.containsKey("_source")) {
+                @SuppressWarnings("unchecked")
+                Map<String, Object> sourceSection = (Map<String, Object>) queryMap.get("_source");
+                if (sourceSection.containsKey("excludes")) {
+                    @SuppressWarnings("unchecked")
+                    List<String> excludes = (List<String>) sourceSection.get("excludes");
+                    sourceBuilder.fetchSource(null, excludes.toArray(new String[0]));
+                }
+            }
+        } catch (IOException e) {
+            throw new SearchRelevanceException("Failed to parse query body", e, RestStatus.BAD_REQUEST);
+        }
+        searchRequest.source(sourceBuilder);
+        if (searchPipeline != null && !searchPipeline.isEmpty()) {
+            searchRequest.pipeline(searchPipeline);
+        }
+        return searchRequest;
+    }
+
+    private String substituteParams(String template, Map<String, String> params) {
+        String searchText = params.get("SearchText");
+        if (searchText == null || searchText.isEmpty()) {
+            throw new SearchRelevanceException("SearchText is required in query_params", RestStatus.BAD_REQUEST);
+        }
+        return template.replace(SEARCH_TEXT_PLACEHOLDER, searchText);
+    }
+}

--- a/src/main/java/org/opensearch/searchrelevance/transport/abTest/ABTestSearchTransportAction.java
+++ b/src/main/java/org/opensearch/searchrelevance/transport/abTest/ABTestSearchTransportAction.java
@@ -17,6 +17,7 @@ import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -25,6 +26,7 @@ import org.opensearch.action.search.SearchResponse;
 import org.opensearch.action.support.ActionFilters;
 import org.opensearch.action.support.HandledTransportAction;
 import org.opensearch.common.inject.Inject;
+import org.opensearch.common.util.concurrent.ThreadContext;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.rest.RestStatus;
 import org.opensearch.search.SearchHit;
@@ -83,15 +85,22 @@ public class ABTestSearchTransportAction extends HandledTransportAction<ABTestSe
             listener.onFailure(new SearchRelevanceException("Request, testId, and params cannot be null", RestStatus.BAD_REQUEST));
             return;
         }
+        // Capture caller's security context before DAO calls stash it
+        final ThreadContext threadContext = client.threadPool().getThreadContext();
+        final Supplier<ThreadContext.StoredContext> restoreCallerContext = threadContext.newRestorableContext(false);
+
         abTestDao.getABTest(
             request.getTestId(),
-            ActionListener.wrap(abTestResponse -> extractTestMetadataAndFetchConfigs(abTestResponse, request, listener), e -> {
-                if (e instanceof org.opensearch.ResourceNotFoundException) {
-                    listener.onFailure(new SearchRelevanceException("AB test not found", RestStatus.NOT_FOUND));
-                } else {
-                    listener.onFailure(new SearchRelevanceException("Failed to read AB test", e, RestStatus.INTERNAL_SERVER_ERROR));
+            ActionListener.wrap(
+                abTestResponse -> extractTestMetadataAndFetchConfigs(abTestResponse, request, restoreCallerContext, listener),
+                e -> {
+                    if (e instanceof org.opensearch.ResourceNotFoundException) {
+                        listener.onFailure(new SearchRelevanceException("AB test not found", RestStatus.NOT_FOUND));
+                    } else {
+                        listener.onFailure(new SearchRelevanceException("Failed to read AB test", e, RestStatus.INTERNAL_SERVER_ERROR));
+                    }
                 }
-            })
+            )
         );
     }
 
@@ -102,6 +111,7 @@ public class ABTestSearchTransportAction extends HandledTransportAction<ABTestSe
     private void extractTestMetadataAndFetchConfigs(
         SearchResponse abTestResponse,
         ABTestSearchRequest request,
+        Supplier<ThreadContext.StoredContext> restoreCallerContext,
         ActionListener<ABTestSearchResponse> listener
     ) {
         try {
@@ -118,7 +128,9 @@ public class ABTestSearchTransportAction extends HandledTransportAction<ABTestSe
             String testId = (String) source.get(ABTest.TEST_ID);
 
             if (enabledObj == null || configAId == null || configAUuid == null || testId == null) {
-                listener.onFailure(new SearchRelevanceException("AB test document is missing required fields", RestStatus.INTERNAL_SERVER_ERROR));
+                listener.onFailure(
+                    new SearchRelevanceException("AB test document is missing required fields", RestStatus.INTERNAL_SERVER_ERROR)
+                );
                 return;
             }
             boolean enabled = enabledObj;
@@ -131,7 +143,17 @@ public class ABTestSearchTransportAction extends HandledTransportAction<ABTestSe
 
             Runnable maybeComplete = () -> {
                 if (remaining.decrementAndGet() == 0 && !failed.get()) {
-                    executeSearchWithConfigs(configARef.get(), configBRef.get(), enabled, testId, configAUuid, configBUuid, request, listener);
+                    executeSearchWithConfigs(
+                        configARef.get(),
+                        configBRef.get(),
+                        enabled,
+                        testId,
+                        configAUuid,
+                        configBUuid,
+                        request,
+                        restoreCallerContext,
+                        listener
+                    );
                 }
             };
 
@@ -175,6 +197,7 @@ public class ABTestSearchTransportAction extends HandledTransportAction<ABTestSe
         String configAUuid,
         String configBUuid,
         ABTestSearchRequest request,
+        Supplier<ThreadContext.StoredContext> restoreCallerContext,
         ActionListener<ABTestSearchResponse> listener
     ) {
         if (configAResponse.getHits().getHits().length == 0) {
@@ -196,7 +219,7 @@ public class ABTestSearchTransportAction extends HandledTransportAction<ABTestSe
         // If test is disabled, only execute config A
         if (!enabled) {
             SearchRequest searchRequestA = SearchRequestBuilder.buildSearchRequest(targetIndex, queryA, searchText, pipelineA, sizeA);
-            executeSingleSearch(searchRequestA, testId, configAUuid, listener);
+            executeSingleSearch(searchRequestA, testId, configAUuid, restoreCallerContext, listener);
             return;
         }
 
@@ -208,10 +231,17 @@ public class ABTestSearchTransportAction extends HandledTransportAction<ABTestSe
         Map<String, Object> configBSource = configBResponse.getHits().getHits()[0].getSourceAsMap();
         String targetIndexB = (String) configBSource.get("index");
         if (targetIndexB == null || !targetIndexB.equals(targetIndex)) {
-            listener.onFailure(new SearchRelevanceException(
-                String.format(Locale.ROOT, "Both search configurations must target the same index. Config A targets [%s], Config B targets [%s]", targetIndex, targetIndexB),
-                RestStatus.BAD_REQUEST
-            ));
+            listener.onFailure(
+                new SearchRelevanceException(
+                    String.format(
+                        Locale.ROOT,
+                        "Both search configurations must target the same index. Config A targets [%s], Config B targets [%s]",
+                        targetIndex,
+                        targetIndexB
+                    ),
+                    RestStatus.BAD_REQUEST
+                )
+            );
             return;
         }
         String queryB = (String) configBSource.get("query");
@@ -219,17 +249,32 @@ public class ABTestSearchTransportAction extends HandledTransportAction<ABTestSe
         int sizeB = configBSource.containsKey("size") ? ((Number) configBSource.get("size")).intValue() : DEFAULT_SEARCH_SIZE;
 
         if (sizeA != sizeB) {
-            listener.onFailure(new SearchRelevanceException(
-                String.format(Locale.ROOT, "Both search configurations must use the same size for fair comparison. Config A size [%d], Config B size [%d]", sizeA, sizeB),
-                RestStatus.BAD_REQUEST
-            ));
+            listener.onFailure(
+                new SearchRelevanceException(
+                    String.format(
+                        Locale.ROOT,
+                        "Both search configurations must use the same size for fair comparison. Config A size [%d], Config B size [%d]",
+                        sizeA,
+                        sizeB
+                    ),
+                    RestStatus.BAD_REQUEST
+                )
+            );
             return;
         }
 
         SearchRequest searchRequestA = SearchRequestBuilder.buildSearchRequest(targetIndex, queryA, searchText, pipelineA, sizeA);
         SearchRequest searchRequestB = SearchRequestBuilder.buildSearchRequest(targetIndex, queryB, searchText, pipelineB, sizeB);
 
-        executeParallelSearchesAndInterleave(searchRequestA, searchRequestB, testId, configAUuid, configBUuid, listener);
+        executeParallelSearchesAndInterleave(
+            searchRequestA,
+            searchRequestB,
+            testId,
+            configAUuid,
+            configBUuid,
+            restoreCallerContext,
+            listener
+        );
     }
 
     /**
@@ -242,6 +287,7 @@ public class ABTestSearchTransportAction extends HandledTransportAction<ABTestSe
         String testId,
         String configAUuid,
         String configBUuid,
+        Supplier<ThreadContext.StoredContext> restoreCallerContext,
         ActionListener<ABTestSearchResponse> listener
     ) {
         AtomicReference<SearchResponse> responseA = new AtomicReference<>();
@@ -267,24 +313,38 @@ public class ABTestSearchTransportAction extends HandledTransportAction<ABTestSe
             }
         };
 
-        // Execute searches with caller's security context (no stashing) to preserve FGAC
-        client.search(searchRequestA, ActionListener.wrap(r -> {
-            responseA.set(r);
-            maybeInterleave.run();
-        }, e -> {
-            if (failed.compareAndSet(false, true)) {
-                listener.onFailure(new SearchRelevanceException("Search execution failed", e, RestStatus.INTERNAL_SERVER_ERROR));
-            }
-        }));
+        // Restore caller's security context before searching target index
+        try (ThreadContext.StoredContext ctx = restoreCallerContext.get()) {
+            client.search(searchRequestA, ActionListener.wrap(r -> {
+                responseA.set(r);
+                maybeInterleave.run();
+            }, e -> {
+                if (failed.compareAndSet(false, true)) {
+                    listener.onFailure(
+                        new SearchRelevanceException(
+                            "Search execution failed",
+                            e,
+                            isSecurityException(e) ? RestStatus.FORBIDDEN : RestStatus.INTERNAL_SERVER_ERROR
+                        )
+                    );
+                }
+            }));
 
-        client.search(searchRequestB, ActionListener.wrap(r -> {
-            responseB.set(r);
-            maybeInterleave.run();
-        }, e -> {
-            if (failed.compareAndSet(false, true)) {
-                listener.onFailure(new SearchRelevanceException("Search execution failed", e, RestStatus.INTERNAL_SERVER_ERROR));
-            }
-        }));
+            client.search(searchRequestB, ActionListener.wrap(r -> {
+                responseB.set(r);
+                maybeInterleave.run();
+            }, e -> {
+                if (failed.compareAndSet(false, true)) {
+                    listener.onFailure(
+                        new SearchRelevanceException(
+                            "Search execution failed",
+                            e,
+                            isSecurityException(e) ? RestStatus.FORBIDDEN : RestStatus.INTERNAL_SERVER_ERROR
+                        )
+                    );
+                }
+            }));
+        }
     }
 
     /**
@@ -295,19 +355,27 @@ public class ABTestSearchTransportAction extends HandledTransportAction<ABTestSe
         SearchRequest searchRequest,
         String testId,
         String configUuid,
+        Supplier<ThreadContext.StoredContext> restoreCallerContext,
         ActionListener<ABTestSearchResponse> listener
     ) {
-        // Execute search with caller's security context (no stashing) to preserve FGAC
-        client.search(searchRequest, ActionListener.wrap(
-            searchResponse -> {
+        // Restore caller's security context before searching target index
+        try (ThreadContext.StoredContext ctx = restoreCallerContext.get()) {
+            client.search(searchRequest, ActionListener.wrap(searchResponse -> {
                 List<Map<String, Object>> responseHits = new ArrayList<>();
                 for (SearchHit hit : searchResponse.getHits().getHits()) {
                     responseHits.add(mapHit(hit, configUuid));
                 }
                 listener.onResponse(new ABTestSearchResponse(testId, false, responseHits));
             },
-            e -> listener.onFailure(new SearchRelevanceException("Search execution failed", e, RestStatus.INTERNAL_SERVER_ERROR))
-        ));
+                e -> listener.onFailure(
+                    new SearchRelevanceException(
+                        "Search execution failed",
+                        e,
+                        isSecurityException(e) ? RestStatus.FORBIDDEN : RestStatus.INTERNAL_SERVER_ERROR
+                    )
+                )
+            ));
+        }
     }
 
     /**
@@ -321,6 +389,11 @@ public class ABTestSearchTransportAction extends HandledTransportAction<ABTestSe
         hitMap.put("_source", hit.getSourceAsMap());
         hitMap.put("_search_configuration_id", configUuid);
         return hitMap;
+    }
+
+    private boolean isSecurityException(Exception e) {
+        return e.getClass().getSimpleName().contains("Security")
+            || (e.getMessage() != null && e.getMessage().contains("no permissions for"));
     }
 
 }

--- a/src/main/java/org/opensearch/searchrelevance/transport/abTest/ABTestSearchTransportAction.java
+++ b/src/main/java/org/opensearch/searchrelevance/transport/abTest/ABTestSearchTransportAction.java
@@ -246,11 +246,7 @@ public class ABTestSearchTransportAction extends HandledTransportAction<ABTestSe
                             // Step 5: Interleave results with TDI
                             List<SearchHit> hitsA = Arrays.asList(items[0].getResponse().getHits().getHits());
                             List<SearchHit> hitsB = Arrays.asList(items[1].getResponse().getHits().getHits());
-                            TeamDraftInterleaver.Result tdiResult = interleaver.interleave(
-                                hitsA,
-                                hitsB,
-                                Math.max(hitsA.size(), hitsB.size())
-                            );
+                            TeamDraftInterleaver.Result tdiResult = interleaver.interleave(hitsA, hitsB, hitsA.size() + hitsB.size());
 
                             List<Map<String, Object>> responseHits = new ArrayList<>();
                             Set<String> teamADocs = tdiResult.getTeamA();

--- a/src/main/java/org/opensearch/searchrelevance/transport/abTest/ABTestSearchTransportAction.java
+++ b/src/main/java/org/opensearch/searchrelevance/transport/abTest/ABTestSearchTransportAction.java
@@ -13,13 +13,15 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.opensearch.action.search.SearchRequest;
 import org.opensearch.action.search.SearchResponse;
 import org.opensearch.action.support.ActionFilters;
-import org.opensearch.action.support.GroupedActionListener;
 import org.opensearch.action.support.HandledTransportAction;
 import org.opensearch.common.inject.Inject;
 import org.opensearch.core.action.ActionListener;
@@ -49,6 +51,7 @@ import org.opensearch.transport.client.Client;
  */
 public class ABTestSearchTransportAction extends HandledTransportAction<ABTestSearchRequest, ABTestSearchResponse> {
     private static final Logger LOGGER = LogManager.getLogger(ABTestSearchTransportAction.class);
+    private static final int DEFAULT_SEARCH_SIZE = 10;
 
     private final ABTestDao abTestDao;
     private final SearchConfigurationDao searchConfigurationDao;
@@ -107,33 +110,52 @@ public class ABTestSearchTransportAction extends HandledTransportAction<ABTestSe
                 return;
             }
             Map<String, Object> source = abTestResponse.getHits().getHits()[0].getSourceAsMap();
-            boolean enabled = (Boolean) source.get(ABTest.ENABLED);
+            Boolean enabledObj = (Boolean) source.get(ABTest.ENABLED);
             String configAId = (String) source.get(ABTest.SEARCH_CONFIGURATION_A);
             String configBId = (String) source.get(ABTest.SEARCH_CONFIGURATION_B);
             String configAUuid = (String) source.get(ABTest.CONFIG_A_UUID);
             String configBUuid = (String) source.get(ABTest.CONFIG_B_UUID);
             String testId = (String) source.get(ABTest.TEST_ID);
 
-            // Fetch both configurations in parallel using GroupedActionListener
-            int configCount = enabled ? 2 : 1;
-            GroupedActionListener<SearchResponse> groupedListener = new GroupedActionListener<>(
-                ActionListener.wrap(
-                    responses -> {
-                        List<SearchResponse> responseList = new ArrayList<>(responses);
-                        SearchResponse configAResponse = responseList.get(0);
-                        SearchResponse configBResponse = responseList.size() > 1 ? responseList.get(1) : null;
-                        executeSearchWithConfigs(configAResponse, configBResponse, enabled, testId, configAUuid, configBUuid, request, listener);
-                    },
-                    e -> listener.onFailure(
-                        new SearchRelevanceException("Failed to fetch search configuration", e, RestStatus.NOT_FOUND)
-                    )
-                ),
-                configCount
-            );
+            if (enabledObj == null || configAId == null || configAUuid == null || testId == null) {
+                listener.onFailure(new SearchRelevanceException("AB test document is missing required fields", RestStatus.INTERNAL_SERVER_ERROR));
+                return;
+            }
+            boolean enabled = enabledObj;
 
-            searchConfigurationDao.getSearchConfiguration(configAId, groupedListener);
+            // Fetch both configurations in parallel with dedicated slots to preserve ordering
+            AtomicReference<SearchResponse> configARef = new AtomicReference<>();
+            AtomicReference<SearchResponse> configBRef = new AtomicReference<>();
+            AtomicInteger remaining = new AtomicInteger(enabled ? 2 : 1);
+            AtomicBoolean failed = new AtomicBoolean(false);
+
+            Runnable maybeComplete = () -> {
+                if (remaining.decrementAndGet() == 0 && !failed.get()) {
+                    executeSearchWithConfigs(configARef.get(), configBRef.get(), enabled, testId, configAUuid, configBUuid, request, listener);
+                }
+            };
+
+            ActionListener<SearchResponse> configAListener = ActionListener.wrap(r -> {
+                configARef.set(r);
+                maybeComplete.run();
+            }, e -> {
+                if (failed.compareAndSet(false, true)) {
+                    listener.onFailure(new SearchRelevanceException("Failed to fetch search configuration A", e, RestStatus.NOT_FOUND));
+                }
+            });
+
+            searchConfigurationDao.getSearchConfiguration(configAId, configAListener);
+
             if (enabled) {
-                searchConfigurationDao.getSearchConfiguration(configBId, groupedListener);
+                ActionListener<SearchResponse> configBListener = ActionListener.wrap(r -> {
+                    configBRef.set(r);
+                    maybeComplete.run();
+                }, e -> {
+                    if (failed.compareAndSet(false, true)) {
+                        listener.onFailure(new SearchRelevanceException("Failed to fetch search configuration B", e, RestStatus.NOT_FOUND));
+                    }
+                });
+                searchConfigurationDao.getSearchConfiguration(configBId, configBListener);
             }
         } catch (Exception e) {
             listener.onFailure(new SearchRelevanceException("ABTestSearch failed", e, RestStatus.INTERNAL_SERVER_ERROR));
@@ -163,6 +185,7 @@ public class ABTestSearchTransportAction extends HandledTransportAction<ABTestSe
         String queryA = (String) configASource.get("query");
         String pipelineA = (String) configASource.get("searchPipeline");
         String targetIndex = (String) configASource.get("index");
+        int sizeA = configASource.containsKey("size") ? ((Number) configASource.get("size")).intValue() : DEFAULT_SEARCH_SIZE;
 
         String searchText = request.getParams().get("SearchText");
         if (searchText == null || searchText.isEmpty()) {
@@ -172,7 +195,7 @@ public class ABTestSearchTransportAction extends HandledTransportAction<ABTestSe
 
         // If test is disabled, only execute config A
         if (!enabled) {
-            SearchRequest searchRequestA = SearchRequestBuilder.buildSearchRequest(targetIndex, queryA, searchText, pipelineA, 10);
+            SearchRequest searchRequestA = SearchRequestBuilder.buildSearchRequest(targetIndex, queryA, searchText, pipelineA, sizeA);
             executeSingleSearch(searchRequestA, testId, configAUuid, listener);
             return;
         }
@@ -185,16 +208,17 @@ public class ABTestSearchTransportAction extends HandledTransportAction<ABTestSe
         Map<String, Object> configBSource = configBResponse.getHits().getHits()[0].getSourceAsMap();
         String queryB = (String) configBSource.get("query");
         String pipelineB = (String) configBSource.get("searchPipeline");
+        int sizeB = configBSource.containsKey("size") ? ((Number) configBSource.get("size")).intValue() : DEFAULT_SEARCH_SIZE;
 
-        SearchRequest searchRequestA = SearchRequestBuilder.buildSearchRequest(targetIndex, queryA, searchText, pipelineA, 10);
-        SearchRequest searchRequestB = SearchRequestBuilder.buildSearchRequest(targetIndex, queryB, searchText, pipelineB, 10);
+        SearchRequest searchRequestA = SearchRequestBuilder.buildSearchRequest(targetIndex, queryA, searchText, pipelineA, sizeA);
+        SearchRequest searchRequestB = SearchRequestBuilder.buildSearchRequest(targetIndex, queryB, searchText, pipelineB, sizeB);
 
         executeParallelSearchesAndInterleave(searchRequestA, searchRequestB, testId, configAUuid, configBUuid, listener);
     }
 
     /**
-     * Executes both search queries in parallel using GroupedActionListener, then applies
-     * Team Draft Interleaving to merge the two ranked lists into one.
+     * Executes both search queries in parallel with dedicated listeners to preserve ordering,
+     * then applies Team Draft Interleaving to merge the two ranked lists into one.
      */
     private void executeParallelSearchesAndInterleave(
         SearchRequest searchRequestA,
@@ -204,35 +228,46 @@ public class ABTestSearchTransportAction extends HandledTransportAction<ABTestSe
         String configBUuid,
         ActionListener<ABTestSearchResponse> listener
     ) {
-        // Fully async parallel execution using GroupedActionListener
-        GroupedActionListener<SearchResponse> groupedListener = new GroupedActionListener<>(
-            ActionListener.wrap(
-                responses -> {
-                    List<SearchResponse> responseList = new ArrayList<>(responses);
-                    SearchResponse responseA = responseList.get(0);
-                    SearchResponse responseB = responseList.get(1);
+        AtomicReference<SearchResponse> responseA = new AtomicReference<>();
+        AtomicReference<SearchResponse> responseB = new AtomicReference<>();
+        AtomicInteger remaining = new AtomicInteger(2);
+        AtomicBoolean failed = new AtomicBoolean(false);
 
-                    // Apply Team Draft Interleaving to merge both result sets
-                    List<SearchHit> hitsA = Arrays.asList(responseA.getHits().getHits());
-                    List<SearchHit> hitsB = Arrays.asList(responseB.getHits().getHits());
-                    TeamDraftInterleaver.Result tdiResult = interleaver.interleave(hitsA, hitsB, Math.max(hitsA.size(), hitsB.size()));
+        Runnable maybeInterleave = () -> {
+            if (remaining.decrementAndGet() == 0 && !failed.get()) {
+                // Apply Team Draft Interleaving to merge both result sets
+                List<SearchHit> hitsA = Arrays.asList(responseA.get().getHits().getHits());
+                List<SearchHit> hitsB = Arrays.asList(responseB.get().getHits().getHits());
+                TeamDraftInterleaver.Result tdiResult = interleaver.interleave(hitsA, hitsB, Math.max(hitsA.size(), hitsB.size()));
 
-                    // Map each hit with its team's config UUID for click attribution
-                    List<Map<String, Object>> responseHits = new ArrayList<>();
-                    Set<String> teamADocs = tdiResult.getTeamA();
-                    for (SearchHit hit : tdiResult.getInterleavedHits()) {
-                        String uuid = teamADocs.contains(hit.getId()) ? configAUuid : configBUuid;
-                        responseHits.add(mapHit(hit, uuid));
-                    }
-                    listener.onResponse(new ABTestSearchResponse(testId, true, responseHits));
-                },
-                e -> listener.onFailure(new SearchRelevanceException("Search execution failed", e, RestStatus.INTERNAL_SERVER_ERROR))
-            ),
-            2
-        );
+                // Map each hit with its team's config UUID for click attribution
+                List<Map<String, Object>> responseHits = new ArrayList<>();
+                Set<String> teamADocs = tdiResult.getTeamA();
+                for (SearchHit hit : tdiResult.getInterleavedHits()) {
+                    String uuid = teamADocs.contains(hit.getId()) ? configAUuid : configBUuid;
+                    responseHits.add(mapHit(hit, uuid));
+                }
+                listener.onResponse(new ABTestSearchResponse(testId, true, responseHits));
+            }
+        };
 
-        StashedThreadContext.run(client, () -> client.search(searchRequestA, groupedListener));
-        StashedThreadContext.run(client, () -> client.search(searchRequestB, groupedListener));
+        StashedThreadContext.run(client, () -> client.search(searchRequestA, ActionListener.wrap(r -> {
+            responseA.set(r);
+            maybeInterleave.run();
+        }, e -> {
+            if (failed.compareAndSet(false, true)) {
+                listener.onFailure(new SearchRelevanceException("Search execution failed", e, RestStatus.INTERNAL_SERVER_ERROR));
+            }
+        })));
+
+        StashedThreadContext.run(client, () -> client.search(searchRequestB, ActionListener.wrap(r -> {
+            responseB.set(r);
+            maybeInterleave.run();
+        }, e -> {
+            if (failed.compareAndSet(false, true)) {
+                listener.onFailure(new SearchRelevanceException("Search execution failed", e, RestStatus.INTERNAL_SERVER_ERROR));
+            }
+        })));
     }
 
     /**

--- a/src/main/java/org/opensearch/searchrelevance/transport/abTest/ABTestSearchTransportAction.java
+++ b/src/main/java/org/opensearch/searchrelevance/transport/abTest/ABTestSearchTransportAction.java
@@ -14,15 +14,13 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicInteger;
-import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.opensearch.action.search.MultiSearchRequest;
+import org.opensearch.action.search.MultiSearchResponse;
 import org.opensearch.action.search.SearchRequest;
-import org.opensearch.action.search.SearchResponse;
 import org.opensearch.action.support.ActionFilters;
 import org.opensearch.action.support.HandledTransportAction;
 import org.opensearch.common.inject.Inject;
@@ -45,11 +43,11 @@ import org.opensearch.transport.client.Client;
  * Transport action for AB test search with Team Draft Interleaving.
  *
  * Flow:
- * 1. Fetch AB test metadata (config IDs, UUIDs, enabled flag)
- * 2. Fetch both search configurations in parallel using GroupedActionListener
- * 3. If test is disabled: execute only config A (single search)
- *    If test is enabled: execute both queries in parallel, interleave with TDI
- * 4. Return results with _search_configuration_id per hit for click attribution
+ * 1. Get AB test metadata (config IDs, UUIDs, enabled flag)
+ * 2. Get config(s) based on test status
+ * 3. Prepare search requests
+ * 4. Call msearch (single round-trip, ordered responses)
+ * 5. Interleave/merge results
  */
 public class ABTestSearchTransportAction extends HandledTransportAction<ABTestSearchRequest, ABTestSearchResponse> {
     private static final Logger LOGGER = LogManager.getLogger(ABTestSearchTransportAction.class);
@@ -86,35 +84,12 @@ public class ABTestSearchTransportAction extends HandledTransportAction<ABTestSe
             return;
         }
         // Capture caller's security context before DAO calls stash it
-        final ThreadContext threadContext = client.threadPool().getThreadContext();
-        final Supplier<ThreadContext.StoredContext> restoreCallerContext = threadContext.newRestorableContext(false);
+        final Supplier<ThreadContext.StoredContext> restoreCallerContext = client.threadPool()
+            .getThreadContext()
+            .newRestorableContext(false);
 
-        abTestDao.getABTest(
-            request.getTestId(),
-            ActionListener.wrap(
-                abTestResponse -> extractTestMetadataAndFetchConfigs(abTestResponse, request, restoreCallerContext, listener),
-                e -> {
-                    if (e instanceof org.opensearch.ResourceNotFoundException) {
-                        listener.onFailure(new SearchRelevanceException("AB test not found", RestStatus.NOT_FOUND));
-                    } else {
-                        listener.onFailure(new SearchRelevanceException("Failed to read AB test", e, RestStatus.INTERNAL_SERVER_ERROR));
-                    }
-                }
-            )
-        );
-    }
-
-    /**
-     * Extracts AB test metadata (config IDs, UUIDs, enabled flag) from the response
-     * and fetches both search configurations in parallel using GroupedActionListener.
-     */
-    private void extractTestMetadataAndFetchConfigs(
-        SearchResponse abTestResponse,
-        ABTestSearchRequest request,
-        Supplier<ThreadContext.StoredContext> restoreCallerContext,
-        ActionListener<ABTestSearchResponse> listener
-    ) {
-        try {
+        // Step 1: Get AB test metadata
+        abTestDao.getABTest(request.getTestId(), ActionListener.wrap(abTestResponse -> {
             if (abTestResponse.getHits().getHits().length == 0) {
                 listener.onFailure(new SearchRelevanceException("AB test not found", RestStatus.NOT_FOUND));
                 return;
@@ -135,252 +110,181 @@ public class ABTestSearchTransportAction extends HandledTransportAction<ABTestSe
             }
             boolean enabled = enabledObj;
 
-            // Fetch both configurations in parallel with dedicated slots to preserve ordering
-            AtomicReference<SearchResponse> configARef = new AtomicReference<>();
-            AtomicReference<SearchResponse> configBRef = new AtomicReference<>();
-            AtomicInteger remaining = new AtomicInteger(enabled ? 2 : 1);
-            AtomicBoolean failed = new AtomicBoolean(false);
-
-            Runnable maybeComplete = () -> {
-                if (remaining.decrementAndGet() == 0 && !failed.get()) {
-                    executeSearchWithConfigs(
-                        configARef.get(),
-                        configBRef.get(),
-                        enabled,
-                        testId,
-                        configAUuid,
-                        configBUuid,
-                        request,
-                        restoreCallerContext,
-                        listener
-                    );
+            // Step 2: Get config A
+            searchConfigurationDao.getSearchConfiguration(configAId, ActionListener.wrap(configAResponse -> {
+                if (configAResponse.getHits().getHits().length == 0) {
+                    listener.onFailure(new SearchRelevanceException("Search configuration A not found", RestStatus.NOT_FOUND));
+                    return;
                 }
-            };
+                Map<String, Object> configASource = configAResponse.getHits().getHits()[0].getSourceAsMap();
+                String queryA = (String) configASource.get("query");
+                String pipelineA = (String) configASource.get("searchPipeline");
+                String targetIndex = (String) configASource.get("index");
+                int sizeA = configASource.containsKey("size") ? ((Number) configASource.get("size")).intValue() : DEFAULT_SEARCH_SIZE;
 
-            ActionListener<SearchResponse> configAListener = ActionListener.wrap(r -> {
-                configARef.set(r);
-                maybeComplete.run();
-            }, e -> {
-                if (failed.compareAndSet(false, true)) {
-                    listener.onFailure(new SearchRelevanceException("Failed to fetch search configuration A", e, RestStatus.NOT_FOUND));
+                String searchText = request.getParams().get("SearchText");
+                if (searchText == null || searchText.isEmpty()) {
+                    listener.onFailure(new SearchRelevanceException("SearchText is required in query_params", RestStatus.BAD_REQUEST));
+                    return;
                 }
-            });
 
-            searchConfigurationDao.getSearchConfiguration(configAId, configAListener);
-
-            if (enabled) {
-                ActionListener<SearchResponse> configBListener = ActionListener.wrap(r -> {
-                    configBRef.set(r);
-                    maybeComplete.run();
-                }, e -> {
-                    if (failed.compareAndSet(false, true)) {
-                        listener.onFailure(new SearchRelevanceException("Failed to fetch search configuration B", e, RestStatus.NOT_FOUND));
-                    }
-                });
-                searchConfigurationDao.getSearchConfiguration(configBId, configBListener);
-            }
-        } catch (Exception e) {
-            listener.onFailure(new SearchRelevanceException("ABTestSearch failed", e, RestStatus.INTERNAL_SERVER_ERROR));
-        }
-    }
-
-    /**
-     * Parses both search configurations, builds search requests using SearchRequestBuilder
-     * (preserving query structure for pipeline processors), and executes search.
-     * If test is disabled, runs only config A. If enabled, runs both in parallel and interleaves.
-     */
-    private void executeSearchWithConfigs(
-        SearchResponse configAResponse,
-        SearchResponse configBResponse,
-        boolean enabled,
-        String testId,
-        String configAUuid,
-        String configBUuid,
-        ABTestSearchRequest request,
-        Supplier<ThreadContext.StoredContext> restoreCallerContext,
-        ActionListener<ABTestSearchResponse> listener
-    ) {
-        if (configAResponse.getHits().getHits().length == 0) {
-            listener.onFailure(new SearchRelevanceException("Search configuration A not found", RestStatus.NOT_FOUND));
-            return;
-        }
-        Map<String, Object> configASource = configAResponse.getHits().getHits()[0].getSourceAsMap();
-        String queryA = (String) configASource.get("query");
-        String pipelineA = (String) configASource.get("searchPipeline");
-        String targetIndex = (String) configASource.get("index");
-        int sizeA = configASource.containsKey("size") ? ((Number) configASource.get("size")).intValue() : DEFAULT_SEARCH_SIZE;
-
-        String searchText = request.getParams().get("SearchText");
-        if (searchText == null || searchText.isEmpty()) {
-            listener.onFailure(new SearchRelevanceException("SearchText is required in query_params", RestStatus.BAD_REQUEST));
-            return;
-        }
-
-        // If test is disabled, only execute config A
-        if (!enabled) {
-            SearchRequest searchRequestA = SearchRequestBuilder.buildSearchRequest(targetIndex, queryA, searchText, pipelineA, sizeA);
-            executeSingleSearch(searchRequestA, testId, configAUuid, restoreCallerContext, listener);
-            return;
-        }
-
-        // Parse config B and execute both searches in parallel with TDI
-        if (configBResponse.getHits().getHits().length == 0) {
-            listener.onFailure(new SearchRelevanceException("Search configuration B not found", RestStatus.NOT_FOUND));
-            return;
-        }
-        Map<String, Object> configBSource = configBResponse.getHits().getHits()[0].getSourceAsMap();
-        String targetIndexB = (String) configBSource.get("index");
-        if (targetIndexB == null || !targetIndexB.equals(targetIndex)) {
-            listener.onFailure(
-                new SearchRelevanceException(
-                    String.format(
-                        Locale.ROOT,
-                        "Both search configurations must target the same index. Config A targets [%s], Config B targets [%s]",
+                // If test is disabled, single search with config A only
+                if (!enabled) {
+                    SearchRequest searchRequestA = SearchRequestBuilder.buildSearchRequest(
                         targetIndex,
-                        targetIndexB
-                    ),
-                    RestStatus.BAD_REQUEST
-                )
-            );
-            return;
-        }
-        String queryB = (String) configBSource.get("query");
-        String pipelineB = (String) configBSource.get("searchPipeline");
-        int sizeB = configBSource.containsKey("size") ? ((Number) configBSource.get("size")).intValue() : DEFAULT_SEARCH_SIZE;
+                        queryA,
+                        searchText,
+                        pipelineA,
+                        sizeA
+                    );
+                    try (ThreadContext.StoredContext ctx = restoreCallerContext.get()) {
+                        client.search(searchRequestA, ActionListener.wrap(searchResponse -> {
+                            List<Map<String, Object>> responseHits = new ArrayList<>();
+                            for (SearchHit hit : searchResponse.getHits().getHits()) {
+                                responseHits.add(mapHit(hit, configAUuid));
+                            }
+                            listener.onResponse(new ABTestSearchResponse(testId, responseHits));
+                        },
+                            e -> listener.onFailure(
+                                new SearchRelevanceException(
+                                    "Search execution failed",
+                                    e,
+                                    isSecurityException(e) ? RestStatus.FORBIDDEN : RestStatus.INTERNAL_SERVER_ERROR
+                                )
+                            )
+                        ));
+                    }
+                    return;
+                }
 
-        if (sizeA != sizeB) {
-            listener.onFailure(
-                new SearchRelevanceException(
-                    String.format(
-                        Locale.ROOT,
-                        "Both search configurations must use the same size for fair comparison. Config A size [%d], Config B size [%d]",
-                        sizeA,
+                // Step 2b: Get config B (only when enabled)
+                searchConfigurationDao.getSearchConfiguration(configBId, ActionListener.wrap(configBResponse -> {
+                    if (configBResponse.getHits().getHits().length == 0) {
+                        listener.onFailure(new SearchRelevanceException("Search configuration B not found", RestStatus.NOT_FOUND));
+                        return;
+                    }
+                    Map<String, Object> configBSource = configBResponse.getHits().getHits()[0].getSourceAsMap();
+                    String targetIndexB = (String) configBSource.get("index");
+                    if (targetIndexB == null || !targetIndexB.equals(targetIndex)) {
+                        listener.onFailure(
+                            new SearchRelevanceException(
+                                String.format(
+                                    Locale.ROOT,
+                                    "Both search configurations must target the same index. Config A targets [%s], Config B targets [%s]",
+                                    targetIndex,
+                                    targetIndexB
+                                ),
+                                RestStatus.BAD_REQUEST
+                            )
+                        );
+                        return;
+                    }
+                    String queryB = (String) configBSource.get("query");
+                    String pipelineB = (String) configBSource.get("searchPipeline");
+                    int sizeB = configBSource.containsKey("size") ? ((Number) configBSource.get("size")).intValue() : DEFAULT_SEARCH_SIZE;
+
+                    if (sizeA != sizeB) {
+                        listener.onFailure(
+                            new SearchRelevanceException(
+                                String.format(
+                                    Locale.ROOT,
+                                    "Both search configurations must use the same size for fair comparison. Config A size [%d], Config B size [%d]",
+                                    sizeA,
+                                    sizeB
+                                ),
+                                RestStatus.BAD_REQUEST
+                            )
+                        );
+                        return;
+                    }
+
+                    // Step 3: Prepare search requests
+                    SearchRequest searchRequestA = SearchRequestBuilder.buildSearchRequest(
+                        targetIndex,
+                        queryA,
+                        searchText,
+                        pipelineA,
+                        sizeA
+                    );
+                    SearchRequest searchRequestB = SearchRequestBuilder.buildSearchRequest(
+                        targetIndex,
+                        queryB,
+                        searchText,
+                        pipelineB,
                         sizeB
-                    ),
-                    RestStatus.BAD_REQUEST
-                )
-            );
-            return;
-        }
+                    );
 
-        SearchRequest searchRequestA = SearchRequestBuilder.buildSearchRequest(targetIndex, queryA, searchText, pipelineA, sizeA);
-        SearchRequest searchRequestB = SearchRequestBuilder.buildSearchRequest(targetIndex, queryB, searchText, pipelineB, sizeB);
+                    // Step 4: Call msearch — single round-trip, ordered responses
+                    MultiSearchRequest msearchRequest = new MultiSearchRequest();
+                    msearchRequest.add(searchRequestA);
+                    msearchRequest.add(searchRequestB);
 
-        executeParallelSearchesAndInterleave(
-            searchRequestA,
-            searchRequestB,
-            testId,
-            configAUuid,
-            configBUuid,
-            restoreCallerContext,
-            listener
-        );
-    }
+                    try (ThreadContext.StoredContext ctx = restoreCallerContext.get()) {
+                        client.multiSearch(msearchRequest, ActionListener.wrap(msearchResponse -> {
+                            MultiSearchResponse.Item[] items = msearchResponse.getResponses();
+                            if (items[0].isFailure()) {
+                                listener.onFailure(
+                                    new SearchRelevanceException(
+                                        "Search A failed",
+                                        items[0].getFailure(),
+                                        isSecurityException(items[0].getFailure()) ? RestStatus.FORBIDDEN : RestStatus.INTERNAL_SERVER_ERROR
+                                    )
+                                );
+                                return;
+                            }
+                            if (items[1].isFailure()) {
+                                listener.onFailure(
+                                    new SearchRelevanceException(
+                                        "Search B failed",
+                                        items[1].getFailure(),
+                                        isSecurityException(items[1].getFailure()) ? RestStatus.FORBIDDEN : RestStatus.INTERNAL_SERVER_ERROR
+                                    )
+                                );
+                                return;
+                            }
 
-    /**
-     * Executes both search queries in parallel with dedicated listeners to preserve ordering,
-     * then applies Team Draft Interleaving to merge the two ranked lists into one.
-     */
-    private void executeParallelSearchesAndInterleave(
-        SearchRequest searchRequestA,
-        SearchRequest searchRequestB,
-        String testId,
-        String configAUuid,
-        String configBUuid,
-        Supplier<ThreadContext.StoredContext> restoreCallerContext,
-        ActionListener<ABTestSearchResponse> listener
-    ) {
-        AtomicReference<SearchResponse> responseA = new AtomicReference<>();
-        AtomicReference<SearchResponse> responseB = new AtomicReference<>();
-        AtomicInteger remaining = new AtomicInteger(2);
-        AtomicBoolean failed = new AtomicBoolean(false);
+                            // Step 5: Interleave results with TDI
+                            List<SearchHit> hitsA = Arrays.asList(items[0].getResponse().getHits().getHits());
+                            List<SearchHit> hitsB = Arrays.asList(items[1].getResponse().getHits().getHits());
+                            TeamDraftInterleaver.Result tdiResult = interleaver.interleave(
+                                hitsA,
+                                hitsB,
+                                Math.min(hitsA.size(), hitsB.size())
+                            );
 
-        Runnable maybeInterleave = () -> {
-            if (remaining.decrementAndGet() == 0 && !failed.get()) {
-                // Apply Team Draft Interleaving to merge both result sets
-                List<SearchHit> hitsA = Arrays.asList(responseA.get().getHits().getHits());
-                List<SearchHit> hitsB = Arrays.asList(responseB.get().getHits().getHits());
-                TeamDraftInterleaver.Result tdiResult = interleaver.interleave(hitsA, hitsB, Math.min(hitsA.size(), hitsB.size()));
+                            List<Map<String, Object>> responseHits = new ArrayList<>();
+                            Set<String> teamADocs = tdiResult.getTeamA();
+                            for (SearchHit hit : tdiResult.getInterleavedHits()) {
+                                String uuid = teamADocs.contains(hit.getId()) ? configAUuid : configBUuid;
+                                responseHits.add(mapHit(hit, uuid));
+                            }
+                            listener.onResponse(new ABTestSearchResponse(testId, responseHits));
 
-                // Map each hit with its team's config UUID for click attribution
-                List<Map<String, Object>> responseHits = new ArrayList<>();
-                Set<String> teamADocs = tdiResult.getTeamA();
-                for (SearchHit hit : tdiResult.getInterleavedHits()) {
-                    String uuid = teamADocs.contains(hit.getId()) ? configAUuid : configBUuid;
-                    responseHits.add(mapHit(hit, uuid));
-                }
-                listener.onResponse(new ABTestSearchResponse(testId, true, responseHits));
+                        },
+                            e -> listener.onFailure(
+                                new SearchRelevanceException(
+                                    "Search execution failed",
+                                    e,
+                                    isSecurityException(e) ? RestStatus.FORBIDDEN : RestStatus.INTERNAL_SERVER_ERROR
+                                )
+                            )
+                        ));
+                    }
+
+                }, e -> listener.onFailure(new SearchRelevanceException("Failed to fetch search configuration B", e, RestStatus.NOT_FOUND)))
+                );
+
+            }, e -> listener.onFailure(new SearchRelevanceException("Failed to fetch search configuration A", e, RestStatus.NOT_FOUND))));
+
+        }, e -> {
+            if (e instanceof org.opensearch.ResourceNotFoundException) {
+                listener.onFailure(new SearchRelevanceException("AB test not found", RestStatus.NOT_FOUND));
+            } else {
+                listener.onFailure(new SearchRelevanceException("Failed to read AB test", e, RestStatus.INTERNAL_SERVER_ERROR));
             }
-        };
-
-        // Restore caller's security context before searching target index
-        try (ThreadContext.StoredContext ctx = restoreCallerContext.get()) {
-            client.search(searchRequestA, ActionListener.wrap(r -> {
-                responseA.set(r);
-                maybeInterleave.run();
-            }, e -> {
-                if (failed.compareAndSet(false, true)) {
-                    listener.onFailure(
-                        new SearchRelevanceException(
-                            "Search execution failed",
-                            e,
-                            isSecurityException(e) ? RestStatus.FORBIDDEN : RestStatus.INTERNAL_SERVER_ERROR
-                        )
-                    );
-                }
-            }));
-
-            client.search(searchRequestB, ActionListener.wrap(r -> {
-                responseB.set(r);
-                maybeInterleave.run();
-            }, e -> {
-                if (failed.compareAndSet(false, true)) {
-                    listener.onFailure(
-                        new SearchRelevanceException(
-                            "Search execution failed",
-                            e,
-                            isSecurityException(e) ? RestStatus.FORBIDDEN : RestStatus.INTERNAL_SERVER_ERROR
-                        )
-                    );
-                }
-            }));
-        }
+        }));
     }
 
-    /**
-     * Executes a single search when the AB test is disabled (only config A).
-     * Fully async — no thread blocking.
-     */
-    private void executeSingleSearch(
-        SearchRequest searchRequest,
-        String testId,
-        String configUuid,
-        Supplier<ThreadContext.StoredContext> restoreCallerContext,
-        ActionListener<ABTestSearchResponse> listener
-    ) {
-        // Restore caller's security context before searching target index
-        try (ThreadContext.StoredContext ctx = restoreCallerContext.get()) {
-            client.search(searchRequest, ActionListener.wrap(searchResponse -> {
-                List<Map<String, Object>> responseHits = new ArrayList<>();
-                for (SearchHit hit : searchResponse.getHits().getHits()) {
-                    responseHits.add(mapHit(hit, configUuid));
-                }
-                listener.onResponse(new ABTestSearchResponse(testId, false, responseHits));
-            },
-                e -> listener.onFailure(
-                    new SearchRelevanceException(
-                        "Search execution failed",
-                        e,
-                        isSecurityException(e) ? RestStatus.FORBIDDEN : RestStatus.INTERNAL_SERVER_ERROR
-                    )
-                )
-            ));
-        }
-    }
-
-    /**
-     * Maps a SearchHit to a response map with config UUID for click attribution.
-     */
     private Map<String, Object> mapHit(SearchHit hit, String configUuid) {
         Map<String, Object> hitMap = new HashMap<>();
         hitMap.put("_index", hit.getIndex());
@@ -395,5 +299,4 @@ public class ABTestSearchTransportAction extends HandledTransportAction<ABTestSe
         return e.getClass().getSimpleName().contains("Security")
             || (e.getMessage() != null && e.getMessage().contains("no permissions for"));
     }
-
 }

--- a/src/main/java/org/opensearch/searchrelevance/transport/abTest/ABTestSearchTransportAction.java
+++ b/src/main/java/org/opensearch/searchrelevance/transport/abTest/ABTestSearchTransportAction.java
@@ -249,7 +249,7 @@ public class ABTestSearchTransportAction extends HandledTransportAction<ABTestSe
                             TeamDraftInterleaver.Result tdiResult = interleaver.interleave(
                                 hitsA,
                                 hitsB,
-                                Math.min(hitsA.size(), hitsB.size())
+                                Math.max(hitsA.size(), hitsB.size())
                             );
 
                             List<Map<String, Object>> responseHits = new ArrayList<>();

--- a/src/main/java/org/opensearch/searchrelevance/transport/abTest/ABTestSearchTransportAction.java
+++ b/src/main/java/org/opensearch/searchrelevance/transport/abTest/ABTestSearchTransportAction.java
@@ -11,6 +11,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -208,7 +209,7 @@ public class ABTestSearchTransportAction extends HandledTransportAction<ABTestSe
         String targetIndexB = (String) configBSource.get("index");
         if (targetIndexB == null || !targetIndexB.equals(targetIndex)) {
             listener.onFailure(new SearchRelevanceException(
-                "Both search configurations must target the same index. Config A targets [" + targetIndex + "], Config B targets [" + targetIndexB + "]",
+                String.format(Locale.ROOT, "Both search configurations must target the same index. Config A targets [%s], Config B targets [%s]", targetIndex, targetIndexB),
                 RestStatus.BAD_REQUEST
             ));
             return;
@@ -216,6 +217,14 @@ public class ABTestSearchTransportAction extends HandledTransportAction<ABTestSe
         String queryB = (String) configBSource.get("query");
         String pipelineB = (String) configBSource.get("searchPipeline");
         int sizeB = configBSource.containsKey("size") ? ((Number) configBSource.get("size")).intValue() : DEFAULT_SEARCH_SIZE;
+
+        if (sizeA != sizeB) {
+            listener.onFailure(new SearchRelevanceException(
+                String.format(Locale.ROOT, "Both search configurations must use the same size for fair comparison. Config A size [%d], Config B size [%d]", sizeA, sizeB),
+                RestStatus.BAD_REQUEST
+            ));
+            return;
+        }
 
         SearchRequest searchRequestA = SearchRequestBuilder.buildSearchRequest(targetIndex, queryA, searchText, pipelineA, sizeA);
         SearchRequest searchRequestB = SearchRequestBuilder.buildSearchRequest(targetIndex, queryB, searchText, pipelineB, sizeB);
@@ -245,7 +254,7 @@ public class ABTestSearchTransportAction extends HandledTransportAction<ABTestSe
                 // Apply Team Draft Interleaving to merge both result sets
                 List<SearchHit> hitsA = Arrays.asList(responseA.get().getHits().getHits());
                 List<SearchHit> hitsB = Arrays.asList(responseB.get().getHits().getHits());
-                TeamDraftInterleaver.Result tdiResult = interleaver.interleave(hitsA, hitsB, Math.max(hitsA.size(), hitsB.size()));
+                TeamDraftInterleaver.Result tdiResult = interleaver.interleave(hitsA, hitsB, Math.min(hitsA.size(), hitsB.size()));
 
                 // Map each hit with its team's config UUID for click attribution
                 List<Map<String, Object>> responseHits = new ArrayList<>();

--- a/src/main/java/org/opensearch/searchrelevance/transport/abTest/ABTestSearchTransportAction.java
+++ b/src/main/java/org/opensearch/searchrelevance/transport/abTest/ABTestSearchTransportAction.java
@@ -7,43 +7,48 @@
  */
 package org.opensearch.searchrelevance.transport.abTest;
 
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicReference;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.opensearch.action.search.SearchRequest;
 import org.opensearch.action.search.SearchResponse;
 import org.opensearch.action.support.ActionFilters;
+import org.opensearch.action.support.GroupedActionListener;
 import org.opensearch.action.support.HandledTransportAction;
 import org.opensearch.common.inject.Inject;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.rest.RestStatus;
 import org.opensearch.search.SearchHit;
-import org.opensearch.search.builder.SearchSourceBuilder;
 import org.opensearch.searchrelevance.algorithm.TeamDraftInterleaver;
 import org.opensearch.searchrelevance.dao.ABTestDao;
 import org.opensearch.searchrelevance.dao.SearchConfigurationDao;
 import org.opensearch.searchrelevance.exception.SearchRelevanceException;
 import org.opensearch.searchrelevance.model.ABTest;
+import org.opensearch.searchrelevance.model.builder.SearchRequestBuilder;
 import org.opensearch.searchrelevance.shared.StashedThreadContext;
 import org.opensearch.tasks.Task;
 import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.transport.TransportService;
 import org.opensearch.transport.client.Client;
 
+/**
+ * Transport action for AB test search with Team Draft Interleaving.
+ *
+ * Flow:
+ * 1. Fetch AB test metadata (config IDs, UUIDs, enabled flag)
+ * 2. Fetch both search configurations in parallel using GroupedActionListener
+ * 3. If test is disabled: execute only config A (single search)
+ *    If test is enabled: execute both queries in parallel, interleave with TDI
+ * 4. Return results with _search_configuration_id per hit for click attribution
+ */
 public class ABTestSearchTransportAction extends HandledTransportAction<ABTestSearchRequest, ABTestSearchResponse> {
     private static final Logger LOGGER = LogManager.getLogger(ABTestSearchTransportAction.class);
-    private static final int SEARCH_TIMEOUT_SECONDS = 30;
-    private static final String SEARCH_TEXT_PLACEHOLDER = "%SearchText%";
 
     private final ABTestDao abTestDao;
     private final SearchConfigurationDao searchConfigurationDao;
@@ -58,14 +63,15 @@ public class ABTestSearchTransportAction extends HandledTransportAction<ABTestSe
         ABTestDao abTestDao,
         SearchConfigurationDao searchConfigurationDao,
         Client client,
-        ThreadPool threadPool
+        ThreadPool threadPool,
+        TeamDraftInterleaver interleaver
     ) {
         super(ABTestSearchAction.NAME, transportService, actionFilters, ABTestSearchRequest::new);
         this.abTestDao = abTestDao;
         this.searchConfigurationDao = searchConfigurationDao;
         this.client = client;
         this.threadPool = threadPool;
-        this.interleaver = new TeamDraftInterleaver();
+        this.interleaver = interleaver;
     }
 
     @Override
@@ -76,7 +82,7 @@ public class ABTestSearchTransportAction extends HandledTransportAction<ABTestSe
         }
         abTestDao.getABTest(
             request.getTestId(),
-            ActionListener.wrap(abTestResponse -> handleABTestResponse(abTestResponse, request, listener), e -> {
+            ActionListener.wrap(abTestResponse -> extractTestMetadataAndFetchConfigs(abTestResponse, request, listener), e -> {
                 if (e instanceof org.opensearch.ResourceNotFoundException) {
                     listener.onFailure(new SearchRelevanceException("AB test not found", RestStatus.NOT_FOUND));
                 } else {
@@ -86,7 +92,11 @@ public class ABTestSearchTransportAction extends HandledTransportAction<ABTestSe
         );
     }
 
-    private void handleABTestResponse(
+    /**
+     * Extracts AB test metadata (config IDs, UUIDs, enabled flag) from the response
+     * and fetches both search configurations in parallel using GroupedActionListener.
+     */
+    private void extractTestMetadataAndFetchConfigs(
         SearchResponse abTestResponse,
         ABTestSearchRequest request,
         ActionListener<ABTestSearchResponse> listener
@@ -104,38 +114,40 @@ public class ABTestSearchTransportAction extends HandledTransportAction<ABTestSe
             String configBUuid = (String) source.get(ABTest.CONFIG_B_UUID);
             String testId = (String) source.get(ABTest.TEST_ID);
 
-            searchConfigurationDao.getSearchConfiguration(
-                configAId,
+            // Fetch both configurations in parallel using GroupedActionListener
+            int configCount = enabled ? 2 : 1;
+            GroupedActionListener<SearchResponse> groupedListener = new GroupedActionListener<>(
                 ActionListener.wrap(
-                    configAResponse -> handleConfigAResponse(
-                        configAResponse,
-                        configBId,
-                        enabled,
-                        testId,
-                        configAUuid,
-                        configBUuid,
-                        request,
-                        listener
-                    ),
-                    e -> {
-                        if (e instanceof org.opensearch.ResourceNotFoundException) {
-                            listener.onFailure(new SearchRelevanceException("Search configuration A not found", RestStatus.NOT_FOUND));
-                        } else {
-                            listener.onFailure(
-                                new SearchRelevanceException("Failed to read config A", e, RestStatus.INTERNAL_SERVER_ERROR)
-                            );
-                        }
-                    }
-                )
+                    responses -> {
+                        List<SearchResponse> responseList = new ArrayList<>(responses);
+                        SearchResponse configAResponse = responseList.get(0);
+                        SearchResponse configBResponse = responseList.size() > 1 ? responseList.get(1) : null;
+                        executeSearchWithConfigs(configAResponse, configBResponse, enabled, testId, configAUuid, configBUuid, request, listener);
+                    },
+                    e -> listener.onFailure(
+                        new SearchRelevanceException("Failed to fetch search configuration", e, RestStatus.NOT_FOUND)
+                    )
+                ),
+                configCount
             );
+
+            searchConfigurationDao.getSearchConfiguration(configAId, groupedListener);
+            if (enabled) {
+                searchConfigurationDao.getSearchConfiguration(configBId, groupedListener);
+            }
         } catch (Exception e) {
             listener.onFailure(new SearchRelevanceException("ABTestSearch failed", e, RestStatus.INTERNAL_SERVER_ERROR));
         }
     }
 
-    private void handleConfigAResponse(
+    /**
+     * Parses both search configurations, builds search requests using SearchRequestBuilder
+     * (preserving query structure for pipeline processors), and executes search.
+     * If test is disabled, runs only config A. If enabled, runs both in parallel and interleaves.
+     */
+    private void executeSearchWithConfigs(
         SearchResponse configAResponse,
-        String configBId,
+        SearchResponse configBResponse,
         boolean enabled,
         String testId,
         String configAUuid,
@@ -148,208 +160,106 @@ public class ABTestSearchTransportAction extends HandledTransportAction<ABTestSe
             return;
         }
         Map<String, Object> configASource = configAResponse.getHits().getHits()[0].getSourceAsMap();
-        String queryA;
-        try {
-            queryA = substituteParams((String) configASource.get("query"), request.getParams());
-        } catch (SearchRelevanceException e) {
-            listener.onFailure(e);
-            return;
-        }
+        String queryA = (String) configASource.get("query");
         String pipelineA = (String) configASource.get("searchPipeline");
         String targetIndex = (String) configASource.get("index");
 
-        if (!enabled) {
-            threadPool.generic().execute(() -> {
-                try {
-                    executeSingleSearch(targetIndex, queryA, pipelineA, testId, configAUuid, listener);
-                } catch (Exception e) {
-                    listener.onFailure(new SearchRelevanceException("ABTestSearch failed", e, RestStatus.INTERNAL_SERVER_ERROR));
-                }
-            });
+        String searchText = request.getParams().get("SearchText");
+        if (searchText == null || searchText.isEmpty()) {
+            listener.onFailure(new SearchRelevanceException("SearchText is required in query_params", RestStatus.BAD_REQUEST));
             return;
         }
 
-        searchConfigurationDao.getSearchConfiguration(
-            configBId,
-            ActionListener.wrap(
-                configBResponse -> handleConfigBResponse(
-                    configBResponse,
-                    targetIndex,
-                    queryA,
-                    pipelineA,
-                    testId,
-                    configAUuid,
-                    configBUuid,
-                    request,
-                    listener
-                ),
-                e -> {
-                    if (e instanceof org.opensearch.ResourceNotFoundException) {
-                        listener.onFailure(new SearchRelevanceException("Search configuration B not found", RestStatus.NOT_FOUND));
-                    } else {
-                        listener.onFailure(new SearchRelevanceException("Failed to read config B", e, RestStatus.INTERNAL_SERVER_ERROR));
-                    }
-                }
-            )
-        );
-    }
+        // If test is disabled, only execute config A
+        if (!enabled) {
+            SearchRequest searchRequestA = SearchRequestBuilder.buildSearchRequest(targetIndex, queryA, searchText, pipelineA, 10);
+            executeSingleSearch(searchRequestA, testId, configAUuid, listener);
+            return;
+        }
 
-    private void handleConfigBResponse(
-        SearchResponse configBResponse,
-        String targetIndex,
-        String queryA,
-        String pipelineA,
-        String testId,
-        String configAUuid,
-        String configBUuid,
-        ABTestSearchRequest request,
-        ActionListener<ABTestSearchResponse> listener
-    ) {
+        // Parse config B and execute both searches in parallel with TDI
         if (configBResponse.getHits().getHits().length == 0) {
             listener.onFailure(new SearchRelevanceException("Search configuration B not found", RestStatus.NOT_FOUND));
             return;
         }
         Map<String, Object> configBSource = configBResponse.getHits().getHits()[0].getSourceAsMap();
-        String queryB;
-        try {
-            queryB = substituteParams((String) configBSource.get("query"), request.getParams());
-        } catch (SearchRelevanceException e) {
-            listener.onFailure(e);
-            return;
-        }
+        String queryB = (String) configBSource.get("query");
         String pipelineB = (String) configBSource.get("searchPipeline");
 
-        threadPool.generic().execute(() -> {
-            try {
-                executeParallelSearches(targetIndex, queryA, pipelineA, queryB, pipelineB, testId, configAUuid, configBUuid, listener);
-            } catch (Exception e) {
-                listener.onFailure(new SearchRelevanceException("ABTestSearch failed", e, RestStatus.INTERNAL_SERVER_ERROR));
-            }
-        });
+        SearchRequest searchRequestA = SearchRequestBuilder.buildSearchRequest(targetIndex, queryA, searchText, pipelineA, 10);
+        SearchRequest searchRequestB = SearchRequestBuilder.buildSearchRequest(targetIndex, queryB, searchText, pipelineB, 10);
+
+        executeParallelSearchesAndInterleave(searchRequestA, searchRequestB, testId, configAUuid, configBUuid, listener);
     }
 
-    private void executeParallelSearches(
-        String targetIndex,
-        String queryA,
-        String pipelineA,
-        String queryB,
-        String pipelineB,
+    /**
+     * Executes both search queries in parallel using GroupedActionListener, then applies
+     * Team Draft Interleaving to merge the two ranked lists into one.
+     */
+    private void executeParallelSearchesAndInterleave(
+        SearchRequest searchRequestA,
+        SearchRequest searchRequestB,
         String testId,
         String configAUuid,
         String configBUuid,
         ActionListener<ABTestSearchResponse> listener
     ) {
-        SearchRequest searchRequestA = buildSearchRequest(targetIndex, queryA, pipelineA);
-        SearchRequest searchRequestB = buildSearchRequest(targetIndex, queryB, pipelineB);
-        CountDownLatch latch = new CountDownLatch(2);
-        AtomicReference<SearchResponse> responseA = new AtomicReference<>();
-        AtomicReference<SearchResponse> responseB = new AtomicReference<>();
-        AtomicReference<Exception> error = new AtomicReference<>();
+        // Fully async parallel execution using GroupedActionListener
+        GroupedActionListener<SearchResponse> groupedListener = new GroupedActionListener<>(
+            ActionListener.wrap(
+                responses -> {
+                    List<SearchResponse> responseList = new ArrayList<>(responses);
+                    SearchResponse responseA = responseList.get(0);
+                    SearchResponse responseB = responseList.get(1);
 
-        StashedThreadContext.run(client, () -> client.search(searchRequestA, new ActionListener<SearchResponse>() {
-            @Override
-            public void onResponse(SearchResponse r) {
-                responseA.set(r);
-                latch.countDown();
-            }
+                    // Apply Team Draft Interleaving to merge both result sets
+                    List<SearchHit> hitsA = Arrays.asList(responseA.getHits().getHits());
+                    List<SearchHit> hitsB = Arrays.asList(responseB.getHits().getHits());
+                    TeamDraftInterleaver.Result tdiResult = interleaver.interleave(hitsA, hitsB, Math.max(hitsA.size(), hitsB.size()));
 
-            @Override
-            public void onFailure(Exception e) {
-                error.compareAndSet(null, e);
-                latch.countDown();
-            }
-        }));
-        StashedThreadContext.run(client, () -> client.search(searchRequestB, new ActionListener<SearchResponse>() {
-            @Override
-            public void onResponse(SearchResponse r) {
-                responseB.set(r);
-                latch.countDown();
-            }
+                    // Map each hit with its team's config UUID for click attribution
+                    List<Map<String, Object>> responseHits = new ArrayList<>();
+                    Set<String> teamADocs = tdiResult.getTeamA();
+                    for (SearchHit hit : tdiResult.getInterleavedHits()) {
+                        String uuid = teamADocs.contains(hit.getId()) ? configAUuid : configBUuid;
+                        responseHits.add(mapHit(hit, uuid));
+                    }
+                    listener.onResponse(new ABTestSearchResponse(testId, true, responseHits));
+                },
+                e -> listener.onFailure(new SearchRelevanceException("Search execution failed", e, RestStatus.INTERNAL_SERVER_ERROR))
+            ),
+            2
+        );
 
-            @Override
-            public void onFailure(Exception e) {
-                error.compareAndSet(null, e);
-                latch.countDown();
-            }
-        }));
-
-        try {
-            if (!latch.await(SEARCH_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
-                listener.onFailure(new SearchRelevanceException("Search timeout", RestStatus.GATEWAY_TIMEOUT));
-                return;
-            }
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            listener.onFailure(new SearchRelevanceException("Search interrupted", e, RestStatus.INTERNAL_SERVER_ERROR));
-            return;
-        }
-        if (error.get() != null) {
-            listener.onFailure(new SearchRelevanceException("Search execution failed", error.get(), RestStatus.INTERNAL_SERVER_ERROR));
-            return;
-        }
-
-        List<SearchHit> hitsA = Arrays.asList(responseA.get().getHits().getHits());
-        List<SearchHit> hitsB = Arrays.asList(responseB.get().getHits().getHits());
-        TeamDraftInterleaver.Result tdiResult = interleaver.interleave(hitsA, hitsB, Math.max(hitsA.size(), hitsB.size()));
-
-        List<Map<String, Object>> responseHits = new ArrayList<>();
-        Set<String> teamADocs = tdiResult.getTeamA();
-        for (SearchHit hit : tdiResult.getInterleavedHits()) {
-            String uuid = teamADocs.contains(hit.getId()) ? configAUuid : configBUuid;
-            responseHits.add(mapHit(hit, uuid));
-        }
-        listener.onResponse(new ABTestSearchResponse(testId, true, responseHits));
+        StashedThreadContext.run(client, () -> client.search(searchRequestA, groupedListener));
+        StashedThreadContext.run(client, () -> client.search(searchRequestB, groupedListener));
     }
 
+    /**
+     * Executes a single search when the AB test is disabled (only config A).
+     * Fully async — no thread blocking.
+     */
     private void executeSingleSearch(
-        String targetIndex,
-        String query,
-        String pipeline,
+        SearchRequest searchRequest,
         String testId,
         String configUuid,
         ActionListener<ABTestSearchResponse> listener
     ) {
-        SearchRequest searchRequest = buildSearchRequest(targetIndex, query, pipeline);
-        CountDownLatch latch = new CountDownLatch(1);
-        AtomicReference<SearchResponse> responseRef = new AtomicReference<>();
-        AtomicReference<Exception> error = new AtomicReference<>();
-
-        StashedThreadContext.run(client, () -> client.search(searchRequest, new ActionListener<SearchResponse>() {
-            @Override
-            public void onResponse(SearchResponse r) {
-                responseRef.set(r);
-                latch.countDown();
-            }
-
-            @Override
-            public void onFailure(Exception e) {
-                error.set(e);
-                latch.countDown();
-            }
-        }));
-
-        try {
-            if (!latch.await(SEARCH_TIMEOUT_SECONDS, TimeUnit.SECONDS)) {
-                listener.onFailure(new SearchRelevanceException("Search timeout", RestStatus.GATEWAY_TIMEOUT));
-                return;
-            }
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            listener.onFailure(new SearchRelevanceException("Search interrupted", e, RestStatus.INTERNAL_SERVER_ERROR));
-            return;
-        }
-        if (error.get() != null) {
-            listener.onFailure(new SearchRelevanceException("Search execution failed", error.get(), RestStatus.INTERNAL_SERVER_ERROR));
-            return;
-        }
-
-        List<Map<String, Object>> responseHits = new ArrayList<>();
-        for (SearchHit hit : responseRef.get().getHits().getHits()) {
-            responseHits.add(mapHit(hit, configUuid));
-        }
-        listener.onResponse(new ABTestSearchResponse(testId, false, responseHits));
+        StashedThreadContext.run(client, () -> client.search(searchRequest, ActionListener.wrap(
+            searchResponse -> {
+                List<Map<String, Object>> responseHits = new ArrayList<>();
+                for (SearchHit hit : searchResponse.getHits().getHits()) {
+                    responseHits.add(mapHit(hit, configUuid));
+                }
+                listener.onResponse(new ABTestSearchResponse(testId, false, responseHits));
+            },
+            e -> listener.onFailure(new SearchRelevanceException("Search execution failed", e, RestStatus.INTERNAL_SERVER_ERROR))
+        )));
     }
 
+    /**
+     * Maps a SearchHit to a response map with config UUID for click attribution.
+     */
     private Map<String, Object> mapHit(SearchHit hit, String configUuid) {
         Map<String, Object> hitMap = new HashMap<>();
         hitMap.put("_index", hit.getIndex());
@@ -360,49 +270,4 @@ public class ABTestSearchTransportAction extends HandledTransportAction<ABTestSe
         return hitMap;
     }
 
-    private SearchRequest buildSearchRequest(String targetIndex, String queryBody, String searchPipeline) {
-        SearchRequest searchRequest = new SearchRequest(targetIndex);
-        SearchSourceBuilder sourceBuilder = new SearchSourceBuilder();
-        try {
-            Map<String, Object> queryMap = org.opensearch.common.xcontent.XContentHelper.convertToMap(
-                org.opensearch.common.xcontent.XContentType.JSON.xContent(),
-                queryBody,
-                false
-            );
-            if (queryMap.containsKey("query")) {
-                @SuppressWarnings("unchecked")
-                Map<String, Object> querySection = (Map<String, Object>) queryMap.get("query");
-                org.opensearch.core.xcontent.XContentBuilder xBuilder = org.opensearch.common.xcontent.XContentFactory.jsonBuilder();
-                xBuilder.map(querySection);
-                sourceBuilder.query(new org.opensearch.index.query.WrapperQueryBuilder(xBuilder.toString()));
-            }
-            if (queryMap.containsKey("size")) {
-                sourceBuilder.size(((Number) queryMap.get("size")).intValue());
-            }
-            if (queryMap.containsKey("_source")) {
-                @SuppressWarnings("unchecked")
-                Map<String, Object> sourceSection = (Map<String, Object>) queryMap.get("_source");
-                if (sourceSection.containsKey("excludes")) {
-                    @SuppressWarnings("unchecked")
-                    List<String> excludes = (List<String>) sourceSection.get("excludes");
-                    sourceBuilder.fetchSource(null, excludes.toArray(new String[0]));
-                }
-            }
-        } catch (IOException e) {
-            throw new SearchRelevanceException("Failed to parse query body", e, RestStatus.BAD_REQUEST);
-        }
-        searchRequest.source(sourceBuilder);
-        if (searchPipeline != null && !searchPipeline.isEmpty()) {
-            searchRequest.pipeline(searchPipeline);
-        }
-        return searchRequest;
-    }
-
-    private String substituteParams(String template, Map<String, String> params) {
-        String searchText = params.get("SearchText");
-        if (searchText == null || searchText.isEmpty()) {
-            throw new SearchRelevanceException("SearchText is required in query_params", RestStatus.BAD_REQUEST);
-        }
-        return template.replace(SEARCH_TEXT_PLACEHOLDER, searchText);
-    }
 }

--- a/src/test/java/org/opensearch/searchrelevance/BaseSearchRelevanceIT.java
+++ b/src/test/java/org/opensearch/searchrelevance/BaseSearchRelevanceIT.java
@@ -335,4 +335,29 @@ public class BaseSearchRelevanceIT extends OpenSearchRestTestCase {
         Response response = client().performRequest(request);
         assertEquals(request.getEndpoint() + ": failed", RestStatus.OK, RestStatus.fromCode(response.getStatusLine().getStatusCode()));
     }
+
+    protected void createTestIndex(String indexName) throws IOException {
+        makeRequest(
+            client(),
+            "PUT",
+            indexName,
+            null,
+            toHttpEntity("{\"settings\":{\"number_of_shards\":1,\"number_of_replicas\":0}}"),
+            ImmutableList.of(new BasicHeader(HttpHeaders.USER_AGENT, DEFAULT_USER_AGENT))
+        );
+    }
+
+    protected String createSearchConfiguration(String name, String index, String query) throws IOException {
+        String configBody = String.format("{\"name\":\"%s\",\"index\":\"%s\",\"query\":\"%s\"}", name, index, query.replace("\"", "\\\""));
+        Response response = makeRequest(
+            client(),
+            "PUT",
+            "/_plugins/_search_relevance/search_configurations",
+            null,
+            toHttpEntity(configBody),
+            ImmutableList.of(new BasicHeader(HttpHeaders.USER_AGENT, DEFAULT_USER_AGENT))
+        );
+        Map<String, Object> result = entityAsMap(response);
+        return (String) result.get("search_configuration_id");
+    }
 }

--- a/src/test/java/org/opensearch/searchrelevance/action/abTest/ABTestSearchIT.java
+++ b/src/test/java/org/opensearch/searchrelevance/action/abTest/ABTestSearchIT.java
@@ -1,0 +1,284 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+package org.opensearch.searchrelevance.action.abTest;
+
+import static org.opensearch.searchrelevance.common.PluginConstants.AB_TESTS_URL;
+
+import java.util.List;
+import java.util.Map;
+
+import org.apache.hc.core5.http.HttpHeaders;
+import org.apache.hc.core5.http.message.BasicHeader;
+import org.opensearch.client.Response;
+import org.opensearch.client.ResponseException;
+import org.opensearch.rest.RestRequest;
+import org.opensearch.searchrelevance.BaseSearchRelevanceIT;
+import org.opensearch.test.OpenSearchIntegTestCase;
+
+import com.carrotsearch.randomizedtesting.annotations.ThreadLeakScope;
+import com.google.common.collect.ImmutableList;
+
+import lombok.SneakyThrows;
+
+/**
+ * Integration tests for the AB Test Search API.
+ * Tests end-to-end flow: create test → search → verify response.
+ */
+@ThreadLeakScope(ThreadLeakScope.Scope.NONE)
+@OpenSearchIntegTestCase.ClusterScope(scope = OpenSearchIntegTestCase.Scope.SUITE)
+public class ABTestSearchIT extends BaseSearchRelevanceIT {
+
+    private static final String TEST_INDEX = "ab-test-search-it-index";
+
+    /** Happy path: enabled test returns interleaved results with UUID attribution per hit */
+    @SneakyThrows
+    public void testSearchWithEnabledTest() {
+        // Setup
+        createTestIndex(TEST_INDEX);
+        indexTestDocuments();
+
+        String configIdA = createSearchConfiguration("it-config-a", TEST_INDEX, "{\"query\":{\"match\":{\"title\":\"%SearchText%\"}}}");
+        String configIdB = createSearchConfiguration("it-config-b", TEST_INDEX, "{\"query\":{\"match_all\":{}}}");
+        createABTest("search-it-enabled", configIdA, configIdB);
+
+        // Execute search
+        Response response = makeRequest(
+            client(),
+            RestRequest.Method.POST.name(),
+            AB_TESTS_URL + "/search-it-enabled/_search",
+            null,
+            toHttpEntity("{\"query_params\":{\"SearchText\":\"laptop\"}}"),
+            ImmutableList.of(new BasicHeader(HttpHeaders.USER_AGENT, DEFAULT_USER_AGENT))
+        );
+
+        // Verify
+        Map<String, Object> result = entityAsMap(response);
+        assertEquals("search-it-enabled", result.get("test_id"));
+
+        @SuppressWarnings("unchecked")
+        List<Map<String, Object>> hits = (List<Map<String, Object>>) result.get("hits");
+        assertFalse("Should have interleaved hits", hits.isEmpty());
+        for (Map<String, Object> hit : hits) {
+            assertNotNull("Each hit should have _search_configuration_id", hit.get("_search_configuration_id"));
+        }
+    }
+
+    /** Disabled test executes only config A without interleaving */
+    @SneakyThrows
+    public void testSearchWithDisabledTest() {
+        // Setup
+        createTestIndex(TEST_INDEX);
+        indexTestDocuments();
+
+        String configIdA = createSearchConfiguration(
+            "it-config-disabled-a",
+            TEST_INDEX,
+            "{\"query\":{\"match\":{\"title\":\"%SearchText%\"}}}"
+        );
+        String configIdB = createSearchConfiguration("it-config-disabled-b", TEST_INDEX, "{\"query\":{\"match_all\":{}}}");
+        String testId = "search-it-disabled";
+        createABTest(testId, configIdA, configIdB);
+
+        // Disable the test
+        makeRequest(
+            client(),
+            RestRequest.Method.PUT.name(),
+            AB_TESTS_URL + "/" + testId + "/_update",
+            null,
+            toHttpEntity("{\"enabled\":false}"),
+            ImmutableList.of(new BasicHeader(HttpHeaders.USER_AGENT, DEFAULT_USER_AGENT))
+        );
+
+        // Execute search
+        Response response = makeRequest(
+            client(),
+            RestRequest.Method.POST.name(),
+            AB_TESTS_URL + "/" + testId + "/_search",
+            null,
+            toHttpEntity("{\"query_params\":{\"SearchText\":\"laptop\"}}"),
+            ImmutableList.of(new BasicHeader(HttpHeaders.USER_AGENT, DEFAULT_USER_AGENT))
+        );
+
+        // Verify
+        Map<String, Object> result = entityAsMap(response);
+        assertEquals(testId, result.get("test_id"));
+    }
+
+    /** Non-existent test ID returns 404 */
+    @SneakyThrows
+    public void testSearchWithNonExistentTest() {
+        try {
+            makeRequest(
+                client(),
+                RestRequest.Method.POST.name(),
+                AB_TESTS_URL + "/non-existent-test/_search",
+                null,
+                toHttpEntity("{\"query_params\":{\"SearchText\":\"laptop\"}}"),
+                ImmutableList.of(new BasicHeader(HttpHeaders.USER_AGENT, DEFAULT_USER_AGENT))
+            );
+            fail("Expected 404 for non-existent test");
+        } catch (ResponseException e) {
+            assertEquals(404, e.getResponse().getStatusLine().getStatusCode());
+        }
+    }
+
+    /** Empty query_params map returns 400 */
+    @SneakyThrows
+    public void testSearchWithMissingQueryParams() {
+        // Setup
+        createTestIndex(TEST_INDEX);
+        indexTestDocuments();
+
+        String configIdA = createSearchConfiguration(
+            "it-config-missing-a",
+            TEST_INDEX,
+            "{\"query\":{\"match\":{\"title\":\"%SearchText%\"}}}"
+        );
+        String configIdB = createSearchConfiguration("it-config-missing-b", TEST_INDEX, "{\"query\":{\"match_all\":{}}}");
+        createABTest("search-it-missing-params", configIdA, configIdB);
+
+        try {
+            makeRequest(
+                client(),
+                RestRequest.Method.POST.name(),
+                AB_TESTS_URL + "/search-it-missing-params/_search",
+                null,
+                toHttpEntity("{\"query_params\":{}}"),
+                ImmutableList.of(new BasicHeader(HttpHeaders.USER_AGENT, DEFAULT_USER_AGENT))
+            );
+            fail("Expected 400 for missing query params");
+        } catch (ResponseException e) {
+            assertEquals(400, e.getResponse().getStatusLine().getStatusCode());
+        }
+    }
+
+    /** query_params without SearchText key returns 400 */
+    @SneakyThrows
+    public void testSearchWithMissingSearchText() {
+        // Setup
+        createTestIndex(TEST_INDEX);
+        indexTestDocuments();
+
+        String configIdA = createSearchConfiguration(
+            "it-config-nosearch-a",
+            TEST_INDEX,
+            "{\"query\":{\"match\":{\"title\":\"%SearchText%\"}}}"
+        );
+        String configIdB = createSearchConfiguration("it-config-nosearch-b", TEST_INDEX, "{\"query\":{\"match_all\":{}}}");
+        createABTest("search-it-no-searchtext", configIdA, configIdB);
+
+        try {
+            makeRequest(
+                client(),
+                RestRequest.Method.POST.name(),
+                AB_TESTS_URL + "/search-it-no-searchtext/_search",
+                null,
+                toHttpEntity("{\"query_params\":{\"SomeOtherParam\":\"value\"}}"),
+                ImmutableList.of(new BasicHeader(HttpHeaders.USER_AGENT, DEFAULT_USER_AGENT))
+            );
+            fail("Expected 400 for missing SearchText");
+        } catch (ResponseException e) {
+            assertEquals(400, e.getResponse().getStatusLine().getStatusCode());
+        }
+    }
+
+    /** Configs targeting different indices returns 400 — TDI requires same index */
+    @SneakyThrows
+    public void testSearchWithDifferentIndices() {
+        // Setup: create two configs targeting different indices
+        createTestIndex(TEST_INDEX);
+        createTestIndex(TEST_INDEX + "-other");
+        indexTestDocuments();
+
+        String configIdA = createSearchConfiguration(
+            "it-config-diff-idx-a",
+            TEST_INDEX,
+            "{\"query\":{\"match\":{\"title\":\"%SearchText%\"}}}"
+        );
+        String configIdB = createSearchConfiguration("it-config-diff-idx-b", TEST_INDEX + "-other", "{\"query\":{\"match_all\":{}}}");
+        createABTest("search-it-diff-index", configIdA, configIdB);
+
+        try {
+            makeRequest(
+                client(),
+                RestRequest.Method.POST.name(),
+                AB_TESTS_URL + "/search-it-diff-index/_search",
+                null,
+                toHttpEntity("{\"query_params\":{\"SearchText\":\"laptop\"}}"),
+                ImmutableList.of(new BasicHeader(HttpHeaders.USER_AGENT, DEFAULT_USER_AGENT))
+            );
+            fail("Expected 400 for different target indices");
+        } catch (ResponseException e) {
+            assertEquals(400, e.getResponse().getStatusLine().getStatusCode());
+        }
+    }
+
+    // TODO: Size validation test — currently size is embedded inside the query string,
+    // not a top-level config field. Size validation will be added when config schema supports it.
+
+    /** SearchText exceeding 1024 characters returns 400 */
+    @SneakyThrows
+    public void testSearchWithTooLongSearchText() {
+        // Setup
+        createTestIndex(TEST_INDEX);
+        indexTestDocuments();
+
+        String configIdA = createSearchConfiguration(
+            "it-config-long-a",
+            TEST_INDEX,
+            "{\"query\":{\"match\":{\"title\":\"%SearchText%\"}}}"
+        );
+        String configIdB = createSearchConfiguration("it-config-long-b", TEST_INDEX, "{\"query\":{\"match_all\":{}}}");
+        createABTest("search-it-long-text", configIdA, configIdB);
+
+        // Create a string longer than 1024 characters
+        String longText = "a".repeat(1025);
+
+        try {
+            makeRequest(
+                client(),
+                RestRequest.Method.POST.name(),
+                AB_TESTS_URL + "/search-it-long-text/_search",
+                null,
+                toHttpEntity("{\"query_params\":{\"SearchText\":\"" + longText + "\"}}"),
+                ImmutableList.of(new BasicHeader(HttpHeaders.USER_AGENT, DEFAULT_USER_AGENT))
+            );
+            fail("Expected 400 for SearchText exceeding max length");
+        } catch (ResponseException e) {
+            assertEquals(400, e.getResponse().getStatusLine().getStatusCode());
+        }
+    }
+
+    private void indexTestDocuments() throws Exception {
+        String bulkBody = "{ \"index\": { \"_index\": \""
+            + TEST_INDEX
+            + "\", \"_id\": \"1\" } }\n"
+            + "{ \"title\": \"laptop pro\", \"category\": \"electronics\" }\n"
+            + "{ \"index\": { \"_index\": \""
+            + TEST_INDEX
+            + "\", \"_id\": \"2\" } }\n"
+            + "{ \"title\": \"wireless mouse\", \"category\": \"electronics\" }\n"
+            + "{ \"index\": { \"_index\": \""
+            + TEST_INDEX
+            + "\", \"_id\": \"3\" } }\n"
+            + "{ \"title\": \"laptop stand\", \"category\": \"accessories\" }\n";
+        bulkIngest(TEST_INDEX, bulkBody);
+    }
+
+    private void createABTest(String testId, String configIdA, String configIdB) throws Exception {
+        String abTestBody = String.format("{\"search_configuration_a\":\"%s\",\"search_configuration_b\":\"%s\"}", configIdA, configIdB);
+        makeRequest(
+            client(),
+            RestRequest.Method.PUT.name(),
+            AB_TESTS_URL + "/" + testId,
+            null,
+            toHttpEntity(abTestBody),
+            ImmutableList.of(new BasicHeader(HttpHeaders.USER_AGENT, DEFAULT_USER_AGENT))
+        );
+    }
+}

--- a/src/test/java/org/opensearch/searchrelevance/action/abTest/ABTestSearchSecurityIT.java
+++ b/src/test/java/org/opensearch/searchrelevance/action/abTest/ABTestSearchSecurityIT.java
@@ -8,13 +8,9 @@
 package org.opensearch.searchrelevance.action.abTest;
 
 import static org.opensearch.searchrelevance.common.PluginConstants.AB_TESTS_URL;
-import static org.opensearch.searchrelevance.common.PluginConstants.SEARCH_CONFIGURATIONS_URL;
-
-import java.util.Map;
 
 import org.apache.hc.core5.http.HttpHeaders;
 import org.apache.hc.core5.http.message.BasicHeader;
-import org.opensearch.client.Response;
 import org.opensearch.client.ResponseException;
 import org.opensearch.rest.RestRequest;
 import org.opensearch.searchrelevance.BaseSearchRelevanceIT;
@@ -57,17 +53,8 @@ public class ABTestSearchSecurityIT extends BaseSearchRelevanceIT {
             return;
         }
 
-        // Step 1: Create test index as admin
-        makeRequest(
-            client(),
-            RestRequest.Method.PUT.name(),
-            TEST_INDEX,
-            null,
-            toHttpEntity("{\"settings\":{\"number_of_shards\":1,\"number_of_replicas\":0}}"),
-            ImmutableList.of(new BasicHeader(HttpHeaders.USER_AGENT, DEFAULT_USER_AGENT))
-        );
-
-        // Index a document
+        // Step 1: Create test index and index a document
+        createTestIndex(TEST_INDEX);
         makeRequest(
             client(),
             RestRequest.Method.POST.name(),
@@ -77,37 +64,13 @@ public class ABTestSearchSecurityIT extends BaseSearchRelevanceIT {
             ImmutableList.of(new BasicHeader(HttpHeaders.USER_AGENT, DEFAULT_USER_AGENT))
         );
 
-        // Step 2: Create search configuration A
-        String configBodyA = String.format(
-            "{\"name\":\"security-test-config-a\",\"index\":\"%s\",\"query\":\"{\\\"query\\\":{\\\"match\\\":{\\\"title\\\":\\\"%%SearchText%%\\\"}}}\"}",
-            TEST_INDEX
+        // Step 2: Create two different search configurations
+        String configIdA = createSearchConfiguration(
+            "security-test-config-a",
+            TEST_INDEX,
+            "{\"query\":{\"match\":{\"title\":\"%SearchText%\"}}}"
         );
-        Response configResponseA = makeRequest(
-            client(),
-            RestRequest.Method.PUT.name(),
-            SEARCH_CONFIGURATIONS_URL,
-            null,
-            toHttpEntity(configBodyA),
-            ImmutableList.of(new BasicHeader(HttpHeaders.USER_AGENT, DEFAULT_USER_AGENT))
-        );
-        Map<String, Object> configResultA = entityAsMap(configResponseA);
-        String configIdA = (String) configResultA.get("search_configuration_id");
-
-        // Step 2b: Create search configuration B
-        String configBodyB = String.format(
-            "{\"name\":\"security-test-config-b\",\"index\":\"%s\",\"query\":\"{\\\"query\\\":{\\\"match_all\\\":{}}}\"}",
-            TEST_INDEX
-        );
-        Response configResponseB = makeRequest(
-            client(),
-            RestRequest.Method.PUT.name(),
-            SEARCH_CONFIGURATIONS_URL,
-            null,
-            toHttpEntity(configBodyB),
-            ImmutableList.of(new BasicHeader(HttpHeaders.USER_AGENT, DEFAULT_USER_AGENT))
-        );
-        Map<String, Object> configResultB = entityAsMap(configResponseB);
-        String configIdB = (String) configResultB.get("search_configuration_id");
+        String configIdB = createSearchConfiguration("security-test-config-b", TEST_INDEX, "{\"query\":{\"match_all\":{}}}");
 
         // Step 3: Create AB test with two different configurations
         String abTestBody = String.format("{\"search_configuration_a\":\"%s\",\"search_configuration_b\":\"%s\"}", configIdA, configIdB);

--- a/src/test/java/org/opensearch/searchrelevance/action/abTest/ABTestSearchSecurityIT.java
+++ b/src/test/java/org/opensearch/searchrelevance/action/abTest/ABTestSearchSecurityIT.java
@@ -1,0 +1,181 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+package org.opensearch.searchrelevance.action.abTest;
+
+import static org.opensearch.searchrelevance.common.PluginConstants.AB_TESTS_URL;
+import static org.opensearch.searchrelevance.common.PluginConstants.SEARCH_CONFIGURATIONS_URL;
+
+import java.util.Map;
+
+import org.apache.hc.core5.http.HttpHeaders;
+import org.apache.hc.core5.http.message.BasicHeader;
+import org.opensearch.client.Response;
+import org.opensearch.client.ResponseException;
+import org.opensearch.rest.RestRequest;
+import org.opensearch.searchrelevance.BaseSearchRelevanceIT;
+import org.opensearch.test.OpenSearchIntegTestCase;
+
+import com.carrotsearch.randomizedtesting.annotations.ThreadLeakScope;
+import com.google.common.collect.ImmutableList;
+
+import lombok.SneakyThrows;
+
+/**
+ * Security-enabled integration test for AB Test Search API.
+ * Verifies that FGAC is enforced when searching target indices — a user without
+ * index-level read permissions must not be able to retrieve results via the AB test search endpoint.
+ *
+ * Run with: ./gradlew integTest -Dsecurity=true -Dhttps=true
+ */
+@ThreadLeakScope(ThreadLeakScope.Scope.NONE)
+@OpenSearchIntegTestCase.ClusterScope(scope = OpenSearchIntegTestCase.Scope.SUITE)
+public class ABTestSearchSecurityIT extends BaseSearchRelevanceIT {
+
+    private static final String TEST_INDEX = "ab-test-security-index";
+    private static final String TEST_ID = "security-fgac-test";
+    private static final String RESTRICTED_USER = "restricted_user";
+    private static final String RESTRICTED_PASSWORD = "RestrictedPass@12345!";
+    private static final String RESTRICTED_ROLE = "no_target_index_access";
+
+    @Override
+    public boolean isUpdateClusterSettings() {
+        return isHttps();
+    }
+
+    /**
+     * Tests that a user without read access to the target index cannot retrieve
+     * search results through the AB test search API (FGAC enforcement).
+     */
+    @SneakyThrows
+    public void testABTestSearchDeniedForRestrictedUser() {
+        if (!isHttps()) {
+            return;
+        }
+
+        // Step 1: Create test index as admin
+        makeRequest(
+            client(),
+            RestRequest.Method.PUT.name(),
+            TEST_INDEX,
+            null,
+            toHttpEntity("{\"settings\":{\"number_of_shards\":1,\"number_of_replicas\":0}}"),
+            ImmutableList.of(new BasicHeader(HttpHeaders.USER_AGENT, DEFAULT_USER_AGENT))
+        );
+
+        // Index a document
+        makeRequest(
+            client(),
+            RestRequest.Method.POST.name(),
+            TEST_INDEX + "/_doc/1?refresh=true",
+            null,
+            toHttpEntity("{\"title\":\"test document\"}"),
+            ImmutableList.of(new BasicHeader(HttpHeaders.USER_AGENT, DEFAULT_USER_AGENT))
+        );
+
+        // Step 2: Create search configuration A
+        String configBodyA = String.format(
+            "{\"name\":\"security-test-config-a\",\"index\":\"%s\",\"query\":\"{\\\"query\\\":{\\\"match\\\":{\\\"title\\\":\\\"%%SearchText%%\\\"}}}\"}",
+            TEST_INDEX
+        );
+        Response configResponseA = makeRequest(
+            client(),
+            RestRequest.Method.PUT.name(),
+            SEARCH_CONFIGURATIONS_URL,
+            null,
+            toHttpEntity(configBodyA),
+            ImmutableList.of(new BasicHeader(HttpHeaders.USER_AGENT, DEFAULT_USER_AGENT))
+        );
+        Map<String, Object> configResultA = entityAsMap(configResponseA);
+        String configIdA = (String) configResultA.get("search_configuration_id");
+
+        // Step 2b: Create search configuration B
+        String configBodyB = String.format(
+            "{\"name\":\"security-test-config-b\",\"index\":\"%s\",\"query\":\"{\\\"query\\\":{\\\"match_all\\\":{}}}\"}",
+            TEST_INDEX
+        );
+        Response configResponseB = makeRequest(
+            client(),
+            RestRequest.Method.PUT.name(),
+            SEARCH_CONFIGURATIONS_URL,
+            null,
+            toHttpEntity(configBodyB),
+            ImmutableList.of(new BasicHeader(HttpHeaders.USER_AGENT, DEFAULT_USER_AGENT))
+        );
+        Map<String, Object> configResultB = entityAsMap(configResponseB);
+        String configIdB = (String) configResultB.get("search_configuration_id");
+
+        // Step 3: Create AB test with two different configurations
+        String abTestBody = String.format("{\"search_configuration_a\":\"%s\",\"search_configuration_b\":\"%s\"}", configIdA, configIdB);
+        makeRequest(
+            client(),
+            RestRequest.Method.PUT.name(),
+            AB_TESTS_URL + "/" + TEST_ID,
+            null,
+            toHttpEntity(abTestBody),
+            ImmutableList.of(new BasicHeader(HttpHeaders.USER_AGENT, DEFAULT_USER_AGENT))
+        );
+
+        // Step 4: Create restricted role (plugin access but no target index access)
+        makeRequest(
+            client(),
+            RestRequest.Method.PUT.name(),
+            "_plugins/_security/api/roles/" + RESTRICTED_ROLE,
+            null,
+            toHttpEntity(
+                "{\"cluster_permissions\":[\"cluster:admin/opensearch/search_relevance/*\"],"
+                    + "\"index_permissions\":[{\"index_patterns\":[\"no-access-index*\"],\"allowed_actions\":[\"indices:data/read*\"]}]}"
+            ),
+            ImmutableList.of(new BasicHeader(HttpHeaders.USER_AGENT, DEFAULT_USER_AGENT))
+        );
+
+        // Step 5: Create restricted user
+        makeRequest(
+            client(),
+            RestRequest.Method.PUT.name(),
+            "_plugins/_security/api/internalusers/" + RESTRICTED_USER,
+            null,
+            toHttpEntity("{\"password\":\"" + RESTRICTED_PASSWORD + "\",\"backend_roles\":[]}"),
+            ImmutableList.of(new BasicHeader(HttpHeaders.USER_AGENT, DEFAULT_USER_AGENT))
+        );
+
+        // Step 6: Map role to user
+        makeRequest(
+            client(),
+            RestRequest.Method.PUT.name(),
+            "_plugins/_security/api/rolesmapping/" + RESTRICTED_ROLE,
+            null,
+            toHttpEntity("{\"users\":[\"" + RESTRICTED_USER + "\"]}"),
+            ImmutableList.of(new BasicHeader(HttpHeaders.USER_AGENT, DEFAULT_USER_AGENT))
+        );
+
+        // Step 7: Call AB test search as restricted user — should fail with 403
+        String searchBody = "{\"query_params\":{\"SearchText\":\"test\"}}";
+        try {
+            makeRequest(
+                client(),
+                RestRequest.Method.POST.name(),
+                AB_TESTS_URL + "/" + TEST_ID + "/_search",
+                null,
+                toHttpEntity(searchBody),
+                ImmutableList.of(
+                    new BasicHeader(HttpHeaders.USER_AGENT, DEFAULT_USER_AGENT),
+                    new BasicHeader(HttpHeaders.AUTHORIZATION, basicAuthHeaderValue(RESTRICTED_USER, RESTRICTED_PASSWORD))
+                )
+            );
+            fail("Expected security exception for restricted user searching target index");
+        } catch (ResponseException e) {
+            int statusCode = e.getResponse().getStatusLine().getStatusCode();
+            assertEquals("Expected 403 Forbidden for restricted user", 403, statusCode);
+        }
+    }
+
+    private String basicAuthHeaderValue(String username, String password) {
+        String credentials = username + ":" + password;
+        return "Basic " + java.util.Base64.getEncoder().encodeToString(credentials.getBytes(java.nio.charset.StandardCharsets.UTF_8));
+    }
+}

--- a/src/test/java/org/opensearch/searchrelevance/algorithm/TeamDraftInterleaverTests.java
+++ b/src/test/java/org/opensearch/searchrelevance/algorithm/TeamDraftInterleaverTests.java
@@ -57,9 +57,8 @@ public class TeamDraftInterleaverTests extends OpenSearchTestCase {
 
         TeamDraftInterleaver.Result result = interleaver.interleave(hitsA, hitsB, 5);
 
-        long doc1Count = result.getInterleavedHits().stream().filter(h -> h.getId().equals("doc1")).count();   // once the interleavig is
-                                                                                                               // performed, we count how
-                                                                                                               // many times "doc 1" appears
+        // Once the interleaving is performed, count how many times "doc1" appears
+        long doc1Count = result.getInterleavedHits().stream().filter(h -> h.getId().equals("doc1")).count();
                                                                                                                // in the result. must be
                                                                                                                // exactly 1 and not greater.
         assertEquals(1, doc1Count);

--- a/src/test/java/org/opensearch/searchrelevance/algorithm/TeamDraftInterleaverTests.java
+++ b/src/test/java/org/opensearch/searchrelevance/algorithm/TeamDraftInterleaverTests.java
@@ -59,8 +59,8 @@ public class TeamDraftInterleaverTests extends OpenSearchTestCase {
 
         // Once the interleaving is performed, count how many times "doc1" appears
         long doc1Count = result.getInterleavedHits().stream().filter(h -> h.getId().equals("doc1")).count();
-                                                                                                               // in the result. must be
-                                                                                                               // exactly 1 and not greater.
+        // in the result. must be
+        // exactly 1 and not greater.
         assertEquals(1, doc1Count);
     }
 

--- a/src/test/java/org/opensearch/searchrelevance/algorithm/TeamDraftInterleaverTests.java
+++ b/src/test/java/org/opensearch/searchrelevance/algorithm/TeamDraftInterleaverTests.java
@@ -1,0 +1,142 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+package org.opensearch.searchrelevance.algorithm;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+
+import org.opensearch.search.SearchHit;
+import org.opensearch.test.OpenSearchTestCase;
+
+public class TeamDraftInterleaverTests extends OpenSearchTestCase {
+
+    private final TeamDraftInterleaver interleaver = new TeamDraftInterleaver();
+
+    private List<SearchHit> createHits(String... ids) {
+        List<SearchHit> hits = new ArrayList<>();
+        for (int i = 0; i < ids.length; i++) {
+            hits.add(new SearchHit(i + 1, ids[i], Collections.emptyMap(), Collections.emptyMap()));
+        }
+        return hits;
+    }
+
+    public void testBothListsContributed() { // happy path
+        List<SearchHit> hitsA = createHits("a1", "a2", "a3");
+        List<SearchHit> hitsB = createHits("b1", "b2", "b3");
+
+        TeamDraftInterleaver.Result result = interleaver.interleave(hitsA, hitsB, 6);
+
+        assertFalse(result.getTeamA().isEmpty());
+        assertFalse(result.getTeamB().isEmpty());
+        assertEquals(6, result.getInterleavedHits().size());
+    }
+
+    public void testNoDuplicatesInResult() {
+        List<SearchHit> hitsA = createHits("a1", "a2", "a3");
+        List<SearchHit> hitsB = createHits("b1", "b2", "b3");
+
+        TeamDraftInterleaver.Result result = interleaver.interleave(hitsA, hitsB, 6);
+
+        Set<String> seen = new java.util.HashSet<>();  // seen is a set that checks if the item already exists. If that happens --> test
+                                                       // fails
+        for (SearchHit hit : result.getInterleavedHits()) {
+            assertTrue("Duplicate found: " + hit.getId(), seen.add(hit.getId()));
+        }
+    }
+
+    public void testOverlappingDocsDeduplicated() {
+        List<SearchHit> hitsA = createHits("doc1", "doc2", "doc3");
+        List<SearchHit> hitsB = createHits("doc1", "doc4", "doc5");
+
+        TeamDraftInterleaver.Result result = interleaver.interleave(hitsA, hitsB, 5);
+
+        long doc1Count = result.getInterleavedHits().stream().filter(h -> h.getId().equals("doc1")).count();   // once the interleavig is
+                                                                                                               // performed, we count how
+                                                                                                               // many times "doc 1" appears
+                                                                                                               // in the result. must be
+                                                                                                               // exactly 1 and not greater.
+        assertEquals(1, doc1Count);
+    }
+
+    public void testOverlappingDocAssignedToOneTeam() {
+        List<SearchHit> hitsA = createHits("shared", "a1", "a2");
+        List<SearchHit> hitsB = createHits("shared", "b1", "b2");
+
+        TeamDraftInterleaver.Result result = interleaver.interleave(hitsA, hitsB, 5);
+
+        boolean inA = result.getTeamA().contains("shared");
+        boolean inB = result.getTeamB().contains("shared");
+        assertTrue("shared must be in exactly one team", inA ^ inB);            // XOR operation is used which will check exactly one must
+                                                                                // be true. not both, not neither.
+    }
+
+    public void testSizeLimitRespected() {
+        List<SearchHit> hitsA = createHits("a1", "a2", "a3", "a4", "a5");
+        List<SearchHit> hitsB = createHits("b1", "b2", "b3", "b4", "b5");
+
+        TeamDraftInterleaver.Result result = interleaver.interleave(hitsA, hitsB, 4);
+
+        assertEquals(4, result.getInterleavedHits().size());
+    }
+
+    public void testEmptyListA() {
+        List<SearchHit> hitsA = createHits();
+        List<SearchHit> hitsB = createHits("b1", "b2", "b3");
+
+        TeamDraftInterleaver.Result result = interleaver.interleave(hitsA, hitsB, 3);
+
+        assertEquals(3, result.getInterleavedHits().size());
+        assertTrue(result.getTeamA().isEmpty());
+        assertEquals(3, result.getTeamB().size());
+    }
+
+    public void testEmptyListB() {
+        List<SearchHit> hitsA = createHits("a1", "a2", "a3");
+        List<SearchHit> hitsB = createHits();
+
+        TeamDraftInterleaver.Result result = interleaver.interleave(hitsA, hitsB, 3);
+
+        assertEquals(3, result.getInterleavedHits().size());
+        assertEquals(3, result.getTeamA().size());
+        assertTrue(result.getTeamB().isEmpty());
+    }
+
+    public void testBothListsEmpty() {
+        List<SearchHit> hitsA = createHits();
+        List<SearchHit> hitsB = createHits();
+
+        TeamDraftInterleaver.Result result = interleaver.interleave(hitsA, hitsB, 5);
+
+        assertEquals(0, result.getInterleavedHits().size());
+    }
+
+    public void testTeamAssignmentCoversAllHits() {
+        List<SearchHit> hitsA = createHits("a1", "a2", "a3");
+        List<SearchHit> hitsB = createHits("b1", "b2", "b3");
+
+        TeamDraftInterleaver.Result result = interleaver.interleave(hitsA, hitsB, 6);
+
+        for (SearchHit hit : result.getInterleavedHits()) {
+            boolean inA = result.getTeamA().contains(hit.getId());
+            boolean inB = result.getTeamB().contains(hit.getId());
+            assertTrue("Hit " + hit.getId() + " must belong to a team", inA || inB);
+            assertFalse("Hit " + hit.getId() + " can't be in both teams", inA && inB);
+        }
+    }
+
+    public void testUnequalListSizes() {
+        List<SearchHit> hitsA = createHits("a1", "a2");
+        List<SearchHit> hitsB = createHits("b1", "b2", "b3", "b4", "b5");
+
+        TeamDraftInterleaver.Result result = interleaver.interleave(hitsA, hitsB, 7);
+
+        assertEquals(7, result.getInterleavedHits().size());
+    }
+}

--- a/src/test/java/org/opensearch/searchrelevance/plugin/SearchRelevancePluginTests.java
+++ b/src/test/java/org/opensearch/searchrelevance/plugin/SearchRelevancePluginTests.java
@@ -119,6 +119,7 @@ public class SearchRelevancePluginTests extends OpenSearchTestCase {
         ScheduledJobsDao.class,
         ScheduledExperimentHistoryDao.class,
         org.opensearch.searchrelevance.dao.ABTestDao.class,
+        org.opensearch.searchrelevance.algorithm.TeamDraftInterleaver.class,
         MLAccessor.class,
         MetricsHelper.class,
         InfoStatsManager.class,

--- a/src/test/java/org/opensearch/searchrelevance/plugin/SearchRelevancePluginTests.java
+++ b/src/test/java/org/opensearch/searchrelevance/plugin/SearchRelevancePluginTests.java
@@ -204,7 +204,7 @@ public class SearchRelevancePluginTests extends OpenSearchTestCase {
     }
 
     public void testTotalRestHandlers() {
-        assertEquals(26, plugin.getRestHandlers(Settings.EMPTY, null, null, null, null, null, null).size());
+        assertEquals(27, plugin.getRestHandlers(Settings.EMPTY, null, null, null, null, null, null).size());
     }
 
     public void testQuerySetTransportIsAdded() {

--- a/src/test/java/org/opensearch/searchrelevance/transport/abTest/ABTestSearchTransportActionTests.java
+++ b/src/test/java/org/opensearch/searchrelevance/transport/abTest/ABTestSearchTransportActionTests.java
@@ -305,7 +305,7 @@ public class ABTestSearchTransportActionTests extends OpenSearchTestCase {
         ABTestSearchResponse response = responseCaptor.getValue();
         assertEquals("my-test", response.getTestId());
         assertNotNull(response.getHits());
-        assertEquals(3, response.getHits().size());
+        assertEquals(6, response.getHits().size());
     }
 
     /**

--- a/src/test/java/org/opensearch/searchrelevance/transport/abTest/ABTestSearchTransportActionTests.java
+++ b/src/test/java/org/opensearch/searchrelevance/transport/abTest/ABTestSearchTransportActionTests.java
@@ -8,7 +8,6 @@
 package org.opensearch.searchrelevance.transport.abTest;
 
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -17,6 +16,7 @@ import static org.mockito.Mockito.when;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ExecutorService;
 
 import org.apache.lucene.search.TotalHits;
 import org.junit.Before;
@@ -37,8 +37,6 @@ import org.opensearch.test.OpenSearchTestCase;
 import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.transport.TransportService;
 import org.opensearch.transport.client.Client;
-
-import java.util.concurrent.ExecutorService;
 
 public class ABTestSearchTransportActionTests extends OpenSearchTestCase {
 
@@ -414,9 +412,7 @@ public class ABTestSearchTransportActionTests extends OpenSearchTestCase {
         // Every hit must have a _search_configuration_id assigned
         for (Map<String, Object> hit : response.getHits()) {
             assertNotNull(hit.get("_search_configuration_id"));
-            assertTrue(
-                hit.get("_search_configuration_id").equals("uuid-a") || hit.get("_search_configuration_id").equals("uuid-b")
-            );
+            assertTrue(hit.get("_search_configuration_id").equals("uuid-a") || hit.get("_search_configuration_id").equals("uuid-b"));
         }
     }
 

--- a/src/test/java/org/opensearch/searchrelevance/transport/abTest/ABTestSearchTransportActionTests.java
+++ b/src/test/java/org/opensearch/searchrelevance/transport/abTest/ABTestSearchTransportActionTests.java
@@ -252,7 +252,7 @@ public class ABTestSearchTransportActionTests extends OpenSearchTestCase {
         verify(listener).onResponse(responseCaptor.capture());
         ABTestSearchResponse response = responseCaptor.getValue();
         assertEquals("my-test", response.getTestId());
-        assertFalse(response.isInterleaved());
+        // Response no longer contains interleaved field
         assertEquals(3, response.getHits().size());
     }
 
@@ -304,7 +304,7 @@ public class ABTestSearchTransportActionTests extends OpenSearchTestCase {
         verify(listener).onResponse(responseCaptor.capture());
         ABTestSearchResponse response = responseCaptor.getValue();
         assertEquals("my-test", response.getTestId());
-        assertTrue(response.isInterleaved());
+        assertNotNull(response.getHits());
         assertEquals(6, response.getHits().size());
     }
 
@@ -356,7 +356,7 @@ public class ABTestSearchTransportActionTests extends OpenSearchTestCase {
         ArgumentCaptor<ABTestSearchResponse> responseCaptor = ArgumentCaptor.forClass(ABTestSearchResponse.class);
         verify(listener).onResponse(responseCaptor.capture());
         ABTestSearchResponse response = responseCaptor.getValue();
-        assertTrue(response.isInterleaved());
+        assertNotNull(response.getHits());
         // Overlapping docs should appear only once in the interleaved list
         long uniqueDocCount = response.getHits().stream().map(h -> h.get("_id")).distinct().count();
         assertEquals(uniqueDocCount, response.getHits().size());

--- a/src/test/java/org/opensearch/searchrelevance/transport/abTest/ABTestSearchTransportActionTests.java
+++ b/src/test/java/org/opensearch/searchrelevance/transport/abTest/ABTestSearchTransportActionTests.java
@@ -1,0 +1,208 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+package org.opensearch.searchrelevance.transport.abTest;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.lucene.search.TotalHits;
+import org.junit.Before;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.opensearch.action.search.SearchResponse;
+import org.opensearch.action.support.ActionFilters;
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.core.common.bytes.BytesReference;
+import org.opensearch.core.rest.RestStatus;
+import org.opensearch.search.SearchHit;
+import org.opensearch.search.SearchHits;
+import org.opensearch.searchrelevance.dao.ABTestDao;
+import org.opensearch.searchrelevance.dao.SearchConfigurationDao;
+import org.opensearch.searchrelevance.model.ABTest;
+import org.opensearch.test.OpenSearchTestCase;
+import org.opensearch.threadpool.ThreadPool;
+import org.opensearch.transport.TransportService;
+import org.opensearch.transport.client.Client;
+
+public class ABTestSearchTransportActionTests extends OpenSearchTestCase {
+
+    @Mock
+    private TransportService transportService;
+    @Mock
+    private ActionFilters actionFilters;
+    @Mock
+    private ABTestDao abTestDao;
+    @Mock
+    private SearchConfigurationDao searchConfigurationDao;
+    @Mock
+    private Client client;
+    @Mock
+    private ThreadPool threadPool;
+
+    private ABTestSearchTransportAction transportAction;
+
+    @Before
+    public void setup() {
+        MockitoAnnotations.openMocks(this);
+        transportAction = new ABTestSearchTransportAction(
+            transportService,
+            actionFilters,
+            abTestDao,
+            searchConfigurationDao,
+            client,
+            threadPool
+        );
+    }
+
+    private SearchResponse createABTestResponse(boolean enabled) {
+        Map<String, Object> source = new HashMap<>();
+        source.put(ABTest.TEST_ID, "my-test");
+        source.put(ABTest.SEARCH_CONFIGURATION_A, "config-a-id");
+        source.put(ABTest.SEARCH_CONFIGURATION_B, "config-b-id");
+        source.put(ABTest.CONFIG_A_UUID, "uuid-a");
+        source.put(ABTest.CONFIG_B_UUID, "uuid-b");
+        source.put(ABTest.ENABLED, enabled);
+
+        SearchHit hit = new SearchHit(1, "my-test", Collections.emptyMap(), Collections.emptyMap());
+        hit.sourceRef(BytesReference.bytes(createXContentFromMap(source)));
+        SearchHits hits = new SearchHits(new SearchHit[] { hit }, new TotalHits(1, TotalHits.Relation.EQUAL_TO), 1.0f);
+        SearchResponse response = mock(SearchResponse.class);
+        org.mockito.Mockito.when(response.getHits()).thenReturn(hits);
+        return response;
+    }
+
+    private SearchResponse createConfigResponse(String query, String index) {
+        Map<String, Object> source = new HashMap<>();
+        source.put("query", query);
+        source.put("index", index);
+        source.put("searchPipeline", "");
+
+        SearchHit hit = new SearchHit(1, "config-id", Collections.emptyMap(), Collections.emptyMap());
+        hit.sourceRef(BytesReference.bytes(createXContentFromMap(source)));
+        SearchHits hits = new SearchHits(new SearchHit[] { hit }, new TotalHits(1, TotalHits.Relation.EQUAL_TO), 1.0f);
+        SearchResponse response = mock(SearchResponse.class);
+        org.mockito.Mockito.when(response.getHits()).thenReturn(hits);
+        return response;
+    }
+
+    private org.opensearch.core.xcontent.XContentBuilder createXContentFromMap(Map<String, Object> source) {
+        try {
+            org.opensearch.core.xcontent.XContentBuilder builder = org.opensearch.common.xcontent.XContentFactory.jsonBuilder();
+            builder.map(source);
+            return builder;
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    /**
+     * Null request returns error
+     */
+    @SuppressWarnings("unchecked")
+    public void testNullRequest() {
+        ActionListener<ABTestSearchResponse> listener = mock(ActionListener.class);
+
+        transportAction.doExecute(null, null, listener);
+
+        ArgumentCaptor<Exception> errorCaptor = ArgumentCaptor.forClass(Exception.class);
+        verify(listener).onFailure(errorCaptor.capture());
+        assertTrue(errorCaptor.getValue().getMessage().contains("cannot be null"));
+    }
+
+    /**
+     * Empty params returns error
+     */
+    @SuppressWarnings("unchecked")
+    public void testEmptyParams() {
+        ABTestSearchRequest request = new ABTestSearchRequest("my-test", Collections.emptyMap());
+        ActionListener<ABTestSearchResponse> listener = mock(ActionListener.class);
+
+        transportAction.doExecute(null, request, listener);
+
+        ArgumentCaptor<Exception> errorCaptor = ArgumentCaptor.forClass(Exception.class);
+        verify(listener).onFailure(errorCaptor.capture());
+        assertTrue(errorCaptor.getValue().getMessage().contains("cannot be null"));
+    }
+
+    /**
+     * Missing SearchText returns error
+     */
+    @SuppressWarnings("unchecked")
+    public void testMissingSearchText() {
+        Map<String, String> params = new HashMap<>();
+        params.put("SomeOtherParam", "value");
+
+        doAnswer(invocation -> {
+            ActionListener<SearchResponse> listener = invocation.getArgument(1);
+            listener.onResponse(createABTestResponse(true));
+            return null;
+        }).when(abTestDao).getABTest(any(String.class), any(ActionListener.class));
+
+        doAnswer(invocation -> {
+            ActionListener<SearchResponse> listener = invocation.getArgument(1);
+            listener.onResponse(createConfigResponse("{\"query\":{\"match\":{\"title\":\"%SearchText%\"}}}", "prime_video"));
+            return null;
+        }).when(searchConfigurationDao).getSearchConfiguration(any(String.class), any(ActionListener.class));
+
+        ABTestSearchRequest request = new ABTestSearchRequest("my-test", params);
+        ActionListener<ABTestSearchResponse> listener = mock(ActionListener.class);
+
+        transportAction.doExecute(null, request, listener);
+
+        ArgumentCaptor<Exception> errorCaptor = ArgumentCaptor.forClass(Exception.class);
+        verify(listener).onFailure(errorCaptor.capture());
+        assertTrue(errorCaptor.getValue().getMessage().contains("SearchText is required"));
+    }
+
+    /**
+     * Test not found returns error
+     */
+    @SuppressWarnings("unchecked")
+    public void testTestNotFound() {
+        doAnswer(invocation -> {
+            ActionListener<SearchResponse> listener = invocation.getArgument(1);
+            listener.onFailure(new org.opensearch.ResourceNotFoundException("not found", RestStatus.NOT_FOUND));
+            return null;
+        }).when(abTestDao).getABTest(any(String.class), any(ActionListener.class));
+
+        Map<String, String> params = new HashMap<>();
+        params.put("SearchText", "spy thriller");
+
+        ABTestSearchRequest request = new ABTestSearchRequest("non-existent", params);
+        ActionListener<ABTestSearchResponse> listener = mock(ActionListener.class);
+
+        transportAction.doExecute(null, request, listener);
+
+        verify(listener).onFailure(any(Exception.class));
+    }
+
+    /**
+     * Null testId returns error
+     */
+    @SuppressWarnings("unchecked")
+    public void testNullTestId() {
+        Map<String, String> params = new HashMap<>();
+        params.put("SearchText", "spy");
+
+        ABTestSearchRequest request = new ABTestSearchRequest(null, params);
+        ActionListener<ABTestSearchResponse> listener = mock(ActionListener.class);
+
+        transportAction.doExecute(null, request, listener);
+
+        ArgumentCaptor<Exception> errorCaptor = ArgumentCaptor.forClass(Exception.class);
+        verify(listener).onFailure(errorCaptor.capture());
+        assertTrue(errorCaptor.getValue().getMessage().contains("cannot be null"));
+    }
+}

--- a/src/test/java/org/opensearch/searchrelevance/transport/abTest/ABTestSearchTransportActionTests.java
+++ b/src/test/java/org/opensearch/searchrelevance/transport/abTest/ABTestSearchTransportActionTests.java
@@ -23,6 +23,7 @@ import org.junit.Before;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+import org.opensearch.action.search.MultiSearchResponse;
 import org.opensearch.action.search.SearchResponse;
 import org.opensearch.action.support.ActionFilters;
 import org.opensearch.core.action.ActionListener;
@@ -58,6 +59,14 @@ public class ABTestSearchTransportActionTests extends OpenSearchTestCase {
     @Before
     public void setup() {
         MockitoAnnotations.openMocks(this);
+        org.opensearch.common.util.concurrent.ThreadContext threadContext = new org.opensearch.common.util.concurrent.ThreadContext(
+            org.opensearch.common.settings.Settings.EMPTY
+        );
+        when(client.threadPool()).thenReturn(threadPool);
+        when(threadPool.getThreadContext()).thenReturn(threadContext);
+        org.opensearch.searchrelevance.model.builder.SearchRequestBuilder.initialize(
+            org.opensearch.core.xcontent.NamedXContentRegistry.EMPTY
+        );
         transportAction = new ABTestSearchTransportAction(
             transportService,
             actionFilters,
@@ -273,25 +282,16 @@ public class ABTestSearchTransportActionTests extends OpenSearchTestCase {
             return null;
         }).when(searchConfigurationDao).getSearchConfiguration(any(String.class), any(ActionListener.class));
 
-        ExecutorService executorService = mock(ExecutorService.class);
-        when(threadPool.generic()).thenReturn(executorService);
-        doAnswer(invocation -> {
-            Runnable task = invocation.getArgument(0);
-            task.run();
-            return null;
-        }).when(executorService).execute(any(Runnable.class));
-
         SearchResponse searchResponseA = createSearchResponseWithHits("doc1", "doc2", "doc3");
         SearchResponse searchResponseB = createSearchResponseWithHits("doc4", "doc5", "doc6");
+        MultiSearchResponse.Item itemA = new MultiSearchResponse.Item(searchResponseA, null);
+        MultiSearchResponse.Item itemB = new MultiSearchResponse.Item(searchResponseB, null);
+        MultiSearchResponse msearchResponse = new MultiSearchResponse(new MultiSearchResponse.Item[] { itemA, itemB }, 0);
         doAnswer(invocation -> {
-            ActionListener<SearchResponse> listener = invocation.getArgument(1);
-            listener.onResponse(searchResponseA);
+            ActionListener<MultiSearchResponse> listener = invocation.getArgument(1);
+            listener.onResponse(msearchResponse);
             return null;
-        }).doAnswer(invocation -> {
-            ActionListener<SearchResponse> listener = invocation.getArgument(1);
-            listener.onResponse(searchResponseB);
-            return null;
-        }).when(client).search(any(), any(ActionListener.class));
+        }).when(client).multiSearch(any(), any(ActionListener.class));
 
         Map<String, String> params = new HashMap<>();
         params.put("SearchText", "laptop");
@@ -305,7 +305,7 @@ public class ABTestSearchTransportActionTests extends OpenSearchTestCase {
         ABTestSearchResponse response = responseCaptor.getValue();
         assertEquals("my-test", response.getTestId());
         assertNotNull(response.getHits());
-        assertEquals(6, response.getHits().size());
+        assertEquals(3, response.getHits().size());
     }
 
     /**
@@ -325,26 +325,17 @@ public class ABTestSearchTransportActionTests extends OpenSearchTestCase {
             return null;
         }).when(searchConfigurationDao).getSearchConfiguration(any(String.class), any(ActionListener.class));
 
-        ExecutorService executorService = mock(ExecutorService.class);
-        when(threadPool.generic()).thenReturn(executorService);
-        doAnswer(invocation -> {
-            Runnable task = invocation.getArgument(0);
-            task.run();
-            return null;
-        }).when(executorService).execute(any(Runnable.class));
-
         // Both configs return overlapping docs (doc1, doc2 appear in both)
         SearchResponse searchResponseA = createSearchResponseWithHits("doc1", "doc2", "doc3");
         SearchResponse searchResponseB = createSearchResponseWithHits("doc1", "doc2", "doc4");
+        MultiSearchResponse.Item itemA = new MultiSearchResponse.Item(searchResponseA, null);
+        MultiSearchResponse.Item itemB = new MultiSearchResponse.Item(searchResponseB, null);
+        MultiSearchResponse msearchResponse = new MultiSearchResponse(new MultiSearchResponse.Item[] { itemA, itemB }, 0);
         doAnswer(invocation -> {
-            ActionListener<SearchResponse> listener = invocation.getArgument(1);
-            listener.onResponse(searchResponseA);
+            ActionListener<MultiSearchResponse> listener = invocation.getArgument(1);
+            listener.onResponse(msearchResponse);
             return null;
-        }).doAnswer(invocation -> {
-            ActionListener<SearchResponse> listener = invocation.getArgument(1);
-            listener.onResponse(searchResponseB);
-            return null;
-        }).when(client).search(any(), any(ActionListener.class));
+        }).when(client).multiSearch(any(), any(ActionListener.class));
 
         Map<String, String> params = new HashMap<>();
         params.put("SearchText", "laptop");
@@ -379,25 +370,16 @@ public class ABTestSearchTransportActionTests extends OpenSearchTestCase {
             return null;
         }).when(searchConfigurationDao).getSearchConfiguration(any(String.class), any(ActionListener.class));
 
-        ExecutorService executorService = mock(ExecutorService.class);
-        when(threadPool.generic()).thenReturn(executorService);
-        doAnswer(invocation -> {
-            Runnable task = invocation.getArgument(0);
-            task.run();
-            return null;
-        }).when(executorService).execute(any(Runnable.class));
-
         SearchResponse searchResponseA = createSearchResponseWithHits("doc1", "doc2");
         SearchResponse searchResponseB = createSearchResponseWithHits("doc3", "doc4");
+        MultiSearchResponse.Item itemA = new MultiSearchResponse.Item(searchResponseA, null);
+        MultiSearchResponse.Item itemB = new MultiSearchResponse.Item(searchResponseB, null);
+        MultiSearchResponse msearchResponse = new MultiSearchResponse(new MultiSearchResponse.Item[] { itemA, itemB }, 0);
         doAnswer(invocation -> {
-            ActionListener<SearchResponse> listener = invocation.getArgument(1);
-            listener.onResponse(searchResponseA);
+            ActionListener<MultiSearchResponse> listener = invocation.getArgument(1);
+            listener.onResponse(msearchResponse);
             return null;
-        }).doAnswer(invocation -> {
-            ActionListener<SearchResponse> listener = invocation.getArgument(1);
-            listener.onResponse(searchResponseB);
-            return null;
-        }).when(client).search(any(), any(ActionListener.class));
+        }).when(client).multiSearch(any(), any(ActionListener.class));
 
         Map<String, String> params = new HashMap<>();
         params.put("SearchText", "laptop");

--- a/src/test/java/org/opensearch/searchrelevance/transport/abTest/ABTestSearchTransportActionTests.java
+++ b/src/test/java/org/opensearch/searchrelevance/transport/abTest/ABTestSearchTransportActionTests.java
@@ -8,9 +8,11 @@
 package org.opensearch.searchrelevance.transport.abTest;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import java.util.Collections;
 import java.util.HashMap;
@@ -35,6 +37,8 @@ import org.opensearch.test.OpenSearchTestCase;
 import org.opensearch.threadpool.ThreadPool;
 import org.opensearch.transport.TransportService;
 import org.opensearch.transport.client.Client;
+
+import java.util.concurrent.ExecutorService;
 
 public class ABTestSearchTransportActionTests extends OpenSearchTestCase {
 
@@ -62,7 +66,8 @@ public class ABTestSearchTransportActionTests extends OpenSearchTestCase {
             abTestDao,
             searchConfigurationDao,
             client,
-            threadPool
+            threadPool,
+            new org.opensearch.searchrelevance.algorithm.TeamDraftInterleaver()
         );
     }
 
@@ -204,5 +209,226 @@ public class ABTestSearchTransportActionTests extends OpenSearchTestCase {
         ArgumentCaptor<Exception> errorCaptor = ArgumentCaptor.forClass(Exception.class);
         verify(listener).onFailure(errorCaptor.capture());
         assertTrue(errorCaptor.getValue().getMessage().contains("cannot be null"));
+    }
+
+    /**
+     * Happy path: test disabled — executes single search with config A only
+     */
+    @SuppressWarnings("unchecked")
+    public void testSingleSearchWhenTestDisabled() {
+        doAnswer(invocation -> {
+            ActionListener<SearchResponse> listener = invocation.getArgument(1);
+            listener.onResponse(createABTestResponse(false));
+            return null;
+        }).when(abTestDao).getABTest(any(String.class), any(ActionListener.class));
+
+        doAnswer(invocation -> {
+            ActionListener<SearchResponse> listener = invocation.getArgument(1);
+            listener.onResponse(createConfigResponse("{\"query\":{\"match\":{\"title\":\"%SearchText%\"}}}", "my-index"));
+            return null;
+        }).when(searchConfigurationDao).getSearchConfiguration(any(String.class), any(ActionListener.class));
+
+        ExecutorService executorService = mock(ExecutorService.class);
+        when(threadPool.generic()).thenReturn(executorService);
+        doAnswer(invocation -> {
+            Runnable task = invocation.getArgument(0);
+            task.run();
+            return null;
+        }).when(executorService).execute(any(Runnable.class));
+
+        SearchResponse searchResponse = createSearchResponseWithHits("doc1", "doc2", "doc3");
+        doAnswer(invocation -> {
+            ActionListener<SearchResponse> listener = invocation.getArgument(1);
+            listener.onResponse(searchResponse);
+            return null;
+        }).when(client).search(any(), any(ActionListener.class));
+
+        Map<String, String> params = new HashMap<>();
+        params.put("SearchText", "laptop");
+        ABTestSearchRequest request = new ABTestSearchRequest("my-test", params);
+        ActionListener<ABTestSearchResponse> listener = mock(ActionListener.class);
+
+        transportAction.doExecute(null, request, listener);
+
+        ArgumentCaptor<ABTestSearchResponse> responseCaptor = ArgumentCaptor.forClass(ABTestSearchResponse.class);
+        verify(listener).onResponse(responseCaptor.capture());
+        ABTestSearchResponse response = responseCaptor.getValue();
+        assertEquals("my-test", response.getTestId());
+        assertFalse(response.isInterleaved());
+        assertEquals(3, response.getHits().size());
+    }
+
+    /**
+     * Happy path: test enabled — executes parallel search and interleaves results using TDI
+     */
+    @SuppressWarnings("unchecked")
+    public void testParallelSearchWithTDIWhenTestEnabled() {
+        doAnswer(invocation -> {
+            ActionListener<SearchResponse> listener = invocation.getArgument(1);
+            listener.onResponse(createABTestResponse(true));
+            return null;
+        }).when(abTestDao).getABTest(any(String.class), any(ActionListener.class));
+
+        doAnswer(invocation -> {
+            ActionListener<SearchResponse> listener = invocation.getArgument(1);
+            listener.onResponse(createConfigResponse("{\"query\":{\"match\":{\"title\":\"%SearchText%\"}}}", "my-index"));
+            return null;
+        }).when(searchConfigurationDao).getSearchConfiguration(any(String.class), any(ActionListener.class));
+
+        ExecutorService executorService = mock(ExecutorService.class);
+        when(threadPool.generic()).thenReturn(executorService);
+        doAnswer(invocation -> {
+            Runnable task = invocation.getArgument(0);
+            task.run();
+            return null;
+        }).when(executorService).execute(any(Runnable.class));
+
+        SearchResponse searchResponseA = createSearchResponseWithHits("doc1", "doc2", "doc3");
+        SearchResponse searchResponseB = createSearchResponseWithHits("doc4", "doc5", "doc6");
+        doAnswer(invocation -> {
+            ActionListener<SearchResponse> listener = invocation.getArgument(1);
+            listener.onResponse(searchResponseA);
+            return null;
+        }).doAnswer(invocation -> {
+            ActionListener<SearchResponse> listener = invocation.getArgument(1);
+            listener.onResponse(searchResponseB);
+            return null;
+        }).when(client).search(any(), any(ActionListener.class));
+
+        Map<String, String> params = new HashMap<>();
+        params.put("SearchText", "laptop");
+        ABTestSearchRequest request = new ABTestSearchRequest("my-test", params);
+        ActionListener<ABTestSearchResponse> listener = mock(ActionListener.class);
+
+        transportAction.doExecute(null, request, listener);
+
+        ArgumentCaptor<ABTestSearchResponse> responseCaptor = ArgumentCaptor.forClass(ABTestSearchResponse.class);
+        verify(listener).onResponse(responseCaptor.capture());
+        ABTestSearchResponse response = responseCaptor.getValue();
+        assertEquals("my-test", response.getTestId());
+        assertTrue(response.isInterleaved());
+        assertEquals(6, response.getHits().size());
+    }
+
+    /**
+     * Happy path: TDI deduplicates overlapping documents from both configs
+     */
+    @SuppressWarnings("unchecked")
+    public void testTDIDeduplicatesOverlappingDocs() {
+        doAnswer(invocation -> {
+            ActionListener<SearchResponse> listener = invocation.getArgument(1);
+            listener.onResponse(createABTestResponse(true));
+            return null;
+        }).when(abTestDao).getABTest(any(String.class), any(ActionListener.class));
+
+        doAnswer(invocation -> {
+            ActionListener<SearchResponse> listener = invocation.getArgument(1);
+            listener.onResponse(createConfigResponse("{\"query\":{\"match\":{\"title\":\"%SearchText%\"}}}", "my-index"));
+            return null;
+        }).when(searchConfigurationDao).getSearchConfiguration(any(String.class), any(ActionListener.class));
+
+        ExecutorService executorService = mock(ExecutorService.class);
+        when(threadPool.generic()).thenReturn(executorService);
+        doAnswer(invocation -> {
+            Runnable task = invocation.getArgument(0);
+            task.run();
+            return null;
+        }).when(executorService).execute(any(Runnable.class));
+
+        // Both configs return overlapping docs (doc1, doc2 appear in both)
+        SearchResponse searchResponseA = createSearchResponseWithHits("doc1", "doc2", "doc3");
+        SearchResponse searchResponseB = createSearchResponseWithHits("doc1", "doc2", "doc4");
+        doAnswer(invocation -> {
+            ActionListener<SearchResponse> listener = invocation.getArgument(1);
+            listener.onResponse(searchResponseA);
+            return null;
+        }).doAnswer(invocation -> {
+            ActionListener<SearchResponse> listener = invocation.getArgument(1);
+            listener.onResponse(searchResponseB);
+            return null;
+        }).when(client).search(any(), any(ActionListener.class));
+
+        Map<String, String> params = new HashMap<>();
+        params.put("SearchText", "laptop");
+        ABTestSearchRequest request = new ABTestSearchRequest("my-test", params);
+        ActionListener<ABTestSearchResponse> listener = mock(ActionListener.class);
+
+        transportAction.doExecute(null, request, listener);
+
+        ArgumentCaptor<ABTestSearchResponse> responseCaptor = ArgumentCaptor.forClass(ABTestSearchResponse.class);
+        verify(listener).onResponse(responseCaptor.capture());
+        ABTestSearchResponse response = responseCaptor.getValue();
+        assertTrue(response.isInterleaved());
+        // Overlapping docs should appear only once in the interleaved list
+        long uniqueDocCount = response.getHits().stream().map(h -> h.get("_id")).distinct().count();
+        assertEquals(uniqueDocCount, response.getHits().size());
+    }
+
+    /**
+     * Happy path: each hit in interleaved response contains _search_configuration_id
+     */
+    @SuppressWarnings("unchecked")
+    public void testInterleavedResponseContainsConfigUuid() {
+        doAnswer(invocation -> {
+            ActionListener<SearchResponse> listener = invocation.getArgument(1);
+            listener.onResponse(createABTestResponse(true));
+            return null;
+        }).when(abTestDao).getABTest(any(String.class), any(ActionListener.class));
+
+        doAnswer(invocation -> {
+            ActionListener<SearchResponse> listener = invocation.getArgument(1);
+            listener.onResponse(createConfigResponse("{\"query\":{\"match\":{\"title\":\"%SearchText%\"}}}", "my-index"));
+            return null;
+        }).when(searchConfigurationDao).getSearchConfiguration(any(String.class), any(ActionListener.class));
+
+        ExecutorService executorService = mock(ExecutorService.class);
+        when(threadPool.generic()).thenReturn(executorService);
+        doAnswer(invocation -> {
+            Runnable task = invocation.getArgument(0);
+            task.run();
+            return null;
+        }).when(executorService).execute(any(Runnable.class));
+
+        SearchResponse searchResponseA = createSearchResponseWithHits("doc1", "doc2");
+        SearchResponse searchResponseB = createSearchResponseWithHits("doc3", "doc4");
+        doAnswer(invocation -> {
+            ActionListener<SearchResponse> listener = invocation.getArgument(1);
+            listener.onResponse(searchResponseA);
+            return null;
+        }).doAnswer(invocation -> {
+            ActionListener<SearchResponse> listener = invocation.getArgument(1);
+            listener.onResponse(searchResponseB);
+            return null;
+        }).when(client).search(any(), any(ActionListener.class));
+
+        Map<String, String> params = new HashMap<>();
+        params.put("SearchText", "laptop");
+        ABTestSearchRequest request = new ABTestSearchRequest("my-test", params);
+        ActionListener<ABTestSearchResponse> listener = mock(ActionListener.class);
+
+        transportAction.doExecute(null, request, listener);
+
+        ArgumentCaptor<ABTestSearchResponse> responseCaptor = ArgumentCaptor.forClass(ABTestSearchResponse.class);
+        verify(listener).onResponse(responseCaptor.capture());
+        ABTestSearchResponse response = responseCaptor.getValue();
+        // Every hit must have a _search_configuration_id assigned
+        for (Map<String, Object> hit : response.getHits()) {
+            assertNotNull(hit.get("_search_configuration_id"));
+            assertTrue(
+                hit.get("_search_configuration_id").equals("uuid-a") || hit.get("_search_configuration_id").equals("uuid-b")
+            );
+        }
+    }
+
+    private SearchResponse createSearchResponseWithHits(String... docIds) {
+        SearchHit[] hits = new SearchHit[docIds.length];
+        for (int i = 0; i < docIds.length; i++) {
+            hits[i] = new SearchHit(i + 1, docIds[i], Collections.emptyMap(), Collections.emptyMap());
+            hits[i].sourceRef(BytesReference.bytes(createXContentFromMap(Collections.singletonMap("title", "test"))));
+        }
+        SearchHits searchHits = new SearchHits(hits, new TotalHits(docIds.length, TotalHits.Relation.EQUAL_TO), 1.0f);
+        SearchResponse response = mock(SearchResponse.class);
+        org.mockito.Mockito.when(response.getHits()).thenReturn(searchHits);
+        return response;
     }
 }


### PR DESCRIPTION
## Description

  This PR adds the **Search API** (`POST /ab_tests/{id}/_search`) with Team Draft Interleaving for A/B testing search configurations. It enables customers to serve interleaved results from two competing search configurations in a single request, with each result attributed to its originating
  config via UUID.

  RFC : opensearch-project/OpenSearch#18383
  PR 1 : #498 

  ## New API

  | Method | Endpoint | Purpose |
  |--------|----------|---------|
  | POST | `/_plugins/_search_relevance/ab_tests/{id}/_search` | Execute interleaved search with TDI |

  ## Features

  - **Team Draft Interleaving algorithm**: Per-round coin flip draft picks for fair representation of both configs
  - **Parallel execution**: Both search configs execute simultaneously on generic thread pool (halves latency)
  - **UUID attribution**: Each result tagged with config UUID — end users cannot identify which config produced it
  - **`%SearchText%` substitution**: Placeholder in config templates replaced with user's query at search time
  - **Disabled mode**: When test is disabled, only Config A runs (no interleaving)
  - **`_source` excludes support**: Configs can exclude fields (e.g., `description_embedding`) from response
  - **Immutable Result collections**: TDI output wrapped in `Collections.unmodifiable*` to prevent accidental mutation
  - **Proper error handling**: 404 for missing test/configs with clear messages (not raw 500s)

  ## Request Example

  ```json
  POST /_plugins/_search_relevance/ab_tests/bm25-vs-neural/_search
  {
    "query_params": {
      "SearchText": "comedy drama series"
    }
  }

  Response Example

  {
    "test_id": "bm25-vs-neural",
    "interleaved": true,
    "hits": [
      {
        "_search_configuration_id": "uuid-a",
        "_index": "prime_video",
        "_id": "2",
        "_score": 3.36,
        "_source": { "title": "Fleabag", "category": "comedy" }
      },
      {
        "_search_configuration_id": "uuid-b",
        "_index": "prime_video",
        "_id": "3",
        "_score": 4.03,
        "_source": { "title": "The Marvelous Mrs. Maisel", "category": "comedy" }
      }
    ]
  }

  Architecture

  Follows the existing 4-layer plugin pattern:
  - REST Handler → Transport Action → DAO → SearchRelevanceIndicesManager
  - Search execution offloaded to generic thread pool (never blocks transport threads)
  - TDI algorithm in dedicated TeamDraftInterleaver class

  Files Added

  ┌───────────────────────────────────────┬───────────────────────┐
  │                 File                  │        Purpose        │
  ├───────────────────────────────────────┼───────────────────────┤
  │ TeamDraftInterleaver.java             │ TDI algorithm         │
  ├───────────────────────────────────────┼───────────────────────┤
  │ ABTestSearchTransportAction.java      │ Search business logic │
  ├───────────────────────────────────────┼───────────────────────┤
  │ ABTestSearchRequest.java              │ Request model         │
  ├───────────────────────────────────────┼───────────────────────┤
  │ ABTestSearchResponse.java             │ Response model        │
  ├───────────────────────────────────────┼───────────────────────┤
  │ ABTestSearchAction.java               │ Action type           │
  ├───────────────────────────────────────┼───────────────────────┤
  │ RestABTestSearchAction.java           │ REST handler          │
  ├───────────────────────────────────────┼───────────────────────┤
  │ TeamDraftInterleaverTests.java        │ 10 unit tests         │
  ├───────────────────────────────────────┼───────────────────────┤
  │ ABTestSearchTransportActionTests.java │ 5 unit tests          │
  └───────────────────────────────────────┴───────────────────────┘

  Issues Resolved

  Related: https://github.com/opensearch-project/OpenSearch/issues/18383

  Check List

  - [x] New functionality includes unit tests
  - [x] New functionality has been documented in PR description
  - [x] Commits are signed off per the DCO requirement
  - [x] All endpoints gated by existing SEARCH_RELEVANCE_WORKBENCH_ENABLED setting
  - [ ] Mustache Template for Search Queries
  