### PR TITLE
Add ci.opensearch.org/m2/ mirror for plugin resolution (search-relevance)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,6 +39,7 @@ buildscript {
 
     repositories {
         mavenLocal()
+        maven { url "https://ci.opensearch.org/m2/" }
         maven { url "https://ci.opensearch.org/maven2/" }
         mavenCentral()
         maven { url "https://ci.opensearch.org/ci/dbc/snapshots/maven/" }
@@ -263,6 +264,7 @@ def _numNodes = findProperty('numNodes') as Integer ?: 1
 
 repositories {
     mavenLocal()
+    maven { url "https://ci.opensearch.org/m2/" }
     maven { url "https://ci.opensearch.org/maven2/" }
     mavenCentral()
     maven { url "https://ci.opensearch.org/ci/dbc/snapshots/maven/" }

--- a/build.gradle
+++ b/build.gradle
@@ -39,8 +39,8 @@ buildscript {
 
     repositories {
         mavenLocal()
-        maven { url "https://ci.opensearch.org/m2/" }
         maven { url "https://ci.opensearch.org/maven2/" }
+        maven { url "https://ci.opensearch.org/m2/" }
         mavenCentral()
         maven { url "https://ci.opensearch.org/ci/dbc/snapshots/maven/" }
         maven { url "https://plugins.gradle.org/m2/" }
@@ -264,8 +264,8 @@ def _numNodes = findProperty('numNodes') as Integer ?: 1
 
 repositories {
     mavenLocal()
-    maven { url "https://ci.opensearch.org/m2/" }
     maven { url "https://ci.opensearch.org/maven2/" }
+    maven { url "https://ci.opensearch.org/m2/" }
     mavenCentral()
     maven { url "https://ci.opensearch.org/ci/dbc/snapshots/maven/" }
     maven { url "https://plugins.gradle.org/m2/" }

--- a/qa/build.gradle
+++ b/qa/build.gradle
@@ -36,8 +36,8 @@ configurations {
 
 repositories {
     mavenLocal()
-    maven { url "https://ci.opensearch.org/m2/" }
     maven { url "https://ci.opensearch.org/maven2/" }
+    maven { url "https://ci.opensearch.org/m2/" }
     mavenCentral()
     maven { url "https://ci.opensearch.org/ci/dbc/snapshots/maven/" }
     maven { url "https://plugins.gradle.org/m2/" }

--- a/qa/build.gradle
+++ b/qa/build.gradle
@@ -36,6 +36,7 @@ configurations {
 
 repositories {
     mavenLocal()
+    maven { url "https://ci.opensearch.org/m2/" }
     maven { url "https://ci.opensearch.org/maven2/" }
     mavenCentral()
     maven { url "https://ci.opensearch.org/ci/dbc/snapshots/maven/" }

--- a/settings.gradle
+++ b/settings.gradle
@@ -9,6 +9,7 @@
 
 pluginManagement {
     repositories {
+        maven { url "https://ci.opensearch.org/m2/" }
         maven { url "https://ci.opensearch.org/maven2/" }
         gradlePluginPortal()
         mavenCentral()

--- a/settings.gradle
+++ b/settings.gradle
@@ -9,8 +9,8 @@
 
 pluginManagement {
     repositories {
-        maven { url "https://ci.opensearch.org/m2/" }
         maven { url "https://ci.opensearch.org/maven2/" }
+        maven { url "https://ci.opensearch.org/m2/" }
         gradlePluginPortal()
         mavenCentral()
     }


### PR DESCRIPTION
### Description
Add ci.opensearch.org/m2/ mirror for plugin resolution (search-relevance)

### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/6278#issuecomment-5135909975

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).