### PR TITLE
Make LLM judgment generation provider-neutral

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Features
 
 - Add experiment execution time input signatures (SHA-256 fingerprints of query set, judgments, and search configurations) and `GET /_plugins/_search_relevance/experiments/{id}/validate` for VALID / DRIFTED / UNAVAILABLE drift checks ([#456](https://github.com/opensearch-project/search-relevance/pull/456))
+- Make LLM judgment generation provider-neutral so any LLM provider can be used through an ml-commons connector blueprint ([#515](https://github.com/opensearch-project/search-relevance/pull/515))
 
 ### Enhancements
 - Optimize Rank-Biased Overlap (RBO) calculation from O(n²) to O(n) by maintaining prefix sets incrementally ([#499](https://github.com/opensearch-project/search-relevance/issues/499))

--- a/src/main/java/org/opensearch/searchrelevance/common/MLConstants.java
+++ b/src/main/java/org/opensearch/searchrelevance/common/MLConstants.java
@@ -23,6 +23,8 @@ public class MLConstants {
      * ML input field names
      */
     public static final String PARAM_MESSAGES_FIELD = "messages";
+    public static final String PARAM_SYSTEM_PROMPT_FIELD = "system_prompt";
+    public static final String PARAM_USER_PROMPT_FIELD = "user_prompt";
     public static final String PROMPT_TEMPLATE = "promptTemplate";
     public static final String LLM_JUDGMENT_RATING_TYPE = "llmJudgmentRatingType";
     public static final String OVERWRITE_CACHE = "overwriteCache";
@@ -46,6 +48,7 @@ public class MLConstants {
     /**
      * ML response field names
      */
+    public static final String RESPONSE_FIELD = "response";
     public static final String RESPONSE_CHOICES_FIELD = "choices";
     public static final String RESPONSE_MESSAGE_FIELD = "message";
     public static final String RESPONSE_CONTENT_FIELD = "content";

--- a/src/main/java/org/opensearch/searchrelevance/ml/MLInputOutputTransformer.java
+++ b/src/main/java/org/opensearch/searchrelevance/ml/MLInputOutputTransformer.java
@@ -8,6 +8,8 @@
 package org.opensearch.searchrelevance.ml;
 
 import static org.opensearch.searchrelevance.common.MLConstants.PARAM_MESSAGES_FIELD;
+import static org.opensearch.searchrelevance.common.MLConstants.PARAM_SYSTEM_PROMPT_FIELD;
+import static org.opensearch.searchrelevance.common.MLConstants.PARAM_USER_PROMPT_FIELD;
 import static org.opensearch.searchrelevance.common.MLConstants.PROMPT_JSON_MESSAGES_SHELL;
 import static org.opensearch.searchrelevance.common.MLConstants.PROMPT_SEARCH_RELEVANCE_SCORE_0_1_START;
 import static org.opensearch.searchrelevance.common.MLConstants.PROMPT_SEARCH_RELEVANCE_SCORE_BINARY;
@@ -16,6 +18,7 @@ import static org.opensearch.searchrelevance.common.MLConstants.RATING_SCORE_BIN
 import static org.opensearch.searchrelevance.common.MLConstants.RATING_SCORE_NUMERIC_SCHEMA;
 import static org.opensearch.searchrelevance.common.MLConstants.RESPONSE_CHOICES_FIELD;
 import static org.opensearch.searchrelevance.common.MLConstants.RESPONSE_CONTENT_FIELD;
+import static org.opensearch.searchrelevance.common.MLConstants.RESPONSE_FIELD;
 import static org.opensearch.searchrelevance.common.MLConstants.RESPONSE_FORMAT_TEMPLATE;
 import static org.opensearch.searchrelevance.common.MLConstants.RESPONSE_MESSAGE_FIELD;
 import static org.opensearch.searchrelevance.common.MLConstants.escapeJson;
@@ -135,6 +138,10 @@ public class MLInputOutputTransformer {
 
         parameters.put(PARAM_MESSAGES_FIELD, messagesArray);
 
+        // Provider-neutral parameters a connector blueprint can reference for any provider
+        parameters.put(PARAM_SYSTEM_PROMPT_FIELD, getSystemPrompt(ratingType));
+        parameters.put(PARAM_USER_PROMPT_FIELD, escapeJson(buildUserContent(searchText, referenceData, hits, promptTemplate)));
+
         // Only add response_format if requested (for models that support it)
         if (includeResponseFormat) {
             String responseFormat = getResponseFormat(ratingType);
@@ -151,11 +158,15 @@ public class MLInputOutputTransformer {
         String promptTemplate,
         LLMJudgmentRatingType ratingType
     ) {
+        String userContent = buildUserContent(searchText, referenceData, hits, promptTemplate);
+        String systemPrompt = getSystemPrompt(ratingType);
+        return String.format(Locale.ROOT, PROMPT_JSON_MESSAGES_SHELL, systemPrompt, escapeJson(userContent));
+    }
+
+    private String buildUserContent(String searchText, Map<String, String> referenceData, Map<String, String> hits, String promptTemplate) {
         try {
             String hitsJson = buildHitsJson(hits);
-            String userContent = UserPromptFactory.buildUserContent(searchText, referenceData, hitsJson, promptTemplate);
-            String systemPrompt = getSystemPrompt(ratingType);
-            return String.format(Locale.ROOT, PROMPT_JSON_MESSAGES_SHELL, systemPrompt, escapeJson(userContent));
+            return UserPromptFactory.buildUserContent(searchText, referenceData, hitsJson, promptTemplate);
         } catch (IOException e) {
             log.error("Error converting hits to JSON string", e);
             throw new IllegalArgumentException("Failed to process hits", e);
@@ -221,8 +232,31 @@ public class MLInputOutputTransformer {
         ModelTensor tensor = tensorOutputList.get(0).getMlModelTensors().get(0);
         Map<String, ?> dataMap = tensor.getDataAsMap();
 
-        Map<String, ?> choices = (Map<String, ?>) ((List<?>) dataMap.get(RESPONSE_CHOICES_FIELD)).get(0);
-        Map<String, ?> message = (Map<String, ?>) choices.get(RESPONSE_MESSAGE_FIELD);
-        return (String) message.get(RESPONSE_CONTENT_FIELD);
+        // Neutral path: a blueprint's post_process_function copies the model text into a "response" field
+        Object response = dataMap.get(RESPONSE_FIELD);
+        if (response instanceof String) {
+            return (String) response;
+        }
+
+        // Fallback to the raw OpenAI chat-completion shape
+        Object choices = dataMap.get(RESPONSE_CHOICES_FIELD);
+        if (choices instanceof List && !((List<?>) choices).isEmpty()) {
+            Object firstChoice = ((List<?>) choices).get(0);
+            if (firstChoice instanceof Map) {
+                Object message = ((Map<?, ?>) firstChoice).get(RESPONSE_MESSAGE_FIELD);
+                if (message instanceof Map) {
+                    Object content = ((Map<?, ?>) message).get(RESPONSE_CONTENT_FIELD);
+                    if (content instanceof String) {
+                        return (String) content;
+                    }
+                }
+            }
+        }
+
+        throw new IllegalStateException(
+            "Unrecognised model response shape; expected a top-level \"response\" string (set by the connector "
+                + "blueprint's post_process_function) or an OpenAI \"choices[0].message.content\". Got keys: "
+                + dataMap.keySet()
+        );
     }
 }

--- a/src/main/java/org/opensearch/searchrelevance/ml/MLInputOutputTransformer.java
+++ b/src/main/java/org/opensearch/searchrelevance/ml/MLInputOutputTransformer.java
@@ -254,8 +254,8 @@ public class MLInputOutputTransformer {
         }
 
         throw new IllegalStateException(
-            "Unrecognised model response shape; expected a top-level \"response\" string (set by the connector "
-                + "blueprint's post_process_function) or an OpenAI \"choices[0].message.content\". Got keys: "
+            "Unrecognised model response shape; expected a top-level \"response\" string set by the connector "
+                + "blueprint's post_process_function, but the response contained these fields instead: "
                 + dataMap.keySet()
         );
     }

--- a/src/test/java/org/opensearch/searchrelevance/ml/MLInputOutputTransformerTests.java
+++ b/src/test/java/org/opensearch/searchrelevance/ml/MLInputOutputTransformerTests.java
@@ -7,11 +7,18 @@
  */
 package org.opensearch.searchrelevance.ml;
 
+import static org.mockito.Mockito.mock;
+
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import org.opensearch.ml.common.dataset.remote.RemoteInferenceInputDataSet;
 import org.opensearch.ml.common.input.MLInput;
+import org.opensearch.ml.common.output.MLOutput;
+import org.opensearch.ml.common.output.model.ModelTensor;
+import org.opensearch.ml.common.output.model.ModelTensorOutput;
+import org.opensearch.ml.common.output.model.ModelTensors;
 import org.opensearch.searchrelevance.model.LLMJudgmentRatingType;
 import org.opensearch.test.OpenSearchTestCase;
 
@@ -239,5 +246,173 @@ public class MLInputOutputTransformerTests extends OpenSearchTestCase {
         assertTrue("response_format should be present", parameters.containsKey("response_format"));
         assertNotNull("messages parameter should not be null", parameters.get("messages"));
         assertFalse("messages parameter should not be empty", parameters.get("messages").isEmpty());
+    }
+
+    // ============================================
+    // Provider-neutral parameter Tests
+    // ============================================
+
+    public void testCreateMLInput_emitsNeutralSystemAndUserPrompt() {
+        Map<String, String> hits = new HashMap<>();
+        hits.put("doc1", "leather running shoes");
+
+        MLInput mlInput = transformer.createMLInput(
+            "red shoes",
+            new HashMap<>(),
+            hits,
+            "{{searchText}} {{hits}}",
+            LLMJudgmentRatingType.SCORE0_1
+        );
+        Map<String, String> parameters = ((RemoteInferenceInputDataSet) mlInput.getInputDataset()).getParameters();
+
+        // Neutral fields a non-OpenAI blueprint references directly.
+        assertTrue("system_prompt should be present", parameters.containsKey("system_prompt"));
+        assertTrue("user_prompt should be present", parameters.containsKey("user_prompt"));
+        assertFalse("system_prompt should not be empty", parameters.get("system_prompt").isEmpty());
+        assertTrue("user_prompt should carry the search text", parameters.get("user_prompt").contains("red shoes"));
+        assertTrue("user_prompt should carry the hit content", parameters.get("user_prompt").contains("leather running shoes"));
+    }
+
+    public void testCreateMLInput_neutralAndLegacyParamsCoexist() {
+        Map<String, String> hits = new HashMap<>();
+        hits.put("doc1", "content");
+
+        MLInput mlInput = transformer.createMLInput("q", new HashMap<>(), hits, "Test prompt", LLMJudgmentRatingType.SCORE0_1);
+        Map<String, String> parameters = ((RemoteInferenceInputDataSet) mlInput.getInputDataset()).getParameters();
+
+        // Both the neutral params and the legacy OpenAI-shaped messages are emitted on every call.
+        assertTrue(parameters.containsKey("system_prompt"));
+        assertTrue(parameters.containsKey("user_prompt"));
+        assertTrue(parameters.containsKey("messages"));
+    }
+
+    public void testCreateMLInput_systemPromptMatchesRatingType() {
+        Map<String, String> hits = new HashMap<>();
+        hits.put("doc1", "content");
+
+        MLInput numeric = transformer.createMLInput("q", new HashMap<>(), hits, "p", LLMJudgmentRatingType.SCORE0_1);
+        MLInput binary = transformer.createMLInput("q", new HashMap<>(), hits, "p", LLMJudgmentRatingType.RELEVANT_IRRELEVANT);
+
+        String numericSystem = ((RemoteInferenceInputDataSet) numeric.getInputDataset()).getParameters().get("system_prompt");
+        String binarySystem = ((RemoteInferenceInputDataSet) binary.getInputDataset()).getParameters().get("system_prompt");
+
+        assertTrue("numeric system prompt should describe the 0-1 scale", numericSystem.contains("Score 1.0"));
+        assertTrue("binary system prompt should describe RELEVANT", binarySystem.contains("RELEVANT"));
+    }
+
+    // ============================================
+    // Response extraction Tests
+    // ============================================
+
+    public void testExtractResponseContent_readsNeutralResponseField() {
+        MLOutput output = outputWithDataMap(Map.of("response", "rated text"));
+        assertEquals("rated text", transformer.extractResponseContent(output));
+    }
+
+    public void testExtractResponseContent_fallsBackToOpenAIChoices() {
+        Map<String, Object> message = Map.of("content", "legacy text");
+        Map<String, Object> choice = Map.of("message", message);
+        MLOutput output = outputWithDataMap(Map.of("choices", List.of(choice)));
+        assertEquals("legacy text", transformer.extractResponseContent(output));
+    }
+
+    public void testExtractResponseContent_prefersResponseFieldOverChoices() {
+        Map<String, Object> message = Map.of("content", "legacy text");
+        Map<String, Object> choice = Map.of("message", message);
+        MLOutput output = outputWithDataMap(Map.of("response", "neutral text", "choices", List.of(choice)));
+        assertEquals("neutral text", transformer.extractResponseContent(output));
+    }
+
+    public void testExtractResponseContent_throwsOnUnrecognisedShape() {
+        MLOutput output = outputWithDataMap(Map.of("unexpected_key", "value"));
+        IllegalStateException ex = expectThrows(IllegalStateException.class, () -> transformer.extractResponseContent(output));
+        assertTrue(ex.getMessage().contains("Unrecognised model response shape"));
+    }
+
+    public void testExtractResponseContent_throwsOnEmptyChoices() {
+        MLOutput output = outputWithDataMap(Map.of("choices", List.of()));
+        expectThrows(IllegalStateException.class, () -> transformer.extractResponseContent(output));
+    }
+
+    public void testExtractResponseContent_throwsOnWrongOutputType() {
+        expectThrows(IllegalArgumentException.class, () -> transformer.extractResponseContent(mock(MLOutput.class)));
+    }
+
+    public void testExtractResponseContent_throwsOnEmptyTensors() {
+        MLOutput output = ModelTensorOutput.builder().mlModelOutputs(List.of()).build();
+        expectThrows(IllegalStateException.class, () -> transformer.extractResponseContent(output));
+    }
+
+    // ============================================
+    // Chunking Tests
+    // ============================================
+
+    public void testCreateMLInputs_splitsIntoMultipleChunksWhenTokenLimitExceeded() {
+        Map<String, String> hits = new HashMap<>();
+        for (int i = 0; i < 5; i++) {
+            hits.put("doc" + i, "content-" + i);
+        }
+        List<MLInput> inputs = transformer.createMLInputs(
+            50,
+            "q",
+            new HashMap<>(),
+            hits,
+            "{{searchText}} {{hits}}",
+            LLMJudgmentRatingType.SCORE0_1
+        );
+        assertTrue("expected multiple chunks, got " + inputs.size(), inputs.size() > 1);
+    }
+
+    public void testCreateMLInputs_singleChunkWhenUnderTokenLimit() {
+        Map<String, String> hits = new HashMap<>();
+        hits.put("doc1", "short");
+        hits.put("doc2", "short");
+        List<MLInput> inputs = transformer.createMLInputs(
+            10000,
+            "q",
+            new HashMap<>(),
+            hits,
+            "{{searchText}} {{hits}}",
+            LLMJudgmentRatingType.SCORE0_1
+        );
+        assertEquals(1, inputs.size());
+    }
+
+    public void testCreateMLInputs_truncatesSingleOversizedHit() {
+        StringBuilder big = new StringBuilder();
+        for (int i = 0; i < 1000; i++) {
+            big.append("very-long-token-text ");
+        }
+        Map<String, String> hits = new HashMap<>();
+        hits.put("doc1", big.toString());
+
+        List<MLInput> inputs = transformer.createMLInputs(
+            30,
+            "q",
+            new HashMap<>(),
+            hits,
+            "{{searchText}} {{hits}}",
+            LLMJudgmentRatingType.SCORE0_1
+        );
+        assertEquals(1, inputs.size());
+        assertNotNull(((RemoteInferenceInputDataSet) inputs.get(0).getInputDataset()).getParameters().get("user_prompt"));
+    }
+
+    public void testCreateMLInputs_emptyHitsReturnsEmptyList() {
+        List<MLInput> inputs = transformer.createMLInputs(
+            1000,
+            "q",
+            new HashMap<>(),
+            new HashMap<>(),
+            "{{searchText}} {{hits}}",
+            LLMJudgmentRatingType.SCORE0_1
+        );
+        assertTrue(inputs.isEmpty());
+    }
+
+    private static MLOutput outputWithDataMap(Map<String, ?> dataMap) {
+        ModelTensor tensor = ModelTensor.builder().dataAsMap(dataMap).build();
+        ModelTensors tensors = ModelTensors.builder().mlModelTensors(List.of(tensor)).build();
+        return ModelTensorOutput.builder().mlModelOutputs(List.of(tensors)).build();
     }
 }


### PR DESCRIPTION
### Description

#### Background
Search Relevance Workbench (SRW) can generate relevance judgments by calling an LLM registered in ml-commons (the "LLM-as-a-judge" flow). Although the model is reached through an ml-commons connector — which is meant to be provider-agnostic — SRW itself was hardcoded to OpenAI's wire format on both ends:

- **Request:** it only sent OpenAI's `messages` array (plus an OpenAI
  `response_format` structured-output spec).
- **Response:** it blindly assumed the OpenAI chat-completion shape and cast
  straight into `choices[0].message.content`.

As a result, only OpenAI-compatible connectors actually worked. Pointing the judgment flow at Bedrock (Claude, Converse), Gemini, Cohere, etc. either failed to produce a usable prompt or threw an `ClassCastException` while parsing the response.

#### What changed
This PR makes the judgment request and response provider-neutral, without removing the existing OpenAI behavior:

- **Request:** in addition to the OpenAI `messages` parameter, SRW now also sends two provider-neutral parameters, `system_prompt` and `user_prompt`. A connector  blueprint references whichever it needs in its `request_body`. ml-commons only substitutes the parameters a blueprint actually uses, so the extra parameters are harmless to existing connectors.
- **Response:** SRW now reads the model text from a neutral top-level `response` field (populated by a blueprint's `post_process_function`). If that is absent, it falls back to the OpenAI `choices[0].message.content` shape. If neither is
  present, it throws a clear error that lists the keys actually returned, instead of an unchecked cast failure.

#### Backward compatibility
Existing OpenAI connectors continue to work unchanged:

SRW still emits `messages` and `response_format`, and the response reader still understands the OpenAI `choices[0].message.content` shape via the fallback. No public API, request schema, or stored-document format changes; no migration is required.

#### Connector blueprints (separate ml-commons PR)
The neutral contract is satisfied entirely by the connector blueprint, so no provider-specific code lives in SRW. Connector blueprints for OpenAI, Azure OpenAI, DeepSeek, Ollama, Google Gemini, Anthropic Claude on Bedrock (native `invoke`), and the generic Amazon Bedrock Converse API are contributed in a separate PR here:

https://github.com/opensearch-project/ml-commons/pull/4878

Each blueprint maps the neutral `system_prompt` / `user_prompt` into the provider's request shape and returns the model text in the neutral `response` field.

#### Testing
- Unit tests in `MLInputOutputTransformerTests` cover the neutral request parameters, the neutral `response` read path, the OpenAI fallback, the unrecognised-shape error, and the existing chunking behavior.
- End-to-end validated against a local OpenSearch cluster.

| Provider | Protocol / API | Test environment | What was exercised |
|---|---|---|---|
| OpenAI | HTTP | Mock endpoint | `request_body` + `post_process_function` |
| Azure OpenAI | HTTP | Mock endpoint | `request_body` + `post_process_function` |
| DeepSeek | HTTP | Mock endpoint | `request_body` + `post_process_function` |
| Ollama | HTTP | Mock endpoint | `request_body` + `post_process_function` |
| Gemini | HTTP | Mock endpoint | `request_body` + `post_process_function` |
| Anthropic Claude | Native `invoke` | Real Amazon Bedrock | Full request/response |
| Bedrock Converse | Converse API | Real Amazon Bedrock | Full request/response |

### Issues Resolved
https://github.com/opensearch-project/search-relevance/issues/509

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
