### PR TITLE
Return correct delete REST status codes and honor querySetSize for sampling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Enhancements
 
 ### Bug Fixes
+- Return correct delete REST status codes and honor querySetSize for sampling ([#542](https://github.com/opensearch-project/search-relevance/pull/542))
 
 ### Infrastructure
 

--- a/src/main/java/org/opensearch/searchrelevance/rest/RestDeleteExperimentAction.java
+++ b/src/main/java/org/opensearch/searchrelevance/rest/RestDeleteExperimentAction.java
@@ -80,7 +80,7 @@ public class RestDeleteExperimentAction extends BaseRestHandler {
             @Override
             public void onFailure(Exception e) {
                 try {
-                    channel.sendResponse(new BytesRestResponse(channel, RestStatus.INTERNAL_SERVER_ERROR, e));
+                    channel.sendResponse(new BytesRestResponse(channel, e));
                 } catch (IOException ex) {
                     LOGGER.error("Failed to send error response", ex);
                 }

--- a/src/main/java/org/opensearch/searchrelevance/rest/RestDeleteJudgmentAction.java
+++ b/src/main/java/org/opensearch/searchrelevance/rest/RestDeleteJudgmentAction.java
@@ -83,7 +83,7 @@ public class RestDeleteJudgmentAction extends BaseRestHandler {
             @Override
             public void onFailure(Exception e) {
                 try {
-                    channel.sendResponse(new BytesRestResponse(channel, RestStatus.INTERNAL_SERVER_ERROR, e));
+                    channel.sendResponse(new BytesRestResponse(channel, e));
                 } catch (IOException ex) {
                     LOGGER.error("Failed to send error response", ex);
                 }

--- a/src/main/java/org/opensearch/searchrelevance/rest/RestDeleteQuerySetAction.java
+++ b/src/main/java/org/opensearch/searchrelevance/rest/RestDeleteQuerySetAction.java
@@ -83,7 +83,7 @@ public class RestDeleteQuerySetAction extends BaseRestHandler {
             @Override
             public void onFailure(Exception e) {
                 try {
-                    channel.sendResponse(new BytesRestResponse(channel, RestStatus.INTERNAL_SERVER_ERROR, e));
+                    channel.sendResponse(new BytesRestResponse(channel, e));
                 } catch (IOException ex) {
                     LOGGER.error("Failed to send error response", ex);
                 }

--- a/src/main/java/org/opensearch/searchrelevance/rest/RestDeleteScheduledExperimentAction.java
+++ b/src/main/java/org/opensearch/searchrelevance/rest/RestDeleteScheduledExperimentAction.java
@@ -93,7 +93,7 @@ public class RestDeleteScheduledExperimentAction extends BaseRestHandler {
             @Override
             public void onFailure(Exception e) {
                 try {
-                    channel.sendResponse(new BytesRestResponse(channel, RestStatus.INTERNAL_SERVER_ERROR, e));
+                    channel.sendResponse(new BytesRestResponse(channel, e));
                 } catch (IOException ex) {
                     LOGGER.error("Failed to send error response", ex);
                 }

--- a/src/main/java/org/opensearch/searchrelevance/rest/RestDeleteSearchConfigurationAction.java
+++ b/src/main/java/org/opensearch/searchrelevance/rest/RestDeleteSearchConfigurationAction.java
@@ -83,7 +83,7 @@ public class RestDeleteSearchConfigurationAction extends BaseRestHandler {
             @Override
             public void onFailure(Exception e) {
                 try {
-                    channel.sendResponse(new BytesRestResponse(channel, RestStatus.INTERNAL_SERVER_ERROR, e));
+                    channel.sendResponse(new BytesRestResponse(channel, e));
                 } catch (IOException ex) {
                     LOGGER.error("Failed to send error response", ex);
                 }

--- a/src/main/java/org/opensearch/searchrelevance/ubi/ProbabilityProportionalToSizeQuerySampler.java
+++ b/src/main/java/org/opensearch/searchrelevance/ubi/ProbabilityProportionalToSizeQuerySampler.java
@@ -110,7 +110,11 @@ public class ProbabilityProportionalToSizeQuerySampler extends QuerySampler {
 
         final UniformRealDistribution uniform = new UniformRealDistribution(0, 1);
 
-        for (int i = 1; i <= getSize(); i++) {
+        final int targetSize = Math.min(getSize(), cumulativeWeights.size());
+        final int maxIterations = Math.max(targetSize * 100, 1000);
+        int iterations = 0;
+
+        while (querySet.size() < targetSize && iterations++ < maxIterations) {
 
             final double r = uniform.sample();
 


### PR DESCRIPTION
## Description

Fixes two Search Relevance Workbench backend issues found during testing.

### Probelm 1 — Delete returns 500 instead of a 4xx
**Before:** Deleting a query set / judgment / search configuration that is still used by an experiment returned HTTP 500 Internal Server Error, hiding the 409 Conflict the transport layer actually raised.
**After:** The five delete REST handlers now propagate the exception's real status (e.g. 409 Conflict), matching the existing GET/PUT handlers.

<img width="1487" height="650" alt="12-1" src="https://github.com/user-attachments/assets/af964b62-4a2f-41c0-81a8-afe5367ba7a7" />
<img width="1477" height="424" alt="12-2" src="https://github.com/user-attachments/assets/9adc0a5b-4eb0-4c8b-a345-fa9d7cba7556" />


### Probelm 2  — querySetSize not honored for pptss sampling
**Before:** Creating a query set with `sampling: pptss` and `querySetSize: 25` produced a random, smaller number of queries, eg: 14, instead of correct 25.
**After:** The pptss sampler keeps sampling until it reaches the requested size (bounded to avoid runaway loops), so the query set has the requested number of distinct queries.

<img width="1496" height="634" alt="14-1" src="https://github.com/user-attachments/assets/fb2c7784-f3bc-41f5-b79e-618b2a6008a9" />
<img width="1502" height="563" alt="14-2" src="https://github.com/user-attachments/assets/178016a2-8b61-42a1-94de-02730cb3bbc6" />


### Check List
- [x] New functionality has been verified manually
- [x] Commits are signed per the DCO
