### PR TITLE
fix: resolve UBI index expressions the way the plugin's own search does and report an invalid UBI index as a client error 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### Bug Fixes
 - Return correct delete REST status codes and honor querySetSize for sampling ([#542](https://github.com/opensearch-project/search-relevance/pull/542))
+- Resolve UBI index expressions the way the plugin's own search does and report an invalid UBI index as a client error ([#551](https://github.com/opensearch-project/search-relevance/pull/551))
 
 ### Infrastructure
 

--- a/src/main/java/org/opensearch/searchrelevance/transport/judgment/PutJudgmentTransportAction.java
+++ b/src/main/java/org/opensearch/searchrelevance/transport/judgment/PutJudgmentTransportAction.java
@@ -10,7 +10,7 @@ package org.opensearch.searchrelevance.transport.judgment;
 import static org.opensearch.searchrelevance.common.MLConstants.LLM_JUDGMENT_RATING_TYPE;
 import static org.opensearch.searchrelevance.common.MLConstants.PROMPT_TEMPLATE;
 import static org.opensearch.searchrelevance.common.MetricsConstants.MODEL_ID;
-import static org.opensearch.searchrelevance.ubi.UbiValidator.checkUbiEventsIndexExists;
+import static org.opensearch.searchrelevance.ubi.UbiValidator.validateUbiEventsIndex;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -27,6 +27,7 @@ import org.opensearch.action.index.IndexResponse;
 import org.opensearch.action.support.ActionFilters;
 import org.opensearch.action.support.GroupedActionListener;
 import org.opensearch.action.support.HandledTransportAction;
+import org.opensearch.cluster.metadata.IndexNameExpressionResolver;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.inject.Inject;
 import org.opensearch.core.action.ActionListener;
@@ -42,6 +43,7 @@ import org.opensearch.searchrelevance.model.Judgment;
 import org.opensearch.searchrelevance.model.JudgmentType;
 import org.opensearch.searchrelevance.model.LLMJudgmentRatingType;
 import org.opensearch.searchrelevance.model.SearchConfiguration;
+import org.opensearch.searchrelevance.ubi.UbiValidator;
 import org.opensearch.searchrelevance.utils.ReferenceValidationUtil;
 import org.opensearch.searchrelevance.utils.TimeUtils;
 import org.opensearch.tasks.Task;
@@ -50,6 +52,7 @@ import org.opensearch.transport.TransportService;
 
 public class PutJudgmentTransportAction extends HandledTransportAction<PutJudgmentRequest, IndexResponse> {
     private final ClusterService clusterService;
+    private final IndexNameExpressionResolver indexNameExpressionResolver;
     private final JudgmentDao judgmentDao;
     private final QuerySetDao querySetDao;
     private final SearchConfigurationDao searchConfigurationDao;
@@ -74,6 +77,7 @@ public class PutJudgmentTransportAction extends HandledTransportAction<PutJudgme
     @Inject
     public PutJudgmentTransportAction(
         ClusterService clusterService,
+        IndexNameExpressionResolver indexNameExpressionResolver,
         TransportService transportService,
         ActionFilters actionFilters,
         JudgmentDao judgmentDao,
@@ -84,6 +88,7 @@ public class PutJudgmentTransportAction extends HandledTransportAction<PutJudgme
     ) {
         super(PutJudgmentAction.NAME, transportService, actionFilters, PutUbiJudgmentRequest::new);
         this.clusterService = clusterService;
+        this.indexNameExpressionResolver = indexNameExpressionResolver;
         this.judgmentDao = judgmentDao;
         this.querySetDao = querySetDao;
         this.searchConfigurationDao = searchConfigurationDao;
@@ -105,6 +110,18 @@ public class PutJudgmentTransportAction extends HandledTransportAction<PutJudgme
                     llmRequest,
                     ActionListener.wrap(v -> { createJudgment(request, listener); }, listener::onFailure)
                 );
+            } else if (request.getType() == JudgmentType.UBI_JUDGMENT) {
+                PutUbiJudgmentRequest ubiRequest = (PutUbiJudgmentRequest) request;
+                UbiValidator.ValidationResult ubiEventsIndexValidation = validateUbiEventsIndex(
+                    clusterService.state(),
+                    indexNameExpressionResolver,
+                    ubiRequest.getUbiEventsIndex()
+                );
+                if (!ubiEventsIndexValidation.isValid()) {
+                    listener.onFailure(new SearchRelevanceException(ubiEventsIndexValidation.getErrorMessage(), RestStatus.BAD_REQUEST));
+                    return;
+                }
+                createJudgment(request, listener);
             } else {
                 createJudgment(request, listener);
             }
@@ -401,9 +418,6 @@ public class PutJudgmentTransportAction extends HandledTransportAction<PutJudgme
             }
             case UBI_JUDGMENT -> {
                 PutUbiJudgmentRequest ubiRequest = (PutUbiJudgmentRequest) request;
-                if (!checkUbiEventsIndexExists(clusterService, ubiRequest.getUbiEventsIndex())) {
-                    throw new SearchRelevanceException("UBI events index does not exist", RestStatus.CONFLICT);
-                }
                 metadata.put("clickModel", ubiRequest.getClickModel());
                 metadata.put("maxRank", ubiRequest.getMaxRank());
                 metadata.put("startDate", ubiRequest.getStartDate());

--- a/src/main/java/org/opensearch/searchrelevance/transport/queryset/PostQuerySetTransportAction.java
+++ b/src/main/java/org/opensearch/searchrelevance/transport/queryset/PostQuerySetTransportAction.java
@@ -7,18 +7,17 @@
  */
 package org.opensearch.searchrelevance.transport.queryset;
 
-import static org.opensearch.searchrelevance.ubi.UbiValidator.checkUbiQueriesIndexExists;
+import static org.opensearch.searchrelevance.ubi.UbiValidator.validateUbiQueriesIndex;
 
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.UUID;
-import java.util.concurrent.ExecutionException;
 import java.util.stream.Collectors;
 
+import org.opensearch.ExceptionsHelper;
 import org.opensearch.action.index.IndexResponse;
 import org.opensearch.action.support.ActionFilters;
 import org.opensearch.action.support.HandledTransportAction;
+import org.opensearch.cluster.metadata.IndexNameExpressionResolver;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.inject.Inject;
 import org.opensearch.core.action.ActionListener;
@@ -28,6 +27,7 @@ import org.opensearch.searchrelevance.exception.SearchRelevanceException;
 import org.opensearch.searchrelevance.model.QuerySet;
 import org.opensearch.searchrelevance.model.QuerySetEntry;
 import org.opensearch.searchrelevance.ubi.QuerySampler;
+import org.opensearch.searchrelevance.ubi.UbiValidator;
 import org.opensearch.searchrelevance.utils.TimeUtils;
 import org.opensearch.tasks.Task;
 import org.opensearch.transport.TransportService;
@@ -36,11 +36,13 @@ import org.opensearch.transport.client.Client;
 public class PostQuerySetTransportAction extends HandledTransportAction<PostQuerySetRequest, IndexResponse> {
     private final Client client;
     private final ClusterService clusterService;
+    private final IndexNameExpressionResolver indexNameExpressionResolver;
     private final QuerySetDao querySetDao;
 
     @Inject
     public PostQuerySetTransportAction(
         ClusterService clusterService,
+        IndexNameExpressionResolver indexNameExpressionResolver,
         TransportService transportService,
         ActionFilters actionFilters,
         Client client,
@@ -49,6 +51,7 @@ public class PostQuerySetTransportAction extends HandledTransportAction<PostQuer
         super(PostQuerySetAction.NAME, transportService, actionFilters, PostUbiQuerySetRequest::new);
         this.client = client;
         this.clusterService = clusterService;
+        this.indexNameExpressionResolver = indexNameExpressionResolver;
         this.querySetDao = querySetDao;
     }
 
@@ -58,11 +61,11 @@ public class PostQuerySetTransportAction extends HandledTransportAction<PostQuer
             listener.onFailure(new SearchRelevanceException("Request cannot be null", RestStatus.BAD_REQUEST));
             return;
         }
-        String id = UUID.randomUUID().toString();
-        String timestamp = TimeUtils.getTimestamp();
-
         String name = request.getName();
-        String description = request.getDescription();
+        if (name == null || name.trim().isEmpty()) {
+            listener.onFailure(new SearchRelevanceException("Name cannot be null or empty. Request: " + request, RestStatus.BAD_REQUEST));
+            return;
+        }
 
         // Currently only UBI-based query sets are supported. Cast to access UBI-specific fields.
         // Future implementations may introduce other types (e.g., LLM-generated)
@@ -70,35 +73,54 @@ public class PostQuerySetTransportAction extends HandledTransportAction<PostQuer
         PostUbiQuerySetRequest ubiRequest = (PostUbiQuerySetRequest) request;
         String ubiQueriesIndex = ubiRequest.getUbiQueriesIndex();
 
-        if (!checkUbiQueriesIndexExists(clusterService, ubiQueriesIndex)) {
-            throw new SearchRelevanceException("UBI queries index does not exist", RestStatus.CONFLICT);
-        }
-
-        // Given sampling type and querySetSize, build the queryset accordingly
-        String sampling = request.getSampling();
-        int querySetSize = request.getQuerySetSize();
-        QuerySampler querySampler = QuerySampler.create(sampling, querySetSize, client, ubiQueriesIndex);
-        Map<String, Integer> querySetQueries = new HashMap<>();
-        try {
-            querySetQueries = querySampler.sample().get();
-        } catch (InterruptedException | ExecutionException e) {
-            listener.onFailure(
-                new SearchRelevanceException("Failed to build querySetQueries. Request: " + request, RestStatus.BAD_REQUEST)
-            );
-        }
-
-        if (name == null || name.trim().isEmpty()) {
-            listener.onFailure(new SearchRelevanceException("Name cannot be null or empty. Request: " + request, RestStatus.BAD_REQUEST));
+        UbiValidator.ValidationResult ubiQueriesIndexValidation = validateUbiQueriesIndex(
+            clusterService.state(),
+            indexNameExpressionResolver,
+            ubiQueriesIndex
+        );
+        if (!ubiQueriesIndexValidation.isValid()) {
+            listener.onFailure(new SearchRelevanceException(ubiQueriesIndexValidation.getErrorMessage(), RestStatus.BAD_REQUEST));
             return;
         }
 
-        // Convert Map<String, Integer> to List<QuerySetEntry> (discarding count values)
-        List<QuerySetEntry> querySetEntries = querySetQueries.entrySet()
-            .stream()
-            .map(entry -> QuerySetEntry.Builder.builder().queryText(entry.getKey()).build())
-            .collect(Collectors.toList());
+        String id = UUID.randomUUID().toString();
+        String timestamp = TimeUtils.getTimestamp();
+        String description = request.getDescription();
+        String sampling = request.getSampling();
+        int querySetSize = request.getQuerySetSize();
 
-        QuerySet querySet = new QuerySet(id, name, description, timestamp, sampling, querySetEntries);
-        querySetDao.putQuerySet(querySet, listener);
+        try {
+            QuerySampler querySampler = QuerySampler.create(sampling, querySetSize, client, ubiQueriesIndex);
+            querySampler.sample().whenComplete((querySetQueries, throwable) -> {
+                if (throwable != null) {
+                    listener.onFailure(
+                        new SearchRelevanceException(
+                            "Failed to build querySetQueries. Request: " + request,
+                            throwable,
+                            ExceptionsHelper.status(throwable)
+                        )
+                    );
+                    return;
+                }
+                try {
+                    // Convert Map<String, Integer> to List<QuerySetEntry> (discarding count values)
+                    List<QuerySetEntry> querySetEntries = querySetQueries.entrySet()
+                        .stream()
+                        .map(entry -> QuerySetEntry.Builder.builder().queryText(entry.getKey()).build())
+                        .collect(Collectors.toList());
+
+                    QuerySet querySet = new QuerySet(id, name, description, timestamp, sampling, querySetEntries);
+                    querySetDao.putQuerySet(querySet, listener);
+                } catch (Exception e) {
+                    listener.onFailure(
+                        new SearchRelevanceException("Failed to create query set. Request: " + request, e, RestStatus.INTERNAL_SERVER_ERROR)
+                    );
+                }
+            });
+        } catch (Exception e) {
+            listener.onFailure(
+                new SearchRelevanceException("Failed to build querySetQueries. Request: " + request, e, ExceptionsHelper.status(e))
+            );
+        }
     }
 }

--- a/src/main/java/org/opensearch/searchrelevance/ubi/UbiValidator.java
+++ b/src/main/java/org/opensearch/searchrelevance/ubi/UbiValidator.java
@@ -7,64 +7,197 @@
  */
 package org.opensearch.searchrelevance.ubi;
 
+import static org.opensearch.searchrelevance.common.PluginConstants.UBI_EVENTS_INDEX_PARAM;
+import static org.opensearch.searchrelevance.common.PluginConstants.UBI_QUERIES_INDEX_PARAM;
 import static org.opensearch.searchrelevance.common.PluginConstants.USER_QUERY_FIELD;
 
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+import org.opensearch.action.search.SearchRequest;
+import org.opensearch.action.support.IndicesOptions;
+import org.opensearch.cluster.ClusterState;
+import org.opensearch.cluster.metadata.IndexMetadata;
+import org.opensearch.cluster.metadata.IndexNameExpressionResolver;
 import org.opensearch.cluster.metadata.MappingMetadata;
-import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.core.index.Index;
+import org.opensearch.index.IndexNotFoundException;
+import org.opensearch.indices.IndexClosedException;
 
 public class UbiValidator {
 
-    /**
-     * Checks if UBI queries index exists in the cluster and has required fields
-     * @param clusterService opensearch cluster instance
-     * @param ubiQueriesIndex the UBI queries index name
-     * @return true if queries index exists with required fields, false otherwise
-     */
-    public static boolean checkUbiQueriesIndexExists(ClusterService clusterService, String ubiQueriesIndex) {
-        if (clusterService == null || !clusterService.state().metadata().hasIndex(ubiQueriesIndex)) {
-            return false;
+    private static final String MAPPING_PROPERTIES = "properties";
+    private static final Index[] NO_INDICES = new Index[0];
+    private static final IndicesOptions RESOLUTION_OPTIONS = SearchRequest.DEFAULT_INDICES_OPTIONS;
+    private static final boolean INCLUDE_DATA_STREAMS = new SearchRequest().includeDataStreams();
+
+    private enum UbiIndexKind {
+        QUERIES(List.of(USER_QUERY_FIELD), "UBI queries", UBI_QUERIES_INDEX_PARAM),
+        EVENTS(List.of("query_id", "action_name", "event_attributes.object.object_id"), "UBI events", UBI_EVENTS_INDEX_PARAM);
+
+        private final List<String> requiredFields;
+        private final String label;
+        private final String requestParameter;
+
+        UbiIndexKind(List<String> requiredFields, String label, String requestParameter) {
+            this.requiredFields = requiredFields;
+            this.label = label;
+            this.requestParameter = requestParameter;
+        }
+    }
+
+    public static class ValidationResult {
+        private final boolean valid;
+        private final String errorMessage;
+
+        public ValidationResult(boolean valid, String errorMessage) {
+            this.valid = valid;
+            this.errorMessage = errorMessage;
         }
 
-        MappingMetadata mappingMetadata = clusterService.state().metadata().index(ubiQueriesIndex).mapping();
-        if (mappingMetadata == null) {
-            return false;
+        public boolean isValid() {
+            return valid;
         }
 
-        return hasField(mappingMetadata, USER_QUERY_FIELD);
+        public String getErrorMessage() {
+            return errorMessage;
+        }
     }
 
     /**
-     * Checks if UBI events index exists in the cluster and has required fields
-     * @param clusterService opensearch cluster instance
-     * @param ubiEventsIndex the UBI events index name
-     * @return true if events index exists with required fields, false otherwise
+     * Validates the UBI queries index expression used to sample query sets.
+     * @param clusterState current cluster state
+     * @param indexNameExpressionResolver resolver used to expand the expression
+     * @param ubiQueriesIndex the UBI queries index expression
+     * @return a valid result, or an invalid result describing what the caller has to fix
      */
-    public static boolean checkUbiEventsIndexExists(ClusterService clusterService, String ubiEventsIndex) {
-        if (clusterService == null || !clusterService.state().metadata().hasIndex(ubiEventsIndex)) {
-            return false;
+    public static ValidationResult validateUbiQueriesIndex(
+        ClusterState clusterState,
+        IndexNameExpressionResolver indexNameExpressionResolver,
+        String ubiQueriesIndex
+    ) {
+        return validate(clusterState, indexNameExpressionResolver, ubiQueriesIndex, UbiIndexKind.QUERIES);
+    }
+
+    /**
+     * Validates the UBI events index expression used to calculate implicit judgments.
+     * @param clusterState current cluster state
+     * @param indexNameExpressionResolver resolver used to expand the expression
+     * @param ubiEventsIndex the UBI events index expression
+     * @return a valid result, or an invalid result describing what the caller has to fix
+     */
+    public static ValidationResult validateUbiEventsIndex(
+        ClusterState clusterState,
+        IndexNameExpressionResolver indexNameExpressionResolver,
+        String ubiEventsIndex
+    ) {
+        return validate(clusterState, indexNameExpressionResolver, ubiEventsIndex, UbiIndexKind.EVENTS);
+    }
+
+    private static ValidationResult validate(
+        ClusterState clusterState,
+        IndexNameExpressionResolver indexNameExpressionResolver,
+        String indexExpression,
+        UbiIndexKind kind
+    ) {
+        if (indexExpression == null || indexExpression.isBlank()) {
+            return invalid("%s index must not be empty. Set it with the '%s' parameter.", kind.label, kind.requestParameter);
         }
 
-        MappingMetadata mappingMetadata = clusterService.state().metadata().index(ubiEventsIndex).mapping();
+        Index[] concreteIndices;
+        try {
+            concreteIndices = indexNameExpressionResolver.concreteIndices(
+                clusterState,
+                RESOLUTION_OPTIONS,
+                INCLUDE_DATA_STREAMS,
+                indexExpression
+            );
+        } catch (IndexNotFoundException e) {
+            concreteIndices = NO_INDICES;
+        } catch (IndexClosedException e) {
+            return invalid(
+                "%s index [%s] resolves to closed index [%s], which cannot be searched. Reopen it, or point at open indices "
+                    + "with the '%s' parameter.",
+                kind.label,
+                indexExpression,
+                e.getIndex() == null ? indexExpression : e.getIndex().getName(),
+                kind.requestParameter
+            );
+        }
+
+        Map<String, List<String>> missingFieldsByIndex = new LinkedHashMap<>();
+        for (Index index : concreteIndices) {
+            IndexMetadata indexMetadata = clusterState.metadata().index(index);
+            if (indexMetadata == null) {
+                continue;
+            }
+            List<String> missingFields = findMissingFields(indexMetadata.mapping(), kind.requiredFields);
+            if (missingFields.isEmpty()) {
+                return new ValidationResult(true, null);
+            }
+            missingFieldsByIndex.put(index.getName(), missingFields);
+        }
+
+        if (missingFieldsByIndex.isEmpty()) {
+            return invalid(
+                "%s index [%s] does not exist. Ingest %s data into it, or point at an existing index, alias or data stream "
+                    + "with the '%s' parameter.",
+                kind.label,
+                indexExpression,
+                kind.label,
+                kind.requestParameter
+            );
+        }
+        if (missingFieldsByIndex.size() == 1) {
+            Map.Entry<String, List<String>> onlyIndex = missingFieldsByIndex.entrySet().iterator().next();
+            return invalid(
+                "Index [%s] resolved from [%s] is not a valid %s index: its mapping is missing the required field(s) %s.",
+                onlyIndex.getKey(),
+                indexExpression,
+                kind.label,
+                onlyIndex.getValue()
+            );
+        }
+        return invalid(
+            "No index resolved from [%s] is a valid %s index. Missing required field(s) per index: %s.",
+            indexExpression,
+            kind.label,
+            missingFieldsByIndex
+        );
+    }
+
+    private static List<String> findMissingFields(MappingMetadata mappingMetadata, List<String> requiredFields) {
         if (mappingMetadata == null) {
-            return false;
+            return new ArrayList<>(requiredFields);
         }
 
-        return hasField(mappingMetadata, "query_id")
-            && hasField(mappingMetadata, "action_name")
-            && hasField(mappingMetadata, "event_attributes.object.object_id");
+        List<String> missingFields = new ArrayList<>();
+        for (String requiredField : requiredFields) {
+            if (!hasField(mappingMetadata, requiredField)) {
+                missingFields.add(requiredField);
+            }
+        }
+        return missingFields;
+    }
+
+    private static ValidationResult invalid(String messageFormat, Object... args) {
+        return new ValidationResult(false, String.format(Locale.ROOT, messageFormat, args));
     }
 
     @SuppressWarnings("unchecked")
     private static boolean hasField(MappingMetadata mappingMetadata, String fieldPath) {
         var sourceAsMap = mappingMetadata.sourceAsMap();
-        var properties = (java.util.Map<String, Object>) sourceAsMap.get("properties");
+        var properties = (Map<String, Object>) sourceAsMap.get(MAPPING_PROPERTIES);
 
         if (properties == null) {
             return false;
         }
 
         String[] pathParts = fieldPath.split("\\.");
-        java.util.Map<String, Object> current = properties;
+        Map<String, Object> current = properties;
 
         for (int i = 0; i < pathParts.length; i++) {
             if (!current.containsKey(pathParts[i])) {
@@ -72,8 +205,8 @@ public class UbiValidator {
             }
 
             if (i < pathParts.length - 1) {
-                var fieldDef = (java.util.Map<String, Object>) current.get(pathParts[i]);
-                current = (java.util.Map<String, Object>) fieldDef.get("properties");
+                var fieldDef = (Map<String, Object>) current.get(pathParts[i]);
+                current = (Map<String, Object>) fieldDef.get(MAPPING_PROPERTIES);
                 if (current == null) {
                     return false;
                 }

--- a/src/test/java/org/opensearch/searchrelevance/action/judgment/UbiEventsIndexResolutionIT.java
+++ b/src/test/java/org/opensearch/searchrelevance/action/judgment/UbiEventsIndexResolutionIT.java
@@ -1,0 +1,188 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+package org.opensearch.searchrelevance.action.judgment;
+
+import static org.opensearch.searchrelevance.common.PluginConstants.JUDGMENTS_URL;
+import static org.opensearch.searchrelevance.common.PluginConstants.JUDGMENT_INDEX;
+import static org.opensearch.searchrelevance.common.PluginConstants.UBI_EVENTS_INDEX;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.hc.core5.http.HttpHeaders;
+import org.apache.hc.core5.http.io.entity.EntityUtils;
+import org.apache.hc.core5.http.message.BasicHeader;
+import org.opensearch.client.Response;
+import org.opensearch.client.ResponseException;
+import org.opensearch.cluster.metadata.IndexMetadata;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.core.rest.RestStatus;
+import org.opensearch.rest.RestRequest;
+import org.opensearch.searchrelevance.BaseSearchRelevanceIT;
+
+import com.google.common.collect.ImmutableList;
+
+import lombok.SneakyThrows;
+
+public class UbiEventsIndexResolutionIT extends BaseSearchRelevanceIT {
+
+    private static final String SAMPLE_UBI_EVENTS_INDEX = "opensearch_dashboards_sample_ubi_events";
+
+    @SneakyThrows
+    public void testImplicitJudgmentsResolveUbiEventsAlias() {
+        createSampleUbiEventsIndex();
+        createAlias(SAMPLE_UBI_EVENTS_INDEX, UBI_EVENTS_INDEX);
+        ingestSampleUbiEvents();
+
+        String judgmentId = createJudgment(readResource("judgment/ImplicitJudgmentsDates.json"));
+        assertJudgmentCompletedWithRatings(judgmentId);
+    }
+
+    @SneakyThrows
+    public void testImplicitJudgmentsAcceptExplicitSampleEventsIndex() {
+        createSampleUbiEventsIndex();
+        ingestSampleUbiEvents(SAMPLE_UBI_EVENTS_INDEX);
+
+        String judgmentId = createJudgment(judgmentRequest(SAMPLE_UBI_EVENTS_INDEX));
+        assertJudgmentCompletedWithRatings(judgmentId);
+    }
+
+    @SneakyThrows
+    public void testImplicitJudgmentsAcceptWildcardEventsIndex() {
+        createSampleUbiEventsIndex();
+        ingestSampleUbiEvents(SAMPLE_UBI_EVENTS_INDEX);
+
+        String judgmentId = createJudgment(judgmentRequest("*ubi_events*"));
+        assertJudgmentCompletedWithRatings(judgmentId);
+    }
+
+    @SneakyThrows
+    public void testUnknownUbiEventsIndexIsRejectedAsBadRequest() {
+        String requestBody = judgmentRequest("no_such_ubi_events");
+
+        ResponseException exception = expectThrows(
+            ResponseException.class,
+            () -> makeRequest(
+                client(),
+                RestRequest.Method.PUT.name(),
+                JUDGMENTS_URL,
+                null,
+                toHttpEntity(requestBody),
+                ImmutableList.of(new BasicHeader(HttpHeaders.USER_AGENT, DEFAULT_USER_AGENT))
+            )
+        );
+
+        assertEquals(RestStatus.BAD_REQUEST.getStatus(), exception.getResponse().getStatusLine().getStatusCode());
+        String responseBody = EntityUtils.toString(exception.getResponse().getEntity());
+        assertTrue(responseBody, responseBody.contains("UBI events index [no_such_ubi_events] does not exist"));
+        assertTrue(responseBody, responseBody.contains("ubiEventsIndex"));
+    }
+
+    @SneakyThrows
+    private void createSampleUbiEventsIndex() {
+        String eventsIndexMapping = readResource("ubi/events-mapping.json");
+        eventsIndexMapping = eventsIndexMapping.substring(1, eventsIndexMapping.length() - 1);
+
+        final Settings indexSettings = Settings.builder()
+            .put(IndexMetadata.INDEX_NUMBER_OF_SHARDS_SETTING.getKey(), 1)
+            .put(IndexMetadata.INDEX_AUTO_EXPAND_REPLICAS_SETTING.getKey(), "0-2")
+            .put(IndexMetadata.SETTING_PRIORITY, Integer.MAX_VALUE)
+            .build();
+        createIndex(SAMPLE_UBI_EVENTS_INDEX, indexSettings, eventsIndexMapping);
+    }
+
+    @SneakyThrows
+    private void createAlias(String indexName, String alias) {
+        Response response = makeRequest(
+            client(),
+            RestRequest.Method.PUT.name(),
+            String.join("/", indexName, "_alias", alias),
+            null,
+            toHttpEntity("{}"),
+            ImmutableList.of(new BasicHeader(HttpHeaders.USER_AGENT, DEFAULT_USER_AGENT))
+        );
+        assertEquals(RestStatus.OK.getStatus(), response.getStatusLine().getStatusCode());
+    }
+
+    @SneakyThrows
+    private void ingestSampleUbiEvents() {
+        ingestSampleUbiEvents(UBI_EVENTS_INDEX);
+    }
+
+    @SneakyThrows
+    private void ingestSampleUbiEvents(String targetIndex) {
+        String bulkBody = readResource("sample_ubi_data/SampleUBIEvents.json");
+        if (!UBI_EVENTS_INDEX.equals(targetIndex)) {
+            bulkBody = bulkBody.replace("\"_index\": \"" + UBI_EVENTS_INDEX + "\"", "\"_index\": \"" + targetIndex + "\"");
+        }
+        bulkIngest(targetIndex, bulkBody);
+    }
+
+    private static String judgmentRequest(String ubiEventsIndex) {
+        return String.format(Locale.ROOT, """
+            {
+              "name": "Implicit Judgements",
+              "clickModel": "coec",
+              "type": "UBI_JUDGMENT",
+              "maxRank": 20,
+              "startDate": "2024-12-15",
+              "endDate": "2024-12-18",
+              "ubiEventsIndex": "%s"
+            }""", ubiEventsIndex);
+    }
+
+    @SneakyThrows
+    private String readResource(String resourcePath) {
+        return Files.readString(Path.of(classLoader.getResource(resourcePath).toURI()));
+    }
+
+    @SneakyThrows
+    private String createJudgment(String requestBody) {
+        Response response = makeRequest(
+            client(),
+            RestRequest.Method.PUT.name(),
+            JUDGMENTS_URL,
+            null,
+            toHttpEntity(requestBody),
+            ImmutableList.of(new BasicHeader(HttpHeaders.USER_AGENT, DEFAULT_USER_AGENT))
+        );
+        Map<String, Object> result = entityAsMap(response);
+        assertNotNull(result);
+        String judgmentId = (String) result.get("judgment_id");
+        assertNotNull(judgmentId);
+        return judgmentId;
+    }
+
+    @SneakyThrows
+    private void assertJudgmentCompletedWithRatings(String judgmentId) {
+        assertBusy(() -> {
+            Response response = makeRequest(
+                adminClient(),
+                RestRequest.Method.GET.name(),
+                String.join("/", JUDGMENT_INDEX, "_doc", judgmentId),
+                null,
+                null,
+                ImmutableList.of(new BasicHeader(HttpHeaders.USER_AGENT, DEFAULT_USER_AGENT))
+            );
+
+            Map<String, Object> result = entityAsMap(response);
+            assertNotNull(result);
+            Map<String, Object> source = (Map<String, Object>) result.get("_source");
+            assertNotNull(source);
+            assertEquals("COMPLETED", source.get("status"));
+
+            List<Map<String, Object>> judgmentRatings = (List<Map<String, Object>>) source.get("judgmentRatings");
+            assertNotNull(judgmentRatings);
+            assertFalse(judgmentRatings.isEmpty());
+        }, 30, TimeUnit.SECONDS);
+    }
+}

--- a/src/test/java/org/opensearch/searchrelevance/transport/judgment/PutJudgmentTransportActionTests.java
+++ b/src/test/java/org/opensearch/searchrelevance/transport/judgment/PutJudgmentTransportActionTests.java
@@ -11,7 +11,9 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import java.util.List;
@@ -23,16 +25,29 @@ import org.junit.Before;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+import org.opensearch.Version;
 import org.opensearch.action.index.IndexResponse;
 import org.opensearch.action.search.SearchResponse;
 import org.opensearch.action.support.ActionFilters;
+import org.opensearch.cluster.ClusterName;
+import org.opensearch.cluster.ClusterState;
+import org.opensearch.cluster.metadata.AliasMetadata;
+import org.opensearch.cluster.metadata.IndexMetadata;
+import org.opensearch.cluster.metadata.IndexNameExpressionResolver;
+import org.opensearch.cluster.metadata.MappingMetadata;
+import org.opensearch.cluster.metadata.Metadata;
 import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.common.util.concurrent.ThreadContext;
 import org.opensearch.core.action.ActionListener;
+import org.opensearch.core.rest.RestStatus;
+import org.opensearch.index.mapper.MapperService;
 import org.opensearch.search.SearchHit;
 import org.opensearch.search.SearchHits;
 import org.opensearch.searchrelevance.dao.JudgmentDao;
 import org.opensearch.searchrelevance.dao.QuerySetDao;
 import org.opensearch.searchrelevance.dao.SearchConfigurationDao;
+import org.opensearch.searchrelevance.exception.SearchRelevanceException;
 import org.opensearch.searchrelevance.judgments.JudgmentsProcessorFactory;
 import org.opensearch.searchrelevance.model.JudgmentType;
 import org.opensearch.searchrelevance.model.LLMJudgmentRatingType;
@@ -74,6 +89,7 @@ public class PutJudgmentTransportActionTests extends OpenSearchTestCase {
         }).when(directExecutor).execute(any(Runnable.class));
         action = new PutJudgmentTransportAction(
             clusterService,
+            new IndexNameExpressionResolver(new ThreadContext(Settings.EMPTY)),
             transportService,
             actionFilters,
             judgmentDao,
@@ -506,5 +522,68 @@ public class PutJudgmentTransportActionTests extends OpenSearchTestCase {
         verify(responseListener).onFailure(exceptionCaptor.capture());
         assertTrue(exceptionCaptor.getValue().getMessage().contains("could not be resolved to a target index"));
         verify(judgmentDao, org.mockito.Mockito.never()).putJudgement(any(), any(ActionListener.class));
+    }
+
+    public void testValidation_UbiJudgment_EventsIndexNotFound() {
+        when(clusterService.state()).thenReturn(emptyClusterState());
+
+        ActionListener<IndexResponse> responseListener = mock(ActionListener.class);
+        action.doExecute(null, ubiJudgmentRequest(), responseListener);
+
+        ArgumentCaptor<Exception> exceptionCaptor = ArgumentCaptor.forClass(Exception.class);
+        verify(responseListener).onFailure(exceptionCaptor.capture());
+        verifyNoInteractions(judgmentDao);
+
+        Exception exception = exceptionCaptor.getValue();
+        assertTrue(exception instanceof SearchRelevanceException);
+        assertEquals(RestStatus.BAD_REQUEST, ((SearchRelevanceException) exception).status());
+        assertTrue(exception.getMessage().contains("UBI events index [ubi_events] does not exist"));
+        assertTrue(exception.getMessage().contains("ubiEventsIndex"));
+    }
+
+    public void testValidation_UbiJudgment_EventsIndexResolvedFromAlias() {
+        when(clusterService.state()).thenReturn(clusterStateWithSampleEventsAliasedAsUbiEvents());
+
+        ActionListener<IndexResponse> responseListener = mock(ActionListener.class);
+        action.doExecute(null, ubiJudgmentRequest(), responseListener);
+
+        verify(responseListener, never()).onFailure(any(Exception.class));
+        verify(judgmentDao).putJudgement(any(), any(ActionListener.class));
+    }
+
+    private static PutUbiJudgmentRequest ubiJudgmentRequest() {
+        return new PutUbiJudgmentRequest(JudgmentType.UBI_JUDGMENT, "my-implicit-judgments", "test description", "coec", 20, "", "", null);
+    }
+
+    private static ClusterState emptyClusterState() {
+        return ClusterState.builder(new ClusterName("test")).metadata(Metadata.builder().build()).build();
+    }
+
+    private static ClusterState clusterStateWithSampleEventsAliasedAsUbiEvents() {
+        MappingMetadata mapping = new MappingMetadata(
+            MapperService.SINGLE_MAPPING_NAME,
+            Map.of(
+                "properties",
+                Map.of(
+                    "query_id",
+                    Map.of("type", "keyword"),
+                    "action_name",
+                    Map.of("type", "keyword"),
+                    "event_attributes",
+                    Map.of("properties", Map.of("object", Map.of("properties", Map.of("object_id", Map.of("type", "keyword")))))
+                )
+            )
+        );
+        IndexMetadata sampleEventsIndex = IndexMetadata.builder("opensearch_dashboards_sample_ubi_events")
+            .settings(
+                Settings.builder()
+                    .put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT)
+                    .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1)
+                    .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0)
+            )
+            .putMapping(mapping)
+            .putAlias(AliasMetadata.builder("ubi_events"))
+            .build();
+        return ClusterState.builder(new ClusterName("test")).metadata(Metadata.builder().put(sampleEventsIndex, false).build()).build();
     }
 }

--- a/src/test/java/org/opensearch/searchrelevance/transport/queryset/PostQuerySetTransportActionTests.java
+++ b/src/test/java/org/opensearch/searchrelevance/transport/queryset/PostQuerySetTransportActionTests.java
@@ -1,0 +1,208 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+package org.opensearch.searchrelevance.transport.queryset;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import java.util.Map;
+
+import org.apache.lucene.search.TotalHits;
+import org.junit.Before;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.opensearch.Version;
+import org.opensearch.action.index.IndexResponse;
+import org.opensearch.action.search.SearchRequest;
+import org.opensearch.action.search.SearchResponse;
+import org.opensearch.action.support.ActionFilters;
+import org.opensearch.cluster.ClusterName;
+import org.opensearch.cluster.ClusterState;
+import org.opensearch.cluster.metadata.AliasMetadata;
+import org.opensearch.cluster.metadata.IndexMetadata;
+import org.opensearch.cluster.metadata.IndexNameExpressionResolver;
+import org.opensearch.cluster.metadata.MappingMetadata;
+import org.opensearch.cluster.metadata.Metadata;
+import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.common.util.concurrent.ThreadContext;
+import org.opensearch.core.action.ActionListener;
+import org.opensearch.core.rest.RestStatus;
+import org.opensearch.index.mapper.MapperService;
+import org.opensearch.search.SearchHit;
+import org.opensearch.search.SearchHits;
+import org.opensearch.searchrelevance.dao.QuerySetDao;
+import org.opensearch.searchrelevance.exception.SearchRelevanceException;
+import org.opensearch.test.OpenSearchTestCase;
+import org.opensearch.transport.TransportService;
+import org.opensearch.transport.client.Client;
+
+public class PostQuerySetTransportActionTests extends OpenSearchTestCase {
+
+    private static final Map<String, Object> VALID_QUERIES_MAPPING = Map.of("properties", Map.of("user_query", Map.of("type", "keyword")));
+    private static final Map<String, Object> UNRELATED_MAPPING = Map.of("properties", Map.of("something_else", Map.of("type", "keyword")));
+
+    @Mock
+    private ClusterService clusterService;
+    @Mock
+    private TransportService transportService;
+    @Mock
+    private ActionFilters actionFilters;
+    @Mock
+    private Client client;
+    @Mock
+    private QuerySetDao querySetDao;
+
+    private PostQuerySetTransportAction action;
+
+    @Before
+    public void setup() {
+        MockitoAnnotations.openMocks(this);
+        action = new PostQuerySetTransportAction(
+            clusterService,
+            new IndexNameExpressionResolver(new ThreadContext(Settings.EMPTY)),
+            transportService,
+            actionFilters,
+            client,
+            querySetDao
+        );
+    }
+
+    public void testValidation_QueriesIndexNotFound() {
+        when(clusterService.state()).thenReturn(clusterState());
+
+        ActionListener<IndexResponse> responseListener = mock(ActionListener.class);
+        action.doExecute(null, querySetRequest(), responseListener);
+
+        ArgumentCaptor<Exception> exceptionCaptor = ArgumentCaptor.forClass(Exception.class);
+        verify(responseListener).onFailure(exceptionCaptor.capture());
+        verifyNoInteractions(querySetDao);
+        verifyNoInteractions(client);
+
+        Exception exception = exceptionCaptor.getValue();
+        assertTrue(exception instanceof SearchRelevanceException);
+        assertEquals(RestStatus.BAD_REQUEST, ((SearchRelevanceException) exception).status());
+        assertTrue(exception.getMessage(), exception.getMessage().contains("UBI queries index [ubi_queries] does not exist"));
+        assertTrue(exception.getMessage(), exception.getMessage().contains("ubiQueriesIndex"));
+    }
+
+    public void testValidation_QueriesIndexMissingRequiredField() {
+        when(clusterService.state()).thenReturn(clusterState(index("ubi_queries", UNRELATED_MAPPING)));
+
+        ActionListener<IndexResponse> responseListener = mock(ActionListener.class);
+        action.doExecute(null, querySetRequest(), responseListener);
+
+        ArgumentCaptor<Exception> exceptionCaptor = ArgumentCaptor.forClass(Exception.class);
+        verify(responseListener).onFailure(exceptionCaptor.capture());
+        verifyNoInteractions(querySetDao);
+
+        Exception exception = exceptionCaptor.getValue();
+        assertEquals(RestStatus.BAD_REQUEST, ((SearchRelevanceException) exception).status());
+        assertTrue(exception.getMessage(), exception.getMessage().contains("user_query"));
+    }
+
+    public void testValidation_QueriesIndexResolvedFromAlias() {
+        when(clusterService.state()).thenReturn(
+            clusterState(index("opensearch_dashboards_sample_ubi_queries", VALID_QUERIES_MAPPING, "ubi_queries"))
+        );
+        stubEmptySearchResponse();
+
+        ActionListener<IndexResponse> responseListener = mock(ActionListener.class);
+        action.doExecute(null, querySetRequest(), responseListener);
+
+        verify(querySetDao).putQuerySet(any(), any());
+    }
+
+    public void testEmptyNameIsRejectedBeforeAnySampling() {
+        when(clusterService.state()).thenReturn(clusterState(index("ubi_queries", VALID_QUERIES_MAPPING)));
+
+        ActionListener<IndexResponse> responseListener = mock(ActionListener.class);
+        action.doExecute(null, new PostUbiQuerySetRequest("   ", "test description", "random", 10, null), responseListener);
+
+        ArgumentCaptor<Exception> exceptionCaptor = ArgumentCaptor.forClass(Exception.class);
+        verify(responseListener).onFailure(exceptionCaptor.capture());
+        verifyNoInteractions(client);
+        verifyNoInteractions(querySetDao);
+
+        assertEquals(RestStatus.BAD_REQUEST, ((SearchRelevanceException) exceptionCaptor.getValue()).status());
+        assertTrue(exceptionCaptor.getValue().getMessage().contains("Name cannot be null or empty"));
+    }
+
+    public void testSamplingFailureCompletesListenerExactlyOnce() {
+        when(clusterService.state()).thenReturn(clusterState(index("ubi_queries", VALID_QUERIES_MAPPING)));
+        doAnswer(invocation -> { throw new IllegalStateException("sampling blew up"); }).when(client)
+            .search(any(SearchRequest.class), any(ActionListener.class));
+
+        ActionListener<IndexResponse> responseListener = mock(ActionListener.class);
+        action.doExecute(null, querySetRequest(), responseListener);
+
+        ArgumentCaptor<Exception> exceptionCaptor = ArgumentCaptor.forClass(Exception.class);
+        verify(responseListener, times(1)).onFailure(exceptionCaptor.capture());
+        verify(responseListener, never()).onResponse(any());
+        verifyNoInteractions(querySetDao);
+
+        assertEquals(RestStatus.INTERNAL_SERVER_ERROR, ((SearchRelevanceException) exceptionCaptor.getValue()).status());
+    }
+
+    public void testDoExecuteDoesNotBlockOnPendingSampling() throws Exception {
+        when(clusterService.state()).thenReturn(clusterState(index("ubi_queries", VALID_QUERIES_MAPPING)));
+        doAnswer(invocation -> null).when(client).search(any(SearchRequest.class), any(ActionListener.class));
+
+        ActionListener<IndexResponse> responseListener = mock(ActionListener.class);
+        Thread caller = new Thread(() -> action.doExecute(null, querySetRequest(), responseListener));
+        caller.start();
+        caller.join(10_000);
+
+        assertFalse("doExecute blocked on the incomplete sampling future", caller.isAlive());
+        verifyNoInteractions(querySetDao);
+    }
+
+    private void stubEmptySearchResponse() {
+        SearchResponse searchResponse = mock(SearchResponse.class);
+        when(searchResponse.getHits()).thenReturn(new SearchHits(new SearchHit[0], new TotalHits(0, TotalHits.Relation.EQUAL_TO), 0.0f));
+        doAnswer(invocation -> {
+            ActionListener<SearchResponse> listener = invocation.getArgument(1);
+            listener.onResponse(searchResponse);
+            return null;
+        }).when(client).search(any(SearchRequest.class), any(ActionListener.class));
+    }
+
+    private static PostUbiQuerySetRequest querySetRequest() {
+        return new PostUbiQuerySetRequest("test-query-set", "test description", "random", 10, null);
+    }
+
+    private static ClusterState clusterState(IndexMetadata.Builder... indices) {
+        Metadata.Builder metadata = Metadata.builder();
+        for (IndexMetadata.Builder index : indices) {
+            metadata.put(index.build(), false);
+        }
+        return ClusterState.builder(new ClusterName("test")).metadata(metadata.build()).build();
+    }
+
+    private static IndexMetadata.Builder index(String indexName, Map<String, Object> mappingSource, String... aliases) {
+        IndexMetadata.Builder builder = IndexMetadata.builder(indexName)
+            .settings(
+                Settings.builder()
+                    .put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT)
+                    .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1)
+                    .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0)
+            )
+            .putMapping(new MappingMetadata(MapperService.SINGLE_MAPPING_NAME, mappingSource));
+        for (String alias : aliases) {
+            builder.putAlias(AliasMetadata.builder(alias));
+        }
+        return builder;
+    }
+}

--- a/src/test/java/org/opensearch/searchrelevance/ubi/UbiValidatorTests.java
+++ b/src/test/java/org/opensearch/searchrelevance/ubi/UbiValidatorTests.java
@@ -7,121 +7,215 @@
  */
 package org.opensearch.searchrelevance.ubi;
 
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
-
+import java.util.List;
 import java.util.Map;
 
+import org.opensearch.Version;
+import org.opensearch.cluster.ClusterName;
 import org.opensearch.cluster.ClusterState;
+import org.opensearch.cluster.metadata.AliasMetadata;
+import org.opensearch.cluster.metadata.DataStream;
 import org.opensearch.cluster.metadata.IndexMetadata;
+import org.opensearch.cluster.metadata.IndexNameExpressionResolver;
 import org.opensearch.cluster.metadata.MappingMetadata;
 import org.opensearch.cluster.metadata.Metadata;
-import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.common.util.concurrent.ThreadContext;
+import org.opensearch.index.mapper.MapperService;
 import org.opensearch.test.OpenSearchTestCase;
 
 public class UbiValidatorTests extends OpenSearchTestCase {
 
-    public void testCheckUbiQueriesIndexExistsWithValidFields() {
-        ClusterService clusterService = mock(ClusterService.class);
-        ClusterState clusterState = mock(ClusterState.class);
-        Metadata metadata = mock(Metadata.class);
-        IndexMetadata indexMetadata = mock(IndexMetadata.class);
-        MappingMetadata mappingMetadata = mock(MappingMetadata.class);
+    private static final String SAMPLE_EVENTS_INDEX = "opensearch_dashboards_sample_ubi_events";
 
-        when(clusterService.state()).thenReturn(clusterState);
-        when(clusterState.metadata()).thenReturn(metadata);
-        when(metadata.hasIndex("ubi_queries")).thenReturn(true);
-        when(metadata.index("ubi_queries")).thenReturn(indexMetadata);
-        when(indexMetadata.mapping()).thenReturn(mappingMetadata);
-        when(mappingMetadata.sourceAsMap()).thenReturn(Map.of("properties", Map.of("user_query", Map.of("type", "text"))));
+    private static final Map<String, Object> VALID_QUERIES_MAPPING = Map.of("properties", Map.of("user_query", Map.of("type", "keyword")));
 
-        assertTrue(UbiValidator.checkUbiQueriesIndexExists(clusterService, "ubi_queries"));
+    private static final Map<String, Object> VALID_EVENTS_MAPPING = Map.of(
+        "properties",
+        Map.of(
+            "query_id",
+            Map.of("type", "keyword"),
+            "action_name",
+            Map.of("type", "keyword"),
+            "event_attributes",
+            Map.of("properties", Map.of("object", Map.of("properties", Map.of("object_id", Map.of("type", "keyword")))))
+        )
+    );
+
+    private static final Map<String, Object> UNRELATED_MAPPING = Map.of("properties", Map.of("something_else", Map.of("type", "keyword")));
+
+    private IndexNameExpressionResolver resolver;
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        resolver = new IndexNameExpressionResolver(new ThreadContext(Settings.EMPTY));
     }
 
-    public void testCheckUbiQueriesIndexExistsWithMissingFields() {
-        ClusterService clusterService = mock(ClusterService.class);
-        ClusterState clusterState = mock(ClusterState.class);
-        Metadata metadata = mock(Metadata.class);
-        IndexMetadata indexMetadata = mock(IndexMetadata.class);
-        MappingMetadata mappingMetadata = mock(MappingMetadata.class);
+    public void testValidateUbiQueriesIndexWithValidFields() {
+        ClusterState clusterState = clusterState(index("ubi_queries", VALID_QUERIES_MAPPING));
 
-        when(clusterService.state()).thenReturn(clusterState);
-        when(clusterState.metadata()).thenReturn(metadata);
-        when(metadata.hasIndex("ubi_queries")).thenReturn(true);
-        when(metadata.index("ubi_queries")).thenReturn(indexMetadata);
-        when(indexMetadata.mapping()).thenReturn(mappingMetadata);
-        when(mappingMetadata.sourceAsMap()).thenReturn(Map.of("properties", Map.of()));
-
-        assertFalse(UbiValidator.checkUbiQueriesIndexExists(clusterService, "ubi_queries"));
+        assertTrue(UbiValidator.validateUbiQueriesIndex(clusterState, resolver, "ubi_queries").isValid());
     }
 
-    public void testCheckUbiEventsIndexExistsWithValidFields() {
-        ClusterService clusterService = mock(ClusterService.class);
-        ClusterState clusterState = mock(ClusterState.class);
-        Metadata metadata = mock(Metadata.class);
-        IndexMetadata indexMetadata = mock(IndexMetadata.class);
-        MappingMetadata mappingMetadata = mock(MappingMetadata.class);
+    public void testValidateUbiQueriesIndexWithMissingFields() {
+        ClusterState clusterState = clusterState(index("ubi_queries", UNRELATED_MAPPING));
 
-        when(clusterService.state()).thenReturn(clusterState);
-        when(clusterState.metadata()).thenReturn(metadata);
-        when(metadata.hasIndex("ubi_events")).thenReturn(true);
-        when(metadata.index("ubi_events")).thenReturn(indexMetadata);
-        when(indexMetadata.mapping()).thenReturn(mappingMetadata);
-        when(mappingMetadata.sourceAsMap()).thenReturn(
-            Map.of(
-                "properties",
-                Map.of(
-                    "query_id",
-                    Map.of("type", "keyword"),
-                    "action_name",
-                    Map.of("type", "keyword"),
-                    "event_attributes",
-                    Map.of("properties", Map.of("object", Map.of("properties", Map.of("object_id", Map.of("type", "keyword")))))
-                )
-            )
+        UbiValidator.ValidationResult result = UbiValidator.validateUbiQueriesIndex(clusterState, resolver, "ubi_queries");
+
+        assertFalse(result.isValid());
+        assertTrue(result.getErrorMessage(), result.getErrorMessage().contains("[ubi_queries]"));
+        assertTrue(result.getErrorMessage(), result.getErrorMessage().contains("user_query"));
+    }
+
+    public void testValidateUbiEventsIndexWithValidFields() {
+        ClusterState clusterState = clusterState(index("ubi_events", VALID_EVENTS_MAPPING));
+
+        assertTrue(UbiValidator.validateUbiEventsIndex(clusterState, resolver, "ubi_events").isValid());
+    }
+
+    public void testValidateUbiEventsIndexWithMissingFields() {
+        ClusterState clusterState = clusterState(index("ubi_events", Map.of("properties", Map.of("query_id", Map.of("type", "keyword")))));
+
+        UbiValidator.ValidationResult result = UbiValidator.validateUbiEventsIndex(clusterState, resolver, "ubi_events");
+
+        assertFalse(result.isValid());
+        assertTrue(result.getErrorMessage(), result.getErrorMessage().contains("action_name"));
+        assertTrue(result.getErrorMessage(), result.getErrorMessage().contains("event_attributes.object.object_id"));
+    }
+
+    public void testValidateUbiEventsIndexWithoutMapping() {
+        ClusterState clusterState = clusterState(index("ubi_events", null));
+
+        assertFalse(UbiValidator.validateUbiEventsIndex(clusterState, resolver, "ubi_events").isValid());
+    }
+
+    public void testValidateUbiQueriesIndexNotExist() {
+        UbiValidator.ValidationResult result = UbiValidator.validateUbiQueriesIndex(clusterState(), resolver, "ubi_queries");
+
+        assertFalse(result.isValid());
+        assertTrue(result.getErrorMessage(), result.getErrorMessage().contains("UBI queries index [ubi_queries] does not exist"));
+        assertTrue(result.getErrorMessage(), result.getErrorMessage().contains("ubiQueriesIndex"));
+    }
+
+    public void testValidateUbiEventsIndexNotExist() {
+        UbiValidator.ValidationResult result = UbiValidator.validateUbiEventsIndex(clusterState(), resolver, "ubi_events");
+
+        assertFalse(result.isValid());
+        assertTrue(result.getErrorMessage(), result.getErrorMessage().contains("UBI events index [ubi_events] does not exist"));
+        assertTrue(result.getErrorMessage(), result.getErrorMessage().contains("ubiEventsIndex"));
+    }
+
+    public void testValidateRejectsBlankIndexExpression() {
+        UbiValidator.ValidationResult result = UbiValidator.validateUbiEventsIndex(clusterState(), resolver, "  ");
+
+        assertFalse(result.isValid());
+        assertTrue(result.getErrorMessage(), result.getErrorMessage().contains("must not be empty"));
+    }
+
+    public void testValidateUbiEventsIndexResolvesAlias() {
+        ClusterState clusterState = clusterState(index(SAMPLE_EVENTS_INDEX, VALID_EVENTS_MAPPING, "ubi_events"));
+
+        assertTrue(UbiValidator.validateUbiEventsIndex(clusterState, resolver, "ubi_events").isValid());
+    }
+
+    public void testValidateUbiQueriesIndexResolvesAlias() {
+        ClusterState clusterState = clusterState(index("opensearch_dashboards_sample_ubi_queries", VALID_QUERIES_MAPPING, "ubi_queries"));
+
+        assertTrue(UbiValidator.validateUbiQueriesIndex(clusterState, resolver, "ubi_queries").isValid());
+    }
+
+    public void testValidateUbiEventsIndexAcceptsAliasWhereOnlySomeBackingIndicesMatch() {
+        ClusterState clusterState = clusterState(
+            index("ubi_events-2026.01", VALID_EVENTS_MAPPING, "ubi_events"),
+            index("unrelated-index", UNRELATED_MAPPING, "ubi_events")
         );
 
-        assertTrue(UbiValidator.checkUbiEventsIndexExists(clusterService, "ubi_events"));
+        assertTrue(UbiValidator.validateUbiEventsIndex(clusterState, resolver, "ubi_events").isValid());
     }
 
-    public void testCheckUbiEventsIndexExistsWithMissingFields() {
-        ClusterService clusterService = mock(ClusterService.class);
-        ClusterState clusterState = mock(ClusterState.class);
-        Metadata metadata = mock(Metadata.class);
-        IndexMetadata indexMetadata = mock(IndexMetadata.class);
-        MappingMetadata mappingMetadata = mock(MappingMetadata.class);
+    public void testValidateUbiEventsIndexRejectsAliasWhereNoBackingIndexMatches() {
+        ClusterState clusterState = clusterState(
+            index("unrelated-one", UNRELATED_MAPPING, "ubi_events"),
+            index("unrelated-two", UNRELATED_MAPPING, "ubi_events")
+        );
 
-        when(clusterService.state()).thenReturn(clusterState);
-        when(clusterState.metadata()).thenReturn(metadata);
-        when(metadata.hasIndex("ubi_events")).thenReturn(true);
-        when(metadata.index("ubi_events")).thenReturn(indexMetadata);
-        when(indexMetadata.mapping()).thenReturn(mappingMetadata);
-        when(mappingMetadata.sourceAsMap()).thenReturn(Map.of("properties", Map.of("query_id", Map.of("type", "keyword"))));
+        UbiValidator.ValidationResult result = UbiValidator.validateUbiEventsIndex(clusterState, resolver, "ubi_events");
 
-        assertFalse(UbiValidator.checkUbiEventsIndexExists(clusterService, "ubi_events"));
+        assertFalse(result.isValid());
+        assertTrue(result.getErrorMessage(), result.getErrorMessage().contains("No index resolved from [ubi_events]"));
+        assertTrue(result.getErrorMessage(), result.getErrorMessage().contains("unrelated-one"));
+        assertTrue(result.getErrorMessage(), result.getErrorMessage().contains("unrelated-two"));
     }
 
-    public void testCheckUbiQueriesIndexNotExist() {
-        ClusterService clusterService = mock(ClusterService.class);
-        ClusterState clusterState = mock(ClusterState.class);
-        Metadata metadata = mock(Metadata.class);
+    public void testValidateUbiEventsIndexResolvesWildcard() {
+        ClusterState clusterState = clusterState(index(SAMPLE_EVENTS_INDEX, VALID_EVENTS_MAPPING));
 
-        when(clusterService.state()).thenReturn(clusterState);
-        when(clusterState.metadata()).thenReturn(metadata);
-        when(metadata.hasIndex("ubi_queries")).thenReturn(false);
-
-        assertFalse(UbiValidator.checkUbiQueriesIndexExists(clusterService, "ubi_queries"));
+        assertTrue(UbiValidator.validateUbiEventsIndex(clusterState, resolver, "*ubi_events*").isValid());
     }
 
-    public void testCheckUbiEventsIndexNotExist() {
-        ClusterService clusterService = mock(ClusterService.class);
-        ClusterState clusterState = mock(ClusterState.class);
-        Metadata metadata = mock(Metadata.class);
+    public void testValidateUbiEventsIndexRejectsWildcardMatchingNothing() {
+        UbiValidator.ValidationResult result = UbiValidator.validateUbiEventsIndex(clusterState(), resolver, "no_such_prefix*");
 
-        when(clusterService.state()).thenReturn(clusterState);
-        when(clusterState.metadata()).thenReturn(metadata);
-        when(metadata.hasIndex("ubi_events")).thenReturn(false);
+        assertFalse(result.isValid());
+        assertTrue(result.getErrorMessage(), result.getErrorMessage().contains("UBI events index [no_such_prefix*] does not exist"));
+    }
 
-        assertFalse(UbiValidator.checkUbiEventsIndexExists(clusterService, "ubi_events"));
+    public void testValidateUbiEventsIndexResolvesDataStream() {
+        String backingIndexName = DataStream.getDefaultBackingIndexName("ubi_events", 1);
+        IndexMetadata backingIndex = index(backingIndexName, VALID_EVENTS_MAPPING).build();
+        DataStream dataStream = new DataStream("ubi_events", new DataStream.TimestampField("@timestamp"), List.of(backingIndex.getIndex()));
+        ClusterState clusterState = ClusterState.builder(new ClusterName("test"))
+            .metadata(Metadata.builder().put(backingIndex, false).put(dataStream).build())
+            .build();
+
+        assertTrue(UbiValidator.validateUbiEventsIndex(clusterState, resolver, "ubi_events").isValid());
+    }
+
+    public void testValidateUbiEventsIndexReportsClosedBackingIndex() {
+        ClusterState clusterState = clusterState(
+            index("ubi_events-2026.01", VALID_EVENTS_MAPPING, "ubi_events"),
+            index("ubi_events-2025.01", VALID_EVENTS_MAPPING, "ubi_events").state(IndexMetadata.State.CLOSE)
+        );
+
+        UbiValidator.ValidationResult result = UbiValidator.validateUbiEventsIndex(clusterState, resolver, "ubi_events");
+
+        assertFalse(result.isValid());
+        assertTrue(result.getErrorMessage(), result.getErrorMessage().contains("closed index [ubi_events-2025.01]"));
+        assertTrue(result.getErrorMessage(), result.getErrorMessage().contains("ubiEventsIndex"));
+    }
+
+    public void testValidateUbiEventsIndexIgnoresClosedIndexOutsideTheExpression() {
+        ClusterState clusterState = clusterState(
+            index("ubi_events", VALID_EVENTS_MAPPING),
+            index("some_closed_index", UNRELATED_MAPPING).state(IndexMetadata.State.CLOSE)
+        );
+
+        assertTrue(UbiValidator.validateUbiEventsIndex(clusterState, resolver, "ubi_events").isValid());
+    }
+
+    private static ClusterState clusterState(IndexMetadata.Builder... indices) {
+        Metadata.Builder metadata = Metadata.builder();
+        for (IndexMetadata.Builder index : indices) {
+            metadata.put(index.build(), false);
+        }
+        return ClusterState.builder(new ClusterName("test")).metadata(metadata.build()).build();
+    }
+
+    private static IndexMetadata.Builder index(String indexName, Map<String, Object> mappingSource, String... aliases) {
+        IndexMetadata.Builder builder = IndexMetadata.builder(indexName)
+            .settings(
+                Settings.builder()
+                    .put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT)
+                    .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1)
+                    .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0)
+            );
+        if (mappingSource != null) {
+            builder.putMapping(new MappingMetadata(MapperService.SINGLE_MAPPING_NAME, mappingSource));
+        }
+        for (String alias : aliases) {
+            builder.putAlias(AliasMetadata.builder(alias));
+        }
+        return builder;
     }
 }


### PR DESCRIPTION
### Description
#### The problem from the issue

UBI data loaded by the Dashboards sample data loader lands in `opensearch_dashboards_sample_ubi_events`, but the plugin looks for `ubi_events` by default. The natural way to bridge that is an alias:

```console
PUT opensearch_dashboards_sample_ubi_events/_alias/ubi_events
```

That did not help. Creating a judgment still failed — even though the alias is perfectly searchable:

```console
GET ubi_events/_count       ->  3555 documents
PUT .../judgments           ->  500  "UBI events index does not exist"
```

#### Why

Two separate defects.

**1. Validation was narrower than the search it guards.** The check used `Metadata#hasIndex`, which only matches concrete index names. But the click model then hands the same string to a `SearchRequest`, which understands aliases, data streams and wildcards. So anything that was not a plain index name got rejected as non existent, even though a real search on it would have worked. The gatekeeper was stricter than the operation behind it.

**2. A client error was reported as a server error.** The check threw a `409` from `buildMetadata()`, but that runs inside `createJudgment()`'s `catch (Exception e)`, which re-wrapped it as a `500`. A request the user could have fixed looked like a plugin crash instead. The message did not help either — it never said which index name it had looked for, nor that a `ubiEventsIndex` parameter exists to override it.

#### The fix

**Resolve the index name the same way the search does.** Rather than implementing name resolution a second time, `UbiValidator` now calls `IndexNameExpressionResolver` with the options read straight off `SearchRequest` — the very object the click model will use. Aliases, data streams and wildcards all work, and validation can no longer drift into being stricter than the search it guards.

**Require the UBI fields on only one of the resolved indices.** A search across an alias simply contributes nothing for indices that do not map those fields, with no shard failure. Demanding that every backing index be valid would reject setups that actually work — a stale rollover index, or an alias reused across a mixed set of indices.

**Validate before writing anything, and report through the listener.** The check moved into `doExecute()`, so it returns a `400` that no longer passes through the catch-all, and a failed request no longer leaves a half-built `PROCESSING` judgment behind. The message now names the index, lists the missing fields, and points at the parameter to set.

The same three defects affected the `ubi_queries` path in `PostQuerySetTransportAction`, fixed alongside.

#### Behaviour change

| Endpoint | Condition | Before | After |
| --- | --- | --- | --- |
| `PUT /_plugins/_search_relevance/judgments` | invalid `ubiEventsIndex` | `500` | `400` |
| `POST /_plugins/_search_relevance/query_sets` | invalid `ubiQueriesIndex` | `409` | `400` |
| `POST /_plugins/_search_relevance/query_sets` | sampling failure | `400` | derived via `ExceptionsHelper.status` |

### Reproducing the reported problem

Verified against a live cluster (`./gradlew run`, OpenSearch 3.8.0-SNAPSHOT with this plugin) and OpenSearch Dashboards 3.8.0 with `dashboards-search-relevance` installed.

**Step 1 — Load the sample UBI data from Dashboards.** Home → Add sample data → **Sample UBI data** creates `opensearch_dashboards_sample_ubi_events` (3555 events), which is **not** named `ubi_events`.



```console
GET _cat/indices/*ubi_events*?v&h=index,docs.count

index                                                                               docs.count
opensearch_dashboards_sample_ubi_events               3555
```


**Step 2 — Run the request from the issue, verbatim.**

```console
PUT _plugins/_search_relevance/judgments
{
  "name": "my-implicit-judgments",
  "clickModel": "coec",
  "type": "UBI_JUDGMENT",
  "maxRank": 20
}
```


Before this change, exactly as reported:

```json
{
  "error": {
    "root_cause": [ { "type": "search_relevance_exception", "reason": "UBI events index does not exist" } ],
    "type": "search_relevance_exception",
    "reason": "Failed to create judgment",
    "caused_by": { "type": "search_relevance_exception", "reason": "UBI events index does not exist" }
  },
  "status": 500
}
```

After, a client error that says what to do about it:

<img width="1512" height="768" alt="1" src="https://github.com/user-attachments/assets/454a9faf-b628-48be-97ac-7ff5c2a8f935" />



**Step 3 — The alias workaround the issue says does not help.**

```console
PUT opensearch_dashboards_sample_ubi_events/_alias/ubi_events
```
<img width="1512" height="316" alt="2" src="https://github.com/user-attachments/assets/865d12e6-139b-4eef-8e0a-6c4e1008f0c1" />

The alias is readable — this is the asymmetry that was the bug:

```console
GET ubi_events/_count
{ "count": 3555, ... }
```


Re-sending the **unchanged** request from step 2:

```console
HTTP 200
{ "judgment_id": "7a02e394-fd41-4f79-90cc-da9d7fce1964" }
```
<img width="1512" height="265" alt="3" src="https://github.com/user-attachments/assets/181908f4-e62e-4a98-a9c3-0370658b7208" />



```console
GET search-relevance-judgment/_doc/7a02e394-fd41-4f79-90cc-da9d7fce1964

status         = COMPLETED
ubiEventsIndex = ubi_events
queries        = 149
ratings        = 1139   (157 non-zero, max 50.962)

laptop   B07P75NDMB   8.571
laptop   B07FM8BNBC   7.529
laptop   B08Q7M6P5H   5.861
hp       B00WJDWG62   6.319
```

<img width="1512" height="764" alt="3-1" src="https://github.com/user-attachments/assets/30bc1de7-095f-4395-9cc0-80d4a37fa944" />

Before this change step 3 also returned `500`.

### The three ways a user can point the plugin at their data

All three verified on the live cluster above.

**1. Pass the index name explicitly.**

```console
PUT _plugins/_search_relevance/judgments
{
  "name": "my-implicit-judgments",
  "clickModel": "coec",
  "type": "UBI_JUDGMENT",
  "maxRank": 20,
  "ubiEventsIndex": "opensearch_dashboards_sample_ubi_events"
}
```

This already worked before the change — it is what the Dashboards UI does when you pick an index from the dropdown, and why the UI worked while the API did not. The old error message never mentioned the parameter, so an API caller had no way to discover it.

**2. Alias the index as `ubi_events` and change nothing else.**

```console
PUT opensearch_dashboards_sample_ubi_events/_alias/ubi_events
```

The default `ubi_events` now resolves through the alias, so existing requests, scripts and docs can keep using `ubi_events` regardless of what the backing index is called or is renamed to. This is the path the issue reports as broken, and the main fix here.

**3. Use a wildcard.**

```console
PUT _plugins/_search_relevance/judgments
{
  "name": "my-implicit-judgments",
  "clickModel": "coec",
  "type": "UBI_JUDGMENT",
  "maxRank": 20,
  "ubiEventsIndex": "*ubi_events*"
}
```

`*ubi_events*` is the same pattern `dashboards-search-relevance` already uses to discover UBI indexes (`judgment_service.ts` → `GetIndexesByPattern/*ubi_events*`), so front end and API can now use one expression without knowing the concrete index name. Wildcards returned `500` before.

Data streams work the same way — `ubiEventsIndex: "ds_ubi_events"` resolves to `.ds-ds_ubi_events-000001`. The equivalent `ubiQueriesIndex` parameter covers all three for `POST /query_sets`.



### Automated tests

`./gradlew spotlessCheck test integTest` — 845 unit tests, 35 integration tests, 0 failures.

* `UbiValidatorTests` builds a real `ClusterState` and uses a real `IndexNameExpressionResolver` instead of mocking `Metadata`, so alias, data stream, wildcard and closed-index behaviour is exercised against the actual resolver. Reverting the resolution change fails 7 of its cases.
* `UbiEventsIndexResolutionIT` reproduces the issue end to end: creates opensearch_dashboards_sample_ubi_events`, aliases `ubi_events` to it, ingests events and issues the request from the issue with no `ubiEventsIndex`, plus the explicit-name, wildcard and rejection cases. Reverting the resolution change fails the alias case with the original error.
* `PostQuerySetTransportActionTests` is new — that path had no unit coverage at all.



### Issues Resolved

[Closes opensearch-project/dashboards-search-relevance#907](https://github.com/opensearch-project/dashboards-search-relevance/issues/907)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
