### PR TITLE
Move jitpack repo before Maven Central mirrors to avoid 429 (search-relevance)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,12 +39,12 @@ buildscript {
 
     repositories {
         mavenLocal()
+        maven { url 'https://jitpack.io' }
         maven { url "https://ci.opensearch.org/maven2/" }
         maven { url "https://ci.opensearch.org/m2/" }
         mavenCentral()
         maven { url "https://ci.opensearch.org/ci/dbc/snapshots/maven/" }
         maven { url "https://plugins.gradle.org/m2/" }
-        maven { url 'https://jitpack.io' }
     }
 
     dependencies {


### PR DESCRIPTION
### Description
Move jitpack repo before Maven Central mirrors to avoid 429 (search-relevance)

### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/6278#issuecomment-5148963803