### PR TITLE
Report LLM judgment success/failure counts and failed queries in the metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Make LLM judgment generation provider-neutral so any LLM provider can be used through an ml-commons connector blueprint ([#515](https://github.com/opensearch-project/search-relevance/pull/515))
 
 ### Enhancements
-- Report LLM judgment outcomes by storing per-run success/failure counts and the list of failed queries with reasons in the judgment metadata ([#521](https://github.com/opensearch-project/search-relevance/pull/521))
+- Report LLM judgment failures by listing the unrated docs on each judgment entry and storing per-run success/failure counts in the judgment metadata ([#521](https://github.com/opensearch-project/search-relevance/pull/521))
 - Optimize Rank-Biased Overlap (RBO) calculation from O(n²) to O(n) by maintaining prefix sets incrementally ([#499](https://github.com/opensearch-project/search-relevance/issues/499))
 - Optimize Frequency Weighted similarity calculation by replacing the O(n²) `listB.contains` scan with HashSet membership and single-pass union/intersection accumulation ([#502](https://github.com/opensearch-project/search-relevance/pull/502))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Make LLM judgment generation provider-neutral so any LLM provider can be used through an ml-commons connector blueprint ([#515](https://github.com/opensearch-project/search-relevance/pull/515))
 
 ### Enhancements
+- Report LLM judgment outcomes by storing per-run success/failure counts and the list of failed queries with reasons in the judgment metadata ([#521](https://github.com/opensearch-project/search-relevance/pull/521))
 - Optimize Rank-Biased Overlap (RBO) calculation from O(n²) to O(n) by maintaining prefix sets incrementally ([#499](https://github.com/opensearch-project/search-relevance/issues/499))
 - Optimize Frequency Weighted similarity calculation by replacing the O(n²) `listB.contains` scan with HashSet membership and single-pass union/intersection accumulation ([#502](https://github.com/opensearch-project/search-relevance/pull/502))
 

--- a/src/main/java/org/opensearch/searchrelevance/judgments/JudgmentDataTransformer.java
+++ b/src/main/java/org/opensearch/searchrelevance/judgments/JudgmentDataTransformer.java
@@ -7,6 +7,7 @@
  */
 package org.opensearch.searchrelevance.judgments;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -30,6 +31,40 @@ public class JudgmentDataTransformer {
 
         judgmentForQuery.put("ratings", docIdRatings);
         return judgmentForQuery;
+    }
+
+    /**
+     * Summarises the per-query judgment results into success/failure counts and a list of failed
+     * queries with their reasons. A query is considered failed when it produced no ratings; the
+     * reason is taken from the optional "error" entry on the result, or a default message otherwise.
+     *
+     * @param judgmentResults per-query results, each holding "query", "ratings" and an optional "error"
+     * @return a map with totalQueries, successfulQueries, failedQueries and a failures list
+     */
+    public static Map<String, Object> buildJudgmentSummary(List<Map<String, Object>> judgmentResults) {
+        List<Map<String, Object>> failures = new ArrayList<>();
+        int successfulQueries = 0;
+
+        for (Map<String, Object> result : judgmentResults) {
+            Object ratings = result.get("ratings");
+            boolean hasRatings = ratings instanceof List && !((List<?>) ratings).isEmpty();
+            if (hasRatings) {
+                successfulQueries++;
+            } else {
+                Object error = result.get("error");
+                Map<String, Object> failure = new HashMap<>();
+                failure.put("query", result.get("query"));
+                failure.put("reason", error != null ? error.toString() : "No ratings were generated");
+                failures.add(failure);
+            }
+        }
+
+        Map<String, Object> summary = new HashMap<>();
+        summary.put("totalQueries", judgmentResults.size());
+        summary.put("successfulQueries", successfulQueries);
+        summary.put("failedQueries", failures.size());
+        summary.put("failures", failures);
+        return summary;
     }
 
     public static String extractQueryText(String queryTextWithCustomInput, String delimiter) {

--- a/src/main/java/org/opensearch/searchrelevance/judgments/JudgmentDataTransformer.java
+++ b/src/main/java/org/opensearch/searchrelevance/judgments/JudgmentDataTransformer.java
@@ -11,12 +11,16 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 /**
  * Handles data transformation for judgment processing
  */
 public class JudgmentDataTransformer {
+
+    /** Transient key on a per-query result carrying its failure reason. Used to build the metadata summary; not persisted. */
+    public static final String RESULT_FAILURE_REASON = "failureReason";
 
     public static Map<String, Object> createJudgmentResult(String queryTextWithCustomInput, Map<String, String> docIdToScore) {
         Map<String, Object> judgmentForQuery = new HashMap<>();
@@ -34,36 +38,55 @@ public class JudgmentDataTransformer {
     }
 
     /**
-     * Summarises the per-query judgment results into success/failure counts and a list of failed
-     * queries with their reasons. A query is considered failed when it produced no ratings; the
-     * reason is taken from the optional "error" entry on the result, or a default message otherwise.
+     * Builds the list of docs that were sent to the LLM but never received a rating. Each entry holds
+     * only the docId: a failure is request-level (throttling, timeout, parse error), so there is no
+     * reliable per-doc reason to attach.
      *
-     * @param judgmentResults per-query results, each holding "query", "ratings" and an optional "error"
-     * @return a map with totalQueries, successfulQueries, failedQueries and a failures list
+     * @param sentDocIds  docs that were sent to the LLM (all search hits for the query)
+     * @param ratedDocIds docs that came back with a rating
+     * @return a list of {"docId": ...} maps for the unrated docs, empty when everything was rated
+     */
+    public static List<Map<String, String>> buildFailedDocs(Set<String> sentDocIds, Set<String> ratedDocIds) {
+        List<Map<String, String>> failures = new ArrayList<>();
+        for (String docId : sentDocIds) {
+            if (!ratedDocIds.contains(docId)) {
+                failures.add(Map.of("docId", docId));
+            }
+        }
+        return failures;
+    }
+
+    /**
+     * Summarises the per-query results into a metadata overview: total/successful/failed query counts
+     * plus the last failure reason seen. A query counts as failed when it has at least one unrated doc
+     * (a non-empty "failures" list), so a partially-rated query is reported as failed rather than
+     * hiding the gap. This is a quick overview only; the per-doc detail lives on each entry's "failures".
+     *
+     * @param judgmentResults per-query results, each holding "query", "ratings", an optional "failures" list and an optional {@link #RESULT_FAILURE_REASON}
+     * @return a map with totalQueries, successfulQueries, failedQueries and (when any failed) lastFailureReason
      */
     public static Map<String, Object> buildJudgmentSummary(List<Map<String, Object>> judgmentResults) {
-        List<Map<String, Object>> failures = new ArrayList<>();
-        int successfulQueries = 0;
+        int failedQueries = 0;
+        String lastFailureReason = null;
 
         for (Map<String, Object> result : judgmentResults) {
-            Object ratings = result.get("ratings");
-            boolean hasRatings = ratings instanceof List && !((List<?>) ratings).isEmpty();
-            if (hasRatings) {
-                successfulQueries++;
-            } else {
-                Object error = result.get("error");
-                Map<String, Object> failure = new HashMap<>();
-                failure.put("query", result.get("query"));
-                failure.put("reason", error != null ? error.toString() : "No ratings were generated");
-                failures.add(failure);
+            Object failures = result.get("failures");
+            if (failures instanceof List && !((List<?>) failures).isEmpty()) {
+                failedQueries++;
+            }
+            Object reason = result.get(RESULT_FAILURE_REASON);
+            if (reason != null) {
+                lastFailureReason = reason.toString();
             }
         }
 
         Map<String, Object> summary = new HashMap<>();
         summary.put("totalQueries", judgmentResults.size());
-        summary.put("successfulQueries", successfulQueries);
-        summary.put("failedQueries", failures.size());
-        summary.put("failures", failures);
+        summary.put("successfulQueries", judgmentResults.size() - failedQueries);
+        summary.put("failedQueries", failedQueries);
+        if (lastFailureReason != null) {
+            summary.put("lastFailureReason", lastFailureReason);
+        }
         return summary;
     }
 

--- a/src/main/java/org/opensearch/searchrelevance/judgments/LlmJudgmentsProcessor.java
+++ b/src/main/java/org/opensearch/searchrelevance/judgments/LlmJudgmentsProcessor.java
@@ -23,10 +23,12 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 
 import org.opensearch.action.StepListener;
@@ -132,8 +134,8 @@ public class LlmJudgmentsProcessor implements BaseJudgmentsProcessor {
                 .map(id -> searchConfigurationDao.getSearchConfigurationSync(id))
                 .collect(Collectors.toList());
 
-            // Record per-run success/failure counts and failed queries (with reasons) into the judgment
-            // metadata before handing the ratings back, so the stored judgment reflects partial outcomes.
+            // Record a per-run overview (total/successful/failed counts and the last failure reason)
+            // into the judgment metadata before handing the ratings back.
             ActionListener<List<Map<String, Object>>> summaryListener = ActionListener.wrap(results -> {
                 metadata.putAll(JudgmentDataTransformer.buildJudgmentSummary(results));
                 listener.onResponse(results);
@@ -320,8 +322,9 @@ public class LlmJudgmentsProcessor implements BaseJudgmentsProcessor {
             );
 
             // Step 3: Process with LLM if needed
+            String llmFailureReason = null;
             if (!unprocessedDocIds.isEmpty()) {
-                processWithLLM(
+                llmFailureReason = processWithLLM(
                     modelId,
                     queryText,
                     queryTextWithCustomInput,
@@ -337,7 +340,12 @@ public class LlmJudgmentsProcessor implements BaseJudgmentsProcessor {
                 );
             }
 
-            Map<String, Object> result = JudgmentDataTransformer.createJudgmentResult(queryTextWithCustomInput, docIdToScore);
+            Map<String, Object> result = buildResultWithFailures(queryTextWithCustomInput, allHits.keySet(), docIdToScore);
+            // A remote error can come back as a failed chunk rather than a thrown exception; carry its
+            // message so the metadata overview can report why the docs went unrated.
+            if (llmFailureReason != null) {
+                result.put(JudgmentDataTransformer.RESULT_FAILURE_REASON, llmFailureReason);
+            }
             return result;
         } catch (Exception e) {
             log.warn(
@@ -347,12 +355,31 @@ public class LlmJudgmentsProcessor implements BaseJudgmentsProcessor {
                 e.getMessage(),
                 e
             );
-            // Always return a result with whatever ratings we managed to collect, tagging the failure
-            // reason so it can be surfaced in the judgment summary.
-            Map<String, Object> result = JudgmentDataTransformer.createJudgmentResult(queryTextWithCustomInput, docIdToScore);
-            result.put("error", e.getMessage());
+            // Return whatever ratings we collected; every doc we sent but did not get a score for is
+            // listed under "failures" so it is visible instead of silently dropped. The reason is
+            // tagged for the metadata overview but not persisted on the entry.
+            Map<String, Object> result = buildResultWithFailures(queryTextWithCustomInput, allHits.keySet(), docIdToScore);
+            result.put(JudgmentDataTransformer.RESULT_FAILURE_REASON, e.getMessage());
             return result;
         }
+    }
+
+    /**
+     * Builds the per-query result and attaches a "failures" list for every sent doc that never got a
+     * rating (real scores stay in "ratings"; failed docs are listed, not given a placeholder rating).
+     * Package-private for testing.
+     */
+    static Map<String, Object> buildResultWithFailures(
+        String queryTextWithCustomInput,
+        Set<String> sentDocIds,
+        Map<String, String> docIdToScore
+    ) {
+        Map<String, Object> result = JudgmentDataTransformer.createJudgmentResult(queryTextWithCustomInput, docIdToScore);
+        List<Map<String, String>> failures = JudgmentDataTransformer.buildFailedDocs(sentDocIds, docIdToScore.keySet());
+        if (!failures.isEmpty()) {
+            result.put("failures", failures);
+        }
+        return result;
     }
 
     private void processSearchConfigurationsAsync(
@@ -436,7 +463,10 @@ public class LlmJudgmentsProcessor implements BaseJudgmentsProcessor {
         return unprocessedDocIds;
     }
 
-    private void processWithLLM(
+    /**
+     * @return the reason a chunk failed (when the remote reported an error without throwing), or null when the call succeeded
+     */
+    private String processWithLLM(
         String modelId,
         String queryText,
         String queryTextWithCustomInput,
@@ -470,6 +500,7 @@ public class LlmJudgmentsProcessor implements BaseJudgmentsProcessor {
 
         // Synchronous LLM call
         PlainActionFuture<Map<String, String>> llmFuture = PlainActionFuture.newFuture();
+        AtomicReference<String> failureReason = new AtomicReference<>();
         generateLLMJudgmentForQueryText(
             modelId,
             queryText,
@@ -482,6 +513,7 @@ public class LlmJudgmentsProcessor implements BaseJudgmentsProcessor {
             promptTemplate,
             ratingType,
             promptTemplateCode,
+            failureReason,
             llmFuture
         );
 
@@ -489,6 +521,7 @@ public class LlmJudgmentsProcessor implements BaseJudgmentsProcessor {
         docIdToScore.putAll(llmResults);
 
         log.info("LLM processing completed. Generated {} ratings", llmResults.size());
+        return failureReason.get();
     }
 
     private void generateLLMJudgmentForQueryText(
@@ -503,6 +536,7 @@ public class LlmJudgmentsProcessor implements BaseJudgmentsProcessor {
         String promptTemplate,
         LLMJudgmentRatingType ratingType,
         String promptTemplateCode,
+        AtomicReference<String> failureReasonOut,
         ActionListener<Map<String, String>> listener
     ) {
         log.debug("calculating LLM evaluation with modelId: {} and unprocessed unionHits: {}", modelId, unprocessedUnionHits);
@@ -554,6 +588,14 @@ public class LlmJudgmentsProcessor implements BaseJudgmentsProcessor {
                         }
 
                         logFailedChunks(chunkResult);
+
+                        // Capture the first chunk error as the query's failure reason. The remote can
+                        // report an error via a failed chunk without throwing, so this is how the
+                        // reason reaches the metadata overview.
+                        Map<Integer, String> failedChunks = chunkResult.getFailedChunks();
+                        if (!failedChunks.isEmpty()) {
+                            failureReasonOut.compareAndSet(null, failedChunks.values().iterator().next());
+                        }
 
                         if (chunkResult.isLastChunk() && !hasFailure.get()) {
                             log.info(

--- a/src/main/java/org/opensearch/searchrelevance/judgments/LlmJudgmentsProcessor.java
+++ b/src/main/java/org/opensearch/searchrelevance/judgments/LlmJudgmentsProcessor.java
@@ -132,6 +132,13 @@ public class LlmJudgmentsProcessor implements BaseJudgmentsProcessor {
                 .map(id -> searchConfigurationDao.getSearchConfigurationSync(id))
                 .collect(Collectors.toList());
 
+            // Record per-run success/failure counts and failed queries (with reasons) into the judgment
+            // metadata before handing the ratings back, so the stored judgment reflects partial outcomes.
+            ActionListener<List<Map<String, Object>>> summaryListener = ActionListener.wrap(results -> {
+                metadata.putAll(JudgmentDataTransformer.buildJudgmentSummary(results));
+                listener.onResponse(results);
+            }, listener::onFailure);
+
             generateLLMJudgmentsAsync(
                 modelId,
                 size,
@@ -143,7 +150,7 @@ public class LlmJudgmentsProcessor implements BaseJudgmentsProcessor {
                 promptTemplate,
                 ratingType,
                 overwriteCache,
-                listener
+                summaryListener
             );
         } catch (Exception e) {
             log.error("Failed to generate LLM judgments", e);
@@ -340,8 +347,11 @@ public class LlmJudgmentsProcessor implements BaseJudgmentsProcessor {
                 e.getMessage(),
                 e
             );
-            // Always return a result with whatever ratings we managed to collect
-            return JudgmentDataTransformer.createJudgmentResult(queryTextWithCustomInput, docIdToScore);
+            // Always return a result with whatever ratings we managed to collect, tagging the failure
+            // reason so it can be surfaced in the judgment summary.
+            Map<String, Object> result = JudgmentDataTransformer.createJudgmentResult(queryTextWithCustomInput, docIdToScore);
+            result.put("error", e.getMessage());
+            return result;
         }
     }
 

--- a/src/main/java/org/opensearch/searchrelevance/ml/MLAccessor.java
+++ b/src/main/java/org/opensearch/searchrelevance/ml/MLAccessor.java
@@ -10,8 +10,6 @@ package org.opensearch.searchrelevance.ml;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.TimeUnit;
 
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.ml.client.MachineLearningNodeClient;
@@ -29,9 +27,6 @@ import lombok.extern.log4j.Log4j2;
 public class MLAccessor {
     private final MachineLearningNodeClient mlClient;
     private final MLInputOutputTransformer transformer;
-
-    private static final int MAX_RETRY_NUMBER = 3;
-    private static final long RETRY_DELAY_MS = 1000;
 
     public MLAccessor(MachineLearningNodeClient mlClient) {
         this.mlClient = mlClient;
@@ -77,103 +72,39 @@ public class MLAccessor {
         boolean triedWithoutResponseFormat,
         ChunkProcessingContext context
     ) {
-        predictSingleChunkWithRetry(modelId, mlInput, chunkIndex, 0, triedWithoutResponseFormat, ActionListener.wrap(response -> {
+        predictSingleChunk(modelId, mlInput, ActionListener.wrap(response -> {
             log.info("Chunk {} processed successfully", chunkIndex);
             String processedResponse = cleanResponse(response);
 
-            // Check if parsing failed (empty ratings array) and we haven't tried without response_format yet
+            // Empty ratings: retry once without response_format for models that do not support structured output.
             if ("[]".equals(processedResponse) && !triedWithoutResponseFormat) {
-                log.warn(
-                    "Chunk {} returned empty ratings with response_format. Retrying without response_format for GPT-3.5 compatibility...",
-                    chunkIndex
-                );
-                // Create new MLInput without response_format and retry
+                log.warn("Chunk {} returned empty ratings with response_format. Retrying without response_format...", chunkIndex);
                 MLInput mlInputWithoutFormat = recreateMLInputWithoutResponseFormat(mlInput);
-                scheduleRetry(() -> processChunkWithFallback(modelId, mlInputWithoutFormat, chunkIndex, true, context), RETRY_DELAY_MS);
+                processChunkWithFallback(modelId, mlInputWithoutFormat, chunkIndex, true, context);
             } else {
                 context.handleSuccess(chunkIndex, processedResponse);
             }
         }, e -> {
-            log.error("Chunk {} failed after all retries", chunkIndex, e);
-            context.handleFailure(chunkIndex, e);
+            // On failure, retry once without response_format for models that do not support structured output.
+            // Transient-error retries (throttling, 5xx, timeouts) are handled by the ml-commons connector's client_config.
+            if (!triedWithoutResponseFormat) {
+                log.warn("Chunk {} failed with response_format. Retrying without response_format...", chunkIndex, e);
+                MLInput mlInputWithoutFormat = recreateMLInputWithoutResponseFormat(mlInput);
+                processChunkWithFallback(modelId, mlInputWithoutFormat, chunkIndex, true, context);
+            } else {
+                log.error("Chunk {} failed", chunkIndex, e);
+                context.handleFailure(chunkIndex, e);
+            }
         }));
     }
 
     private String cleanResponse(String response) {
-        // Use sanitizeLLMResponse to handle both structured (with response_format) and unstructured responses
-        // For GPT-4o with response_format: extracts {"ratings": [...]}
-        // For GPT-3.5 without response_format: parses and sanitizes unstructured JSON
+        // Handle both structured (with response_format) and unstructured responses
         return RatingOutputProcessor.sanitizeLLMResponse(response);
     }
 
     /**
-     * Retries prediction with automatic fallback to non-structured output.
-     * First tries with response_format, then falls back to without response_format if it fails.
-     *
-     * @param triedWithoutResponseFormat Tracks if we've already tried without response_format
-     */
-    private void predictSingleChunkWithRetry(
-        String modelId,
-        MLInput mlInput,
-        int chunkIndex,
-        int retryCount,
-        boolean triedWithoutResponseFormat,
-        ActionListener<String> chunkListener
-    ) {
-        predictSingleChunk(modelId, mlInput, new ActionListener<String>() {
-            @Override
-            public void onResponse(String response) {
-                log.debug(
-                    "DEBUG: Chunk {} received response (length: {}). First 200 chars: {}",
-                    chunkIndex,
-                    response.length(),
-                    response.substring(0, Math.min(200, response.length()))
-                );
-                chunkListener.onResponse(response);
-            }
-
-            @Override
-            public void onFailure(Exception e) {
-                log.debug(
-                    "DEBUG: Chunk {} failed with error: {}. triedWithoutResponseFormat: {}, retryCount: {}",
-                    chunkIndex,
-                    e.getMessage(),
-                    triedWithoutResponseFormat,
-                    retryCount
-                );
-                // If we haven't tried without response_format yet, try that first before regular retries
-                if (!triedWithoutResponseFormat) {
-                    log.warn(
-                        "Chunk {} failed with response_format. Retrying without response_format for GPT-3.5 compatibility...",
-                        chunkIndex
-                    );
-                    log.debug("DEBUG: Creating MLInput without response_format for chunk {}", chunkIndex);
-
-                    // Create new MLInput without response_format
-                    MLInput mlInputWithoutFormat = recreateMLInputWithoutResponseFormat(mlInput);
-
-                    long delay = RETRY_DELAY_MS;
-                    scheduleRetry(
-                        () -> predictSingleChunkWithRetry(modelId, mlInputWithoutFormat, chunkIndex, 0, true, chunkListener),
-                        delay
-                    );
-                } else if (retryCount < MAX_RETRY_NUMBER) {
-                    log.warn("Chunk {} failed, attempt {}/{}. Retrying...", chunkIndex, retryCount + 1, MAX_RETRY_NUMBER);
-
-                    long delay = RETRY_DELAY_MS * (long) Math.pow(2, retryCount);
-                    scheduleRetry(
-                        () -> predictSingleChunkWithRetry(modelId, mlInput, chunkIndex, retryCount + 1, true, chunkListener),
-                        delay
-                    );
-                } else {
-                    chunkListener.onFailure(e);
-                }
-            }
-        });
-    }
-
-    /**
-     * Recreates MLInput without response_format parameter for models that don't support it (e.g., GPT-3.5).
+     * Recreates MLInput without the response_format parameter for models that do not support structured output.
      */
     private MLInput recreateMLInputWithoutResponseFormat(MLInput originalInput) {
         // Extract the parameters from the original input and rebuild without response_format
@@ -189,10 +120,6 @@ public class MLAccessor {
         }
 
         return MLInput.builder().algorithm(originalInput.getAlgorithm()).inputDataset(new RemoteInferenceInputDataSet(newParams)).build();
-    }
-
-    private void scheduleRetry(Runnable runnable, long delayMs) {
-        CompletableFuture.delayedExecutor(delayMs, TimeUnit.MILLISECONDS).execute(runnable);
     }
 
     public void predictSingleChunk(String modelId, MLInput mlInput, ActionListener<String> listener) {

--- a/src/main/java/org/opensearch/searchrelevance/ml/MLAccessor.java
+++ b/src/main/java/org/opensearch/searchrelevance/ml/MLAccessor.java
@@ -7,7 +7,6 @@
  */
 package org.opensearch.searchrelevance.ml;
 
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -62,64 +61,19 @@ public class MLAccessor {
     }
 
     private void processChunk(String modelId, MLInput mlInput, int chunkIndex, ChunkProcessingContext context) {
-        processChunkWithFallback(modelId, mlInput, chunkIndex, false, context);
-    }
-
-    private void processChunkWithFallback(
-        String modelId,
-        MLInput mlInput,
-        int chunkIndex,
-        boolean triedWithoutResponseFormat,
-        ChunkProcessingContext context
-    ) {
+        // Transient-error retries (throttling, 5xx, timeouts) are handled by the ml-commons connector's client_config.
         predictSingleChunk(modelId, mlInput, ActionListener.wrap(response -> {
             log.info("Chunk {} processed successfully", chunkIndex);
-            String processedResponse = cleanResponse(response);
-
-            // Empty ratings: retry once without response_format for models that do not support structured output.
-            if ("[]".equals(processedResponse) && !triedWithoutResponseFormat) {
-                log.warn("Chunk {} returned empty ratings with response_format. Retrying without response_format...", chunkIndex);
-                MLInput mlInputWithoutFormat = recreateMLInputWithoutResponseFormat(mlInput);
-                processChunkWithFallback(modelId, mlInputWithoutFormat, chunkIndex, true, context);
-            } else {
-                context.handleSuccess(chunkIndex, processedResponse);
-            }
+            context.handleSuccess(chunkIndex, cleanResponse(response));
         }, e -> {
-            // On failure, retry once without response_format for models that do not support structured output.
-            // Transient-error retries (throttling, 5xx, timeouts) are handled by the ml-commons connector's client_config.
-            if (!triedWithoutResponseFormat) {
-                log.warn("Chunk {} failed with response_format. Retrying without response_format...", chunkIndex, e);
-                MLInput mlInputWithoutFormat = recreateMLInputWithoutResponseFormat(mlInput);
-                processChunkWithFallback(modelId, mlInputWithoutFormat, chunkIndex, true, context);
-            } else {
-                log.error("Chunk {} failed", chunkIndex, e);
-                context.handleFailure(chunkIndex, e);
-            }
+            log.error("Chunk {} failed", chunkIndex, e);
+            context.handleFailure(chunkIndex, e);
         }));
     }
 
     private String cleanResponse(String response) {
         // Handle both structured (with response_format) and unstructured responses
         return RatingOutputProcessor.sanitizeLLMResponse(response);
-    }
-
-    /**
-     * Recreates MLInput without the response_format parameter for models that do not support structured output.
-     */
-    private MLInput recreateMLInputWithoutResponseFormat(MLInput originalInput) {
-        // Extract the parameters from the original input and rebuild without response_format
-        RemoteInferenceInputDataSet originalDataSet = (RemoteInferenceInputDataSet) originalInput.getInputDataset();
-        Map<String, String> originalParams = originalDataSet.getParameters();
-
-        // Create new parameters map without response_format
-        Map<String, String> newParams = new HashMap<>();
-        for (Map.Entry<String, String> entry : originalParams.entrySet()) {
-            if (!"response_format".equals(entry.getKey())) {
-                newParams.put(entry.getKey(), entry.getValue());
-            }
-        }
-
-        return MLInput.builder().algorithm(originalInput.getAlgorithm()).inputDataset(new RemoteInferenceInputDataSet(newParams)).build();
     }
 
     public void predictSingleChunk(String modelId, MLInput mlInput, ActionListener<String> listener) {

--- a/src/main/java/org/opensearch/searchrelevance/ml/MLInputOutputTransformer.java
+++ b/src/main/java/org/opensearch/searchrelevance/ml/MLInputOutputTransformer.java
@@ -116,23 +116,6 @@ public class MLInputOutputTransformer {
         String promptTemplate,
         LLMJudgmentRatingType ratingType
     ) {
-        return createMLInput(searchText, referenceData, hits, promptTemplate, ratingType, true);
-    }
-
-    /**
-     * Creates MLInput with optional response_format parameter.
-     * Some models (like GPT-3.5) don't support response_format, so we can disable it for fallback.
-     *
-     * @param includeResponseFormat If true, includes response_format parameter; if false, excludes it
-     */
-    public MLInput createMLInput(
-        String searchText,
-        Map<String, String> referenceData,
-        Map<String, String> hits,
-        String promptTemplate,
-        LLMJudgmentRatingType ratingType,
-        boolean includeResponseFormat
-    ) {
         Map<String, String> parameters = new HashMap<>();
         String messagesArray = buildMessagesArray(searchText, referenceData, hits, promptTemplate, ratingType);
 
@@ -142,11 +125,8 @@ public class MLInputOutputTransformer {
         parameters.put(PARAM_SYSTEM_PROMPT_FIELD, getSystemPrompt(ratingType));
         parameters.put(PARAM_USER_PROMPT_FIELD, escapeJson(buildUserContent(searchText, referenceData, hits, promptTemplate)));
 
-        // Only add response_format if requested (for models that support it)
-        if (includeResponseFormat) {
-            String responseFormat = getResponseFormat(ratingType);
-            parameters.put("response_format", responseFormat);
-        }
+        // Legacy OpenAI structured-output spec, kept for connectors that reference ${parameters.response_format}
+        parameters.put("response_format", getResponseFormat(ratingType));
 
         return MLInput.builder().algorithm(FunctionName.REMOTE).inputDataset(new RemoteInferenceInputDataSet(parameters)).build();
     }

--- a/src/main/java/org/opensearch/searchrelevance/model/Judgment.java
+++ b/src/main/java/org/opensearch/searchrelevance/model/Judgment.java
@@ -62,6 +62,18 @@ public class Judgment implements ToXContentObject {
                 xContentBuilder.endObject();
             }
             xContentBuilder.endArray();
+            Object failures = judgment.get("failures");
+            if (failures instanceof List && !((List<?>) failures).isEmpty()) {
+                xContentBuilder.startArray("failures");
+                for (Map<String, Object> failure : (List<Map<String, Object>>) failures) {
+                    xContentBuilder.startObject();
+                    for (Map.Entry<String, Object> entry : failure.entrySet()) {
+                        xContentBuilder.field(entry.getKey(), entry.getValue());
+                    }
+                    xContentBuilder.endObject();
+                }
+                xContentBuilder.endArray();
+            }
             xContentBuilder.endObject();
         }
         xContentBuilder.endArray();

--- a/src/test/java/org/opensearch/searchrelevance/action/judgment/LlmJudgmentTemplateIT.java
+++ b/src/test/java/org/opensearch/searchrelevance/action/judgment/LlmJudgmentTemplateIT.java
@@ -137,9 +137,10 @@ public class LlmJudgmentTemplateIT extends BaseSearchRelevanceIT {
             Map<String, Object> firstRating = judgmentRatings.get(0);
             String queryText = (String) firstRating.get("query");
             assertNotNull(queryText);
-            assertTrue(queryText.contains("#\n")); // Custom delimiter
-            assertTrue(queryText.contains("category:"));
-            assertTrue(queryText.contains("referenceAnswer:"));
+            // Custom input is stored as "queryText#{json custom fields}"
+            assertTrue(queryText.contains("#"));
+            assertTrue(queryText.contains("category"));
+            assertTrue(queryText.contains("referenceAnswer"));
         }
     }
 

--- a/src/test/java/org/opensearch/searchrelevance/action/judgment/LlmJudgmentTemplateIT.java
+++ b/src/test/java/org/opensearch/searchrelevance/action/judgment/LlmJudgmentTemplateIT.java
@@ -137,10 +137,9 @@ public class LlmJudgmentTemplateIT extends BaseSearchRelevanceIT {
             Map<String, Object> firstRating = judgmentRatings.get(0);
             String queryText = (String) firstRating.get("query");
             assertNotNull(queryText);
-            // Custom input is stored as "queryText#{json custom fields}"
-            assertTrue(queryText.contains("#"));
-            assertTrue(queryText.contains("category"));
-            assertTrue(queryText.contains("referenceAnswer"));
+            assertTrue(queryText.contains("#\n")); // Custom delimiter
+            assertTrue(queryText.contains("category:"));
+            assertTrue(queryText.contains("referenceAnswer:"));
         }
     }
 

--- a/src/test/java/org/opensearch/searchrelevance/executors/JudgmentDataTransformerTests.java
+++ b/src/test/java/org/opensearch/searchrelevance/executors/JudgmentDataTransformerTests.java
@@ -184,4 +184,58 @@ public class JudgmentDataTransformerTests extends OpenSearchTestCase {
         assertEquals("doc1", ratings.get(0).get("docId"));
         assertEquals("1.0", ratings.get(0).get("rating"));
     }
+
+    public void testBuildJudgmentSummaryAllSuccessful() {
+        List<Map<String, Object>> results = List.of(
+            transformer.createJudgmentResult("q1", Map.of("doc1", "0.9")),
+            transformer.createJudgmentResult("q2", Map.of("doc2", "0.4"))
+        );
+
+        Map<String, Object> summary = JudgmentDataTransformer.buildJudgmentSummary(results);
+
+        assertEquals(2, summary.get("totalQueries"));
+        assertEquals(2, summary.get("successfulQueries"));
+        assertEquals(0, summary.get("failedQueries"));
+        assertTrue(((List<?>) summary.get("failures")).isEmpty());
+    }
+
+    public void testBuildJudgmentSummaryWithTaggedFailure() {
+        Map<String, Object> failed = transformer.createJudgmentResult("bad query", Map.of());
+        failed.put("error", "model timed out");
+
+        List<Map<String, Object>> results = List.of(transformer.createJudgmentResult("good query", Map.of("doc1", "1.0")), failed);
+
+        Map<String, Object> summary = JudgmentDataTransformer.buildJudgmentSummary(results);
+
+        assertEquals(2, summary.get("totalQueries"));
+        assertEquals(1, summary.get("successfulQueries"));
+        assertEquals(1, summary.get("failedQueries"));
+
+        List<Map<String, Object>> failures = (List<Map<String, Object>>) summary.get("failures");
+        assertEquals(1, failures.size());
+        assertEquals("bad query", failures.get(0).get("query"));
+        assertEquals("model timed out", failures.get(0).get("reason"));
+    }
+
+    public void testBuildJudgmentSummaryEmptyRatingsWithoutErrorUsesDefaultReason() {
+        List<Map<String, Object>> results = List.of(transformer.createJudgmentResult("silent query", Map.of()));
+
+        Map<String, Object> summary = JudgmentDataTransformer.buildJudgmentSummary(results);
+
+        assertEquals(0, summary.get("successfulQueries"));
+        assertEquals(1, summary.get("failedQueries"));
+
+        List<Map<String, Object>> failures = (List<Map<String, Object>>) summary.get("failures");
+        assertEquals("silent query", failures.get(0).get("query"));
+        assertEquals("No ratings were generated", failures.get(0).get("reason"));
+    }
+
+    public void testBuildJudgmentSummaryEmptyResults() {
+        Map<String, Object> summary = JudgmentDataTransformer.buildJudgmentSummary(List.of());
+
+        assertEquals(0, summary.get("totalQueries"));
+        assertEquals(0, summary.get("successfulQueries"));
+        assertEquals(0, summary.get("failedQueries"));
+        assertTrue(((List<?>) summary.get("failures")).isEmpty());
+    }
 }

--- a/src/test/java/org/opensearch/searchrelevance/executors/JudgmentDataTransformerTests.java
+++ b/src/test/java/org/opensearch/searchrelevance/executors/JudgmentDataTransformerTests.java
@@ -9,6 +9,7 @@ package org.opensearch.searchrelevance.executors;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import org.opensearch.searchrelevance.judgments.JudgmentDataTransformer;
 import org.opensearch.test.OpenSearchTestCase;
@@ -185,6 +186,51 @@ public class JudgmentDataTransformerTests extends OpenSearchTestCase {
         assertEquals("1.0", ratings.get(0).get("rating"));
     }
 
+    public void testBuildFailedDocsListsUnratedDocs() {
+        Set<String> sentDocIds = Set.of("A", "B", "C");
+        Set<String> ratedDocIds = Set.of("A", "B");
+
+        List<Map<String, String>> failures = JudgmentDataTransformer.buildFailedDocs(sentDocIds, ratedDocIds);
+
+        assertEquals(1, failures.size());
+        assertEquals("C", failures.get(0).get("docId"));
+    }
+
+    public void testBuildFailedDocsAllRated() {
+        Set<String> sentDocIds = Set.of("A", "B");
+        Set<String> ratedDocIds = Set.of("A", "B");
+
+        assertTrue(JudgmentDataTransformer.buildFailedDocs(sentDocIds, ratedDocIds).isEmpty());
+    }
+
+    public void testBuildFailedDocsNoDocsSent() {
+        // No search hits for the query: nothing was sent, so there is nothing to report as failed.
+        assertTrue(JudgmentDataTransformer.buildFailedDocs(Set.of(), Set.of()).isEmpty());
+    }
+
+    public void testBuildFailedDocsAllFailed() {
+        Set<String> sentDocIds = Set.of("A", "B");
+        Set<String> ratedDocIds = Set.of();
+
+        List<Map<String, String>> failures = JudgmentDataTransformer.buildFailedDocs(sentDocIds, ratedDocIds);
+
+        assertEquals(2, failures.size());
+        Set<String> failedIds = failures.stream().map(f -> f.get("docId")).collect(java.util.stream.Collectors.toSet());
+        assertEquals(Set.of("A", "B"), failedIds);
+    }
+
+    private Map<String, Object> resultWithFailures(String query, Map<String, String> ratings, String... failedDocIds) {
+        Map<String, Object> result = transformer.createJudgmentResult(query, ratings);
+        if (failedDocIds.length > 0) {
+            List<Map<String, String>> failures = new java.util.ArrayList<>();
+            for (String docId : failedDocIds) {
+                failures.add(Map.of("docId", docId));
+            }
+            result.put("failures", failures);
+        }
+        return result;
+    }
+
     public void testBuildJudgmentSummaryAllSuccessful() {
         List<Map<String, Object>> results = List.of(
             transformer.createJudgmentResult("q1", Map.of("doc1", "0.9")),
@@ -196,38 +242,45 @@ public class JudgmentDataTransformerTests extends OpenSearchTestCase {
         assertEquals(2, summary.get("totalQueries"));
         assertEquals(2, summary.get("successfulQueries"));
         assertEquals(0, summary.get("failedQueries"));
-        assertTrue(((List<?>) summary.get("failures")).isEmpty());
+        assertFalse("no lastFailureReason when nothing failed", summary.containsKey("lastFailureReason"));
     }
 
-    public void testBuildJudgmentSummaryWithTaggedFailure() {
-        Map<String, Object> failed = transformer.createJudgmentResult("bad query", Map.of());
-        failed.put("error", "model timed out");
-
-        List<Map<String, Object>> results = List.of(transformer.createJudgmentResult("good query", Map.of("doc1", "1.0")), failed);
+    public void testBuildJudgmentSummaryCountsQueryWithFailuresAsFailed() {
+        // "good" is fully rated; "bad" has an unrated doc, so it counts as failed.
+        List<Map<String, Object>> results = List.of(
+            resultWithFailures("good", Map.of("doc1", "1.0")),
+            resultWithFailures("bad", Map.of(), "doc2")
+        );
 
         Map<String, Object> summary = JudgmentDataTransformer.buildJudgmentSummary(results);
 
         assertEquals(2, summary.get("totalQueries"));
         assertEquals(1, summary.get("successfulQueries"));
         assertEquals(1, summary.get("failedQueries"));
-
-        List<Map<String, Object>> failures = (List<Map<String, Object>>) summary.get("failures");
-        assertEquals(1, failures.size());
-        assertEquals("bad query", failures.get(0).get("query"));
-        assertEquals("model timed out", failures.get(0).get("reason"));
     }
 
-    public void testBuildJudgmentSummaryEmptyRatingsWithoutErrorUsesDefaultReason() {
-        List<Map<String, Object>> results = List.of(transformer.createJudgmentResult("silent query", Map.of()));
+    public void testBuildJudgmentSummaryPartiallyRatedQueryCountsAsFailed() {
+        // A query with some real ratings AND an unrated doc still counts as failed.
+        List<Map<String, Object>> results = List.of(resultWithFailures("laptop", Map.of("doc1", "1.0"), "doc6"));
 
         Map<String, Object> summary = JudgmentDataTransformer.buildJudgmentSummary(results);
 
+        assertEquals(1, summary.get("totalQueries"));
         assertEquals(0, summary.get("successfulQueries"));
         assertEquals(1, summary.get("failedQueries"));
+    }
 
-        List<Map<String, Object>> failures = (List<Map<String, Object>>) summary.get("failures");
-        assertEquals("silent query", failures.get(0).get("query"));
-        assertEquals("No ratings were generated", failures.get(0).get("reason"));
+    public void testBuildJudgmentSummaryRecordsLastFailureReason() {
+        Map<String, Object> failed = resultWithFailures("bad", Map.of(), "doc1");
+        failed.put(JudgmentDataTransformer.RESULT_FAILURE_REASON, "model timed out");
+
+        List<Map<String, Object>> results = List.of(transformer.createJudgmentResult("good", Map.of("doc1", "1.0")), failed);
+
+        Map<String, Object> summary = JudgmentDataTransformer.buildJudgmentSummary(results);
+
+        assertEquals(1, summary.get("successfulQueries"));
+        assertEquals(1, summary.get("failedQueries"));
+        assertEquals("model timed out", summary.get("lastFailureReason"));
     }
 
     public void testBuildJudgmentSummaryEmptyResults() {
@@ -236,6 +289,6 @@ public class JudgmentDataTransformerTests extends OpenSearchTestCase {
         assertEquals(0, summary.get("totalQueries"));
         assertEquals(0, summary.get("successfulQueries"));
         assertEquals(0, summary.get("failedQueries"));
-        assertTrue(((List<?>) summary.get("failures")).isEmpty());
+        assertFalse(summary.containsKey("lastFailureReason"));
     }
 }

--- a/src/test/java/org/opensearch/searchrelevance/judgments/LlmJudgmentsProcessorTests.java
+++ b/src/test/java/org/opensearch/searchrelevance/judgments/LlmJudgmentsProcessorTests.java
@@ -12,6 +12,7 @@ import static org.mockito.Mockito.when;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
 import org.junit.Before;
@@ -190,6 +191,53 @@ public class LlmJudgmentsProcessorTests extends OpenSearchTestCase {
 
         assertTrue("Valid values should contain SCORE0_1", validValues.contains("SCORE0_1"));
         assertTrue("Valid values should contain RELEVANT_IRRELEVANT", validValues.contains("RELEVANT_IRRELEVANT"));
+    }
+
+    // ============================================
+    // buildResultWithFailures Tests
+    // ============================================
+
+    @SuppressWarnings("unchecked")
+    public void testBuildResultWithFailures_partialFailure() {
+        Map<String, String> docIdToScore = Map.of("A", "0.9", "B", "0.4");
+
+        Map<String, Object> result = LlmJudgmentsProcessor.buildResultWithFailures("laptop", Set.of("A", "B", "C"), docIdToScore);
+
+        assertEquals("laptop", result.get("query"));
+        List<Map<String, String>> ratings = (List<Map<String, String>>) result.get("ratings");
+        assertEquals(2, ratings.size());
+
+        List<Map<String, String>> failures = (List<Map<String, String>>) result.get("failures");
+        assertNotNull(failures);
+        assertEquals(1, failures.size());
+        assertEquals("C", failures.get(0).get("docId"));
+    }
+
+    @SuppressWarnings("unchecked")
+    public void testBuildResultWithFailures_allRated_noFailuresKey() {
+        Map<String, String> docIdToScore = Map.of("A", "0.9", "B", "0.4");
+
+        Map<String, Object> result = LlmJudgmentsProcessor.buildResultWithFailures("laptop", Set.of("A", "B"), docIdToScore);
+
+        assertEquals(2, ((List<Map<String, String>>) result.get("ratings")).size());
+        assertFalse("no failures key when every doc was rated", result.containsKey("failures"));
+    }
+
+    @SuppressWarnings("unchecked")
+    public void testBuildResultWithFailures_allFailed_emptyRatings() {
+        Map<String, String> docIdToScore = Map.of();
+
+        Map<String, Object> result = LlmJudgmentsProcessor.buildResultWithFailures("laptop", Set.of("A", "B"), docIdToScore);
+
+        assertTrue(((List<Map<String, String>>) result.get("ratings")).isEmpty());
+        assertEquals(2, ((List<Map<String, String>>) result.get("failures")).size());
+    }
+
+    public void testBuildResultWithFailures_noDocsSent_noFailuresKey() {
+        Map<String, Object> result = LlmJudgmentsProcessor.buildResultWithFailures("laptop", Set.of(), Map.of());
+
+        assertTrue(((List<?>) result.get("ratings")).isEmpty());
+        assertFalse("no failures key when nothing was sent", result.containsKey("failures"));
     }
 
     // ============================================

--- a/src/test/java/org/opensearch/searchrelevance/ml/MLAccessorIntegrationTests.java
+++ b/src/test/java/org/opensearch/searchrelevance/ml/MLAccessorIntegrationTests.java
@@ -32,29 +32,12 @@ import org.opensearch.searchrelevance.model.LLMJudgmentRatingType;
 import org.opensearch.test.OpenSearchTestCase;
 
 /**
- * Integration tests for MLAccessor focusing on:
- * - First attempt success with response_format (GPT-4o scenario)
- * - Response processing with structured outputs
- *
- * Note: Tests for retry logic and fallback behavior (GPT-3.5 compatibility) are documented
- * in TESTING_GPT35_FALLBACK.md as manual tests because they require delayed retries which
- * create thread leaks in the OpenSearch test framework. The retry mechanism uses
- * CompletableFuture.delayedExecutor which creates daemon threads that cannot be properly
- * cleaned up within test execution.
- *
- * Covered by unit tests:
- * - MLInputOutputTransformerTests: Verifies response_format parameter is correctly included/excluded
- * - RatingOutputProcessorTests: Verifies both structured and unstructured response parsing
+ * Integration tests for MLAccessor covering:
+ * - First-attempt success with response_format
+ * - One-shot fallback to no response_format on failure (for models without structured-output support)
+ * - No client-side retry loop: transient-error retries are delegated to the ml-commons connector
  */
 public class MLAccessorIntegrationTests extends OpenSearchTestCase {
-
-    /**
-     * Note: GPT-3.5 fallback testing is documented in TESTING_GPT35_FALLBACK.md as "Scenario 2"
-     * This scenario requires triggering scheduleRetry which creates CompletableFuture threads that leak.
-     * Coverage is provided by:
-     * - Unit tests: MLInputOutputTransformerTests verifies response_format parameter handling
-     * - Manual tests: Real OpenAI GPT-3.5 API integration testing
-     */
 
     /**
      * Test that MLAccessor works correctly on first attempt when model supports response_format.
@@ -118,20 +101,99 @@ public class MLAccessorIntegrationTests extends OpenSearchTestCase {
     }
 
     /**
-     * Note: Binary rating (RELEVANT/IRRELEVANT) fallback testing is documented in
-     * TESTING_GPT35_FALLBACK.md as "Scenario 3". This test would trigger scheduleRetry
-     * creating thread leaks. Coverage is provided by:
-     * - Unit tests: MLInputOutputTransformerTests.testCreateMLInput_BinaryRatingWithoutResponseFormat
-     * - Unit tests: RatingOutputProcessorTests verifies RELEVANT→1.0, IRRELEVANT→0.0 conversion
-     * - Manual tests: Real OpenAI API integration testing
+     * On failure with response_format, MLAccessor retries exactly once without response_format
+     * (for models without structured-output support) and succeeds. No additional client-side retries.
      */
+    public void testFallbackToWithoutResponseFormat_OnFailure() throws Exception {
+        MachineLearningNodeClient mlClient = mock(MachineLearningNodeClient.class);
+        MLAccessor mlAccessor = new MLAccessor(mlClient);
+
+        AtomicInteger attemptCount = new AtomicInteger(0);
+        CountDownLatch latch = new CountDownLatch(1);
+        AtomicReference<ChunkResult> result = new AtomicReference<>();
+
+        doAnswer(invocation -> {
+            MLInput mlInput = invocation.getArgument(1);
+            ActionListener<MLOutput> listener = invocation.getArgument(2);
+            attemptCount.incrementAndGet();
+
+            RemoteInferenceInputDataSet dataset = (RemoteInferenceInputDataSet) mlInput.getInputDataset();
+            boolean hasResponseFormat = dataset.getParameters().containsKey("response_format");
+
+            if (hasResponseFormat) {
+                // Model rejects structured output
+                listener.onFailure(new RuntimeException("response_format not supported"));
+            } else {
+                listener.onResponse(createMockMLOutput("{\"ratings\":[{\"id\":\"doc1\",\"rating_score\":0.9}]}"));
+            }
+            return null;
+        }).when(mlClient).predict(any(), any(MLInput.class), any());
+
+        mlAccessor.predict(
+            "gpt-3.5-turbo",
+            4000,
+            "test query",
+            new HashMap<>(),
+            Map.of("doc1", "test content"),
+            "Test prompt",
+            LLMJudgmentRatingType.SCORE0_1,
+            ActionListener.wrap(chunkResult -> {
+                result.set(chunkResult);
+                latch.countDown();
+            }, e -> latch.countDown())
+        );
+
+        assertTrue("Should complete", latch.await(10, TimeUnit.SECONDS));
+        assertEquals("One attempt with response_format, one without", 2, attemptCount.get());
+
+        ChunkResult chunkResult = result.get();
+        assertNotNull(chunkResult);
+        assertEquals(1, chunkResult.getSuccessfulChunksCount());
+        assertEquals(0, chunkResult.getFailedChunksCount());
+    }
 
     /**
-     * Note: Testing retry exhaustion (all attempts fail) is documented in TESTING_GPT35_FALLBACK.md
-     * as a manual test scenario because it requires delayed retries which create thread leaks in tests.
-     * The retry logic with exponential backoff uses CompletableFuture.delayedExecutor which creates
-     * daemon threads that cannot be properly cleaned up in the OpenSearch test framework.
+     * When every call fails, MLAccessor makes exactly two attempts (with then without response_format)
+     * and reports the chunk as failed. It does NOT enter a retry loop - transient-error retries are the
+     * ml-commons connector's responsibility.
      */
+    public void testNoClientSideRetryLoop_WhenAllAttemptsFail() throws Exception {
+        MachineLearningNodeClient mlClient = mock(MachineLearningNodeClient.class);
+        MLAccessor mlAccessor = new MLAccessor(mlClient);
+
+        AtomicInteger attemptCount = new AtomicInteger(0);
+        CountDownLatch latch = new CountDownLatch(1);
+        AtomicReference<ChunkResult> result = new AtomicReference<>();
+
+        doAnswer(invocation -> {
+            ActionListener<MLOutput> listener = invocation.getArgument(2);
+            attemptCount.incrementAndGet();
+            listener.onFailure(new RuntimeException("boom"));
+            return null;
+        }).when(mlClient).predict(any(), any(MLInput.class), any());
+
+        mlAccessor.predict(
+            "gpt-4o-mini",
+            4000,
+            "test query",
+            new HashMap<>(),
+            Map.of("doc1", "test content"),
+            "Test prompt",
+            LLMJudgmentRatingType.SCORE0_1,
+            ActionListener.wrap(chunkResult -> {
+                result.set(chunkResult);
+                latch.countDown();
+            }, e -> latch.countDown())
+        );
+
+        assertTrue("Should complete", latch.await(10, TimeUnit.SECONDS));
+        assertEquals("Exactly two attempts: with and without response_format, no retry loop", 2, attemptCount.get());
+
+        ChunkResult chunkResult = result.get();
+        assertNotNull(chunkResult);
+        assertEquals(0, chunkResult.getSuccessfulChunksCount());
+        assertEquals(1, chunkResult.getFailedChunksCount());
+    }
 
     // ============================================
     // Helper Methods

--- a/src/test/java/org/opensearch/searchrelevance/ml/MLAccessorIntegrationTests.java
+++ b/src/test/java/org/opensearch/searchrelevance/ml/MLAccessorIntegrationTests.java
@@ -33,9 +33,9 @@ import org.opensearch.test.OpenSearchTestCase;
 
 /**
  * Integration tests for MLAccessor covering:
- * - First-attempt success with response_format
- * - One-shot fallback to no response_format on failure (for models without structured-output support)
- * - No client-side retry loop: transient-error retries are delegated to the ml-commons connector
+ * - First-attempt success
+ * - Failures are reported after a single call (no client-side retry loop); transient-error retries
+ *   are delegated to the ml-commons connector
  */
 public class MLAccessorIntegrationTests extends OpenSearchTestCase {
 
@@ -101,63 +101,11 @@ public class MLAccessorIntegrationTests extends OpenSearchTestCase {
     }
 
     /**
-     * On failure with response_format, MLAccessor retries exactly once without response_format
-     * (for models without structured-output support) and succeeds. No additional client-side retries.
+     * On failure, MLAccessor reports the chunk as failed after exactly one call. It does not retry
+     * without response_format and does not enter a retry loop - transient-error retries (throttling,
+     * 5xx, timeouts) are the ml-commons connector's responsibility.
      */
-    public void testFallbackToWithoutResponseFormat_OnFailure() throws Exception {
-        MachineLearningNodeClient mlClient = mock(MachineLearningNodeClient.class);
-        MLAccessor mlAccessor = new MLAccessor(mlClient);
-
-        AtomicInteger attemptCount = new AtomicInteger(0);
-        CountDownLatch latch = new CountDownLatch(1);
-        AtomicReference<ChunkResult> result = new AtomicReference<>();
-
-        doAnswer(invocation -> {
-            MLInput mlInput = invocation.getArgument(1);
-            ActionListener<MLOutput> listener = invocation.getArgument(2);
-            attemptCount.incrementAndGet();
-
-            RemoteInferenceInputDataSet dataset = (RemoteInferenceInputDataSet) mlInput.getInputDataset();
-            boolean hasResponseFormat = dataset.getParameters().containsKey("response_format");
-
-            if (hasResponseFormat) {
-                // Model rejects structured output
-                listener.onFailure(new RuntimeException("response_format not supported"));
-            } else {
-                listener.onResponse(createMockMLOutput("{\"ratings\":[{\"id\":\"doc1\",\"rating_score\":0.9}]}"));
-            }
-            return null;
-        }).when(mlClient).predict(any(), any(MLInput.class), any());
-
-        mlAccessor.predict(
-            "gpt-3.5-turbo",
-            4000,
-            "test query",
-            new HashMap<>(),
-            Map.of("doc1", "test content"),
-            "Test prompt",
-            LLMJudgmentRatingType.SCORE0_1,
-            ActionListener.wrap(chunkResult -> {
-                result.set(chunkResult);
-                latch.countDown();
-            }, e -> latch.countDown())
-        );
-
-        assertTrue("Should complete", latch.await(10, TimeUnit.SECONDS));
-        assertEquals("One attempt with response_format, one without", 2, attemptCount.get());
-
-        ChunkResult chunkResult = result.get();
-        assertNotNull(chunkResult);
-        assertEquals(1, chunkResult.getSuccessfulChunksCount());
-        assertEquals(0, chunkResult.getFailedChunksCount());
-    }
-
-    /**
-     * When every call fails, MLAccessor makes exactly two attempts (with then without response_format)
-     * and reports the chunk as failed. It does NOT enter a retry loop - transient-error retries are the
-     * ml-commons connector's responsibility.
-     */
-    public void testNoClientSideRetryLoop_WhenAllAttemptsFail() throws Exception {
+    public void testFailure_reportedAfterSingleCall_noRetry() throws Exception {
         MachineLearningNodeClient mlClient = mock(MachineLearningNodeClient.class);
         MLAccessor mlAccessor = new MLAccessor(mlClient);
 
@@ -187,7 +135,7 @@ public class MLAccessorIntegrationTests extends OpenSearchTestCase {
         );
 
         assertTrue("Should complete", latch.await(10, TimeUnit.SECONDS));
-        assertEquals("Exactly two attempts: with and without response_format, no retry loop", 2, attemptCount.get());
+        assertEquals("Exactly one call, no retry loop", 1, attemptCount.get());
 
         ChunkResult chunkResult = result.get();
         assertNotNull(chunkResult);

--- a/src/test/java/org/opensearch/searchrelevance/ml/MLInputOutputTransformerTests.java
+++ b/src/test/java/org/opensearch/searchrelevance/ml/MLInputOutputTransformerTests.java
@@ -47,7 +47,7 @@ public class MLInputOutputTransformerTests extends OpenSearchTestCase {
         String promptTemplate = "Test prompt";
         LLMJudgmentRatingType ratingType = LLMJudgmentRatingType.SCORE0_1;
 
-        MLInput mlInput = transformer.createMLInput(searchText, referenceData, hits, promptTemplate, ratingType, true);
+        MLInput mlInput = transformer.createMLInput(searchText, referenceData, hits, promptTemplate, ratingType);
 
         assertNotNull(mlInput);
         RemoteInferenceInputDataSet dataset = (RemoteInferenceInputDataSet) mlInput.getInputDataset();
@@ -57,26 +57,6 @@ public class MLInputOutputTransformerTests extends OpenSearchTestCase {
         assertTrue("response_format parameter should be present", parameters.containsKey("response_format"));
         assertNotNull("response_format should not be null", parameters.get("response_format"));
         assertTrue("response_format should contain json_schema", parameters.get("response_format").contains("json_schema"));
-    }
-
-    public void testCreateMLInput_WithoutResponseFormat() {
-        String searchText = "test query";
-        Map<String, String> referenceData = new HashMap<>();
-        Map<String, String> hits = new HashMap<>();
-        hits.put("doc1", "test content");
-        String promptTemplate = "Test prompt";
-        LLMJudgmentRatingType ratingType = LLMJudgmentRatingType.SCORE0_1;
-
-        MLInput mlInput = transformer.createMLInput(searchText, referenceData, hits, promptTemplate, ratingType, false);
-
-        assertNotNull(mlInput);
-        RemoteInferenceInputDataSet dataset = (RemoteInferenceInputDataSet) mlInput.getInputDataset();
-        Map<String, String> parameters = dataset.getParameters();
-
-        // Should NOT include response_format parameter
-        assertFalse("response_format parameter should not be present for GPT-3.5 compatibility", parameters.containsKey("response_format"));
-        // Messages parameter should still be present
-        assertTrue("messages parameter should be present", parameters.containsKey("messages"));
     }
 
     public void testCreateMLInput_DefaultIncludesResponseFormat() {
@@ -110,7 +90,7 @@ public class MLInputOutputTransformerTests extends OpenSearchTestCase {
         String promptTemplate = "Test prompt";
         LLMJudgmentRatingType ratingType = LLMJudgmentRatingType.RELEVANT_IRRELEVANT;
 
-        MLInput mlInput = transformer.createMLInput(searchText, referenceData, hits, promptTemplate, ratingType, true);
+        MLInput mlInput = transformer.createMLInput(searchText, referenceData, hits, promptTemplate, ratingType);
 
         assertNotNull(mlInput);
         RemoteInferenceInputDataSet dataset = (RemoteInferenceInputDataSet) mlInput.getInputDataset();
@@ -124,24 +104,6 @@ public class MLInputOutputTransformerTests extends OpenSearchTestCase {
         assertTrue("Binary rating should include IRRELEVANT", responseFormat.contains("IRRELEVANT"));
     }
 
-    public void testCreateMLInput_BinaryRatingWithoutResponseFormat() {
-        String searchText = "test query";
-        Map<String, String> referenceData = new HashMap<>();
-        Map<String, String> hits = new HashMap<>();
-        hits.put("doc1", "test content");
-        String promptTemplate = "Test prompt";
-        LLMJudgmentRatingType ratingType = LLMJudgmentRatingType.RELEVANT_IRRELEVANT;
-
-        MLInput mlInput = transformer.createMLInput(searchText, referenceData, hits, promptTemplate, ratingType, false);
-
-        assertNotNull(mlInput);
-        RemoteInferenceInputDataSet dataset = (RemoteInferenceInputDataSet) mlInput.getInputDataset();
-        Map<String, String> parameters = dataset.getParameters();
-
-        // Should NOT include response_format for GPT-3.5 compatibility
-        assertFalse("response_format should not be present", parameters.containsKey("response_format"));
-    }
-
     public void testCreateMLInput_NumericRatingWithResponseFormat() {
         String searchText = "test query";
         Map<String, String> referenceData = new HashMap<>();
@@ -150,7 +112,7 @@ public class MLInputOutputTransformerTests extends OpenSearchTestCase {
         String promptTemplate = "Test prompt";
         LLMJudgmentRatingType ratingType = LLMJudgmentRatingType.SCORE0_1;
 
-        MLInput mlInput = transformer.createMLInput(searchText, referenceData, hits, promptTemplate, ratingType, true);
+        MLInput mlInput = transformer.createMLInput(searchText, referenceData, hits, promptTemplate, ratingType);
 
         assertNotNull(mlInput);
         RemoteInferenceInputDataSet dataset = (RemoteInferenceInputDataSet) mlInput.getInputDataset();
@@ -176,33 +138,13 @@ public class MLInputOutputTransformerTests extends OpenSearchTestCase {
         String promptTemplate = "Test prompt";
         LLMJudgmentRatingType ratingType = LLMJudgmentRatingType.SCORE0_1;
 
-        MLInput mlInput = transformer.createMLInput(searchText, referenceData, hits, promptTemplate, ratingType, true);
+        MLInput mlInput = transformer.createMLInput(searchText, referenceData, hits, promptTemplate, ratingType);
 
         assertNotNull(mlInput);
         RemoteInferenceInputDataSet dataset = (RemoteInferenceInputDataSet) mlInput.getInputDataset();
         Map<String, String> parameters = dataset.getParameters();
 
         assertTrue("response_format should be present even with multiple hits", parameters.containsKey("response_format"));
-        assertNotNull("messages parameter should not be null", parameters.get("messages"));
-        assertFalse("messages parameter should not be empty", parameters.get("messages").isEmpty());
-    }
-
-    public void testCreateMLInput_MultipleHitsWithoutResponseFormat() {
-        String searchText = "test query";
-        Map<String, String> referenceData = new HashMap<>();
-        Map<String, String> hits = new HashMap<>();
-        hits.put("doc1", "content 1");
-        hits.put("doc2", "content 2");
-        String promptTemplate = "Test prompt";
-        LLMJudgmentRatingType ratingType = LLMJudgmentRatingType.SCORE0_1;
-
-        MLInput mlInput = transformer.createMLInput(searchText, referenceData, hits, promptTemplate, ratingType, false);
-
-        assertNotNull(mlInput);
-        RemoteInferenceInputDataSet dataset = (RemoteInferenceInputDataSet) mlInput.getInputDataset();
-        Map<String, String> parameters = dataset.getParameters();
-
-        assertFalse("response_format should not be present", parameters.containsKey("response_format"));
         assertNotNull("messages parameter should not be null", parameters.get("messages"));
         assertFalse("messages parameter should not be empty", parameters.get("messages").isEmpty());
     }
@@ -218,7 +160,7 @@ public class MLInputOutputTransformerTests extends OpenSearchTestCase {
         String promptTemplate = "Test prompt";
         LLMJudgmentRatingType ratingType = LLMJudgmentRatingType.SCORE0_1;
 
-        MLInput mlInput = transformer.createMLInput(searchText, referenceData, hits, promptTemplate, ratingType, true);
+        MLInput mlInput = transformer.createMLInput(searchText, referenceData, hits, promptTemplate, ratingType);
 
         assertNotNull(mlInput);
         RemoteInferenceInputDataSet dataset = (RemoteInferenceInputDataSet) mlInput.getInputDataset();
@@ -237,7 +179,7 @@ public class MLInputOutputTransformerTests extends OpenSearchTestCase {
         String promptTemplate = "Test prompt";
         LLMJudgmentRatingType ratingType = LLMJudgmentRatingType.SCORE0_1;
 
-        MLInput mlInput = transformer.createMLInput(searchText, referenceData, hits, promptTemplate, ratingType, true);
+        MLInput mlInput = transformer.createMLInput(searchText, referenceData, hits, promptTemplate, ratingType);
 
         assertNotNull(mlInput);
         RemoteInferenceInputDataSet dataset = (RemoteInferenceInputDataSet) mlInput.getInputDataset();

--- a/src/test/java/org/opensearch/searchrelevance/model/JudgmentTests.java
+++ b/src/test/java/org/opensearch/searchrelevance/model/JudgmentTests.java
@@ -1,0 +1,113 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+package org.opensearch.searchrelevance.model;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.opensearch.common.xcontent.XContentFactory;
+import org.opensearch.common.xcontent.XContentHelper;
+import org.opensearch.common.xcontent.XContentType;
+import org.opensearch.core.common.bytes.BytesReference;
+import org.opensearch.core.xcontent.ToXContent;
+import org.opensearch.core.xcontent.XContentBuilder;
+import org.opensearch.searchrelevance.judgments.JudgmentDataTransformer;
+import org.opensearch.test.OpenSearchTestCase;
+
+public class JudgmentTests extends OpenSearchTestCase {
+
+    @SuppressWarnings("unchecked")
+    private Map<String, Object> serialize(List<Map<String, Object>> judgmentRatings) throws IOException {
+        Judgment judgment = new Judgment(
+            "id",
+            "2024-01-01T00:00:00Z",
+            "name",
+            AsyncStatus.COMPLETED,
+            JudgmentType.LLM_JUDGMENT,
+            Map.of(),
+            judgmentRatings
+        );
+        XContentBuilder builder = XContentFactory.jsonBuilder();
+        judgment.toXContent(builder, ToXContent.EMPTY_PARAMS);
+        return XContentHelper.convertToMap(BytesReference.bytes(builder), false, XContentType.JSON).v2();
+    }
+
+    private Map<String, Object> entry(String query, List<Map<String, Object>> ratings) {
+        Map<String, Object> entry = new HashMap<>();
+        entry.put("query", query);
+        entry.put("ratings", ratings);
+        return entry;
+    }
+
+    @SuppressWarnings("unchecked")
+    private Map<String, Object> firstEntry(Map<String, Object> serialized) {
+        List<Map<String, Object>> judgmentRatings = (List<Map<String, Object>>) serialized.get("judgmentRatings");
+        assertEquals(1, judgmentRatings.size());
+        return judgmentRatings.get(0);
+    }
+
+    @SuppressWarnings("unchecked")
+    public void testToXContentWritesRatings() throws IOException {
+        Map<String, Object> entry = entry("laptop", List.of(Map.of("docId", "A", "rating", "2"), Map.of("docId", "B", "rating", "1")));
+
+        Map<String, Object> outEntry = firstEntry(serialize(List.of(entry)));
+
+        assertEquals("laptop", outEntry.get("query"));
+        List<Map<String, Object>> ratings = (List<Map<String, Object>>) outEntry.get("ratings");
+        assertEquals(2, ratings.size());
+        assertFalse("no failures key when none present", outEntry.containsKey("failures"));
+    }
+
+    @SuppressWarnings("unchecked")
+    public void testToXContentWritesFailuresWhenPresent() throws IOException {
+        Map<String, Object> entry = entry("laptop", List.of(Map.of("docId", "A", "rating", "2")));
+        entry.put("failures", List.of(Map.of("docId", "C")));
+
+        Map<String, Object> outEntry = firstEntry(serialize(List.of(entry)));
+
+        List<Map<String, Object>> failures = (List<Map<String, Object>>) outEntry.get("failures");
+        assertNotNull(failures);
+        assertEquals(1, failures.size());
+        assertEquals("C", failures.get(0).get("docId"));
+    }
+
+    public void testToXContentOmitsFailuresWhenEmptyList() throws IOException {
+        Map<String, Object> entry = entry("laptop", List.of(Map.of("docId", "A", "rating", "2")));
+        entry.put("failures", List.of());
+
+        Map<String, Object> outEntry = firstEntry(serialize(List.of(entry)));
+
+        assertFalse("empty failures list should not be written", outEntry.containsKey("failures"));
+    }
+
+    public void testToXContentDoesNotPersistFailureReason() throws IOException {
+        // The failure reason is a transient field used only for the metadata overview; it must not
+        // be written onto the stored judgment entry.
+        Map<String, Object> entry = entry("laptop", List.of());
+        entry.put("failures", List.of(Map.of("docId", "A")));
+        entry.put(JudgmentDataTransformer.RESULT_FAILURE_REASON, "model timed out");
+
+        Map<String, Object> outEntry = firstEntry(serialize(List.of(entry)));
+
+        assertFalse(outEntry.containsKey(JudgmentDataTransformer.RESULT_FAILURE_REASON));
+        assertEquals(1, ((List<?>) outEntry.get("failures")).size());
+    }
+
+    public void testToXContentAllDocsFailed() throws IOException {
+        // A fully failed query: no ratings, every sent doc listed as a failure.
+        Map<String, Object> entry = entry("laptop", List.of());
+        entry.put("failures", List.of(Map.of("docId", "A"), Map.of("docId", "B")));
+
+        Map<String, Object> outEntry = firstEntry(serialize(List.of(entry)));
+
+        assertTrue(((List<?>) outEntry.get("ratings")).isEmpty());
+        assertEquals(2, ((List<?>) outEntry.get("failures")).size());
+    }
+}


### PR DESCRIPTION
### Description

This PR makes LLM judgment failures visible and removes SRW's duplicate retry layer.

#### 1. Report which docs failed to get rated

Currently, a `(query, doc)` pair that fails to get rated silently disappears from the result (#276) — the judgment is still marked `COMPLETED`, with no record of what was rated or why anything is missing. A clean run and one that lost half its docs look identical.

This PR records the unrated docs directly on each judgment entry, so nothing disappears silently:

- Each `judgmentRatings` entry keeps `ratings` for the docs that were rated, and gains a `failures` list of the docs that were sent to the LLM but came back without a rating.
- `metadata` gains a run overview: `totalQueries`, `successfulQueries`, `failedQueries`, and `lastFailureReason` (the last error seen, for the "why"). A query counts as failed when it has at least one unrated doc, so a partially-rated query is reported as failed rather than hiding the gap.

```json
{
  "query": "laptop",
  "ratings":  [ { "docId": "1", "rating": "1.0" }, { "docId": "5", "rating": "1.0" } ],
  "failures": [ { "docId": "6" } ]
}
```


#### 2. Delegate transient-error retries to the ml-commons connector

Currently `MLAccessor` retries every failed model call itself (3 attempts, exponential backoff). But the ml-commons connector already retries through its `client_config`, so the two layers multiply: with both set to 3, one failing call can be attempted up to 3 × 3 = 9 times. SRW's loop also retries blindly — e.g. a `400` for a malformed request, which will never succeed — instead of only retrying transient errors.

This PR removes SRW's retry loop, leaving the connector as the single place that retries. The connector-side retry change lives in opensearch-project/ml-commons#4882.

### End-to-end testing

Verified against real Amazon Bedrock (Claude Haiku 4.5) through the full flow (index docs → search configuration → query set → `PUT /_plugins/_search_relevance/judgments`), using the SRW Bedrock/Claude connector blueprint.

**1. All succeed** — working model:

```json
"status": "COMPLETED",
"metadata": { "totalQueries": 2, "successfulQueries": 2, "failedQueries": 0 },
"judgmentRatings": [
  { "query": "laptop", "ratings": [ { "docId": "1", "rating": "1.0" }, { "docId": "5", "rating": "1.0" } ] },
  { "query": "chair",  "ratings": [ { "docId": "2", "rating": "1.0" } ] }
]
```

No `failures` key and no `lastFailureReason` when everything is rated.

**2. All fail** — connector pointing at an invalid model id:

```json
"status": "COMPLETED",
"metadata": {
  "totalQueries": 2, "successfulQueries": 0, "failedQueries": 2,
  "lastFailureReason": "Error from remote service: {\"message\":\"The provided model identifier is invalid.\"}"
},
"judgmentRatings": [
  { "query": "laptop", "ratings": [], "failures": [ { "docId": "1" }, { "docId": "5" } ] },
  { "query": "chair",  "ratings": [], "failures": [ { "docId": "2" } ] }
]
```

**3. Partial failure within one query** — rated docs `1` and `5` first (cached), then added a new doc `6` and re-ran with the failing model:

```json
"status": "COMPLETED",
"metadata": {
  "totalQueries": 2, "successfulQueries": 1, "failedQueries": 1,
  "lastFailureReason": "Error from remote service: {\"message\":\"The provided model identifier is invalid.\"}"
},
"judgmentRatings": [
  {
    "query": "laptop",
    "ratings":  [ { "docId": "1", "rating": "1.0" }, { "docId": "5", "rating": "1.0" } ],
    "failures": [ { "docId": "6" } ]
  },
  { "query": "chair", "ratings": [ { "docId": "2", "rating": "1.0" } ] }
]
```

Real ratings and per-doc failures coexist on the same query, and the query-level counts reflect it: `laptop` counts as failed (it has an unrated doc), so `successfulQueries: 1, failedQueries: 1`.

Unit tests: `JudgmentDataTransformerTests` covers `buildFailedDocs` and the metadata summary (counts + `lastFailureReason`, including a partially-rated query counting as failed); `LlmJudgmentsProcessorTests` covers the result assembly (`ratings` vs `failures`); `JudgmentTests` covers serialization (failures written when present, omitted when empty, and the transient failure reason is not persisted on the entry).

### Issues Resolved

Addresses #510. Failure reporting and retry handling are covered here; cache-based "resume judgment" / targeted re-run of failed pairs is deferred to follow-up work.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).