### PR TITLE
Report a missing UBI events index as 400 and name the ubiEventsIndex parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### Bug Fixes
 - Return correct delete REST status codes and honor querySetSize for sampling ([#542](https://github.com/opensearch-project/search-relevance/pull/542))
+- Report an invalid UBI events index as a `400` naming the index and the `ubiEventsIndex` parameter instead of a `500` ([#558](https://github.com/opensearch-project/search-relevance/pull/558))
 
 ### Infrastructure
 

--- a/src/main/java/org/opensearch/searchrelevance/transport/judgment/PutJudgmentTransportAction.java
+++ b/src/main/java/org/opensearch/searchrelevance/transport/judgment/PutJudgmentTransportAction.java
@@ -111,18 +111,7 @@ public class PutJudgmentTransportAction extends HandledTransportAction<PutJudgme
                 PutUbiJudgmentRequest ubiRequest = (PutUbiJudgmentRequest) request;
                 String ubiEventsIndex = ubiRequest.getUbiEventsIndex();
                 if (!checkUbiEventsIndexExists(clusterService, ubiEventsIndex)) {
-                    listener.onFailure(
-                        new SearchRelevanceException(
-                            String.format(
-                                Locale.ROOT,
-                                "UBI events index [%s] does not exist or does not have the required UBI event fields. "
-                                    + "Ingest UBI events data into it, or set the '%s' parameter to an existing UBI events index.",
-                                ubiEventsIndex,
-                                UBI_EVENTS_INDEX_PARAM
-                            ),
-                            RestStatus.BAD_REQUEST
-                        )
-                    );
+                    listener.onFailure(invalidUbiEventsIndexException(ubiEventsIndex, ubiRequest.isUbiEventsIndexProvided()));
                     return;
                 }
                 createJudgment(request, listener);
@@ -133,6 +122,35 @@ public class PutJudgmentTransportAction extends HandledTransportAction<PutJudgme
             LOGGER.error("Failed to process judgment request", e);
             listener.onFailure(new SearchRelevanceException("Failed to process judgment request", e, RestStatus.INTERNAL_SERVER_ERROR));
         }
+    }
+
+    private static SearchRelevanceException invalidUbiEventsIndexException(String ubiEventsIndex, boolean ubiEventsIndexProvided) {
+        String requiredFields = "query_id, action_name, event_attributes.object.object_id";
+        String message;
+        if (ubiEventsIndexProvided) {
+            message = String.format(
+                Locale.ROOT,
+                "The UBI events index [%s] set by the '%s' parameter does not exist or is missing required UBI event "
+                    + "fields (%s). Ingest UBI events data into it, or set the '%s' parameter to an existing UBI events index.",
+                ubiEventsIndex,
+                UBI_EVENTS_INDEX_PARAM,
+                requiredFields,
+                UBI_EVENTS_INDEX_PARAM
+            );
+        } else {
+            message = String.format(
+                Locale.ROOT,
+                "No '%s' parameter was provided and the default UBI events index [%s] does not exist or is missing "
+                    + "required UBI event fields (%s). Ingest UBI events data into [%s], or set the '%s' parameter to an "
+                    + "existing UBI events index.",
+                UBI_EVENTS_INDEX_PARAM,
+                ubiEventsIndex,
+                requiredFields,
+                ubiEventsIndex,
+                UBI_EVENTS_INDEX_PARAM
+            );
+        }
+        return new SearchRelevanceException(message, RestStatus.BAD_REQUEST);
     }
 
     private void createJudgment(PutJudgmentRequest request, ActionListener<IndexResponse> listener) {

--- a/src/main/java/org/opensearch/searchrelevance/transport/judgment/PutJudgmentTransportAction.java
+++ b/src/main/java/org/opensearch/searchrelevance/transport/judgment/PutJudgmentTransportAction.java
@@ -10,6 +10,7 @@ package org.opensearch.searchrelevance.transport.judgment;
 import static org.opensearch.searchrelevance.common.MLConstants.LLM_JUDGMENT_RATING_TYPE;
 import static org.opensearch.searchrelevance.common.MLConstants.PROMPT_TEMPLATE;
 import static org.opensearch.searchrelevance.common.MetricsConstants.MODEL_ID;
+import static org.opensearch.searchrelevance.common.PluginConstants.UBI_EVENTS_INDEX_PARAM;
 import static org.opensearch.searchrelevance.ubi.UbiValidator.checkUbiEventsIndexExists;
 
 import java.util.ArrayList;
@@ -17,6 +18,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
@@ -105,6 +107,25 @@ public class PutJudgmentTransportAction extends HandledTransportAction<PutJudgme
                     llmRequest,
                     ActionListener.wrap(v -> { createJudgment(request, listener); }, listener::onFailure)
                 );
+            } else if (request.getType() == JudgmentType.UBI_JUDGMENT) {
+                PutUbiJudgmentRequest ubiRequest = (PutUbiJudgmentRequest) request;
+                String ubiEventsIndex = ubiRequest.getUbiEventsIndex();
+                if (!checkUbiEventsIndexExists(clusterService, ubiEventsIndex)) {
+                    listener.onFailure(
+                        new SearchRelevanceException(
+                            String.format(
+                                Locale.ROOT,
+                                "UBI events index [%s] does not exist or does not have the required UBI event fields. "
+                                    + "Ingest UBI events data into it, or set the '%s' parameter to an existing UBI events index.",
+                                ubiEventsIndex,
+                                UBI_EVENTS_INDEX_PARAM
+                            ),
+                            RestStatus.BAD_REQUEST
+                        )
+                    );
+                    return;
+                }
+                createJudgment(request, listener);
             } else {
                 createJudgment(request, listener);
             }
@@ -401,9 +422,6 @@ public class PutJudgmentTransportAction extends HandledTransportAction<PutJudgme
             }
             case UBI_JUDGMENT -> {
                 PutUbiJudgmentRequest ubiRequest = (PutUbiJudgmentRequest) request;
-                if (!checkUbiEventsIndexExists(clusterService, ubiRequest.getUbiEventsIndex())) {
-                    throw new SearchRelevanceException("UBI events index does not exist", RestStatus.CONFLICT);
-                }
                 metadata.put("clickModel", ubiRequest.getClickModel());
                 metadata.put("maxRank", ubiRequest.getMaxRank());
                 metadata.put("startDate", ubiRequest.getStartDate());

--- a/src/main/java/org/opensearch/searchrelevance/transport/judgment/PutUbiJudgmentRequest.java
+++ b/src/main/java/org/opensearch/searchrelevance/transport/judgment/PutUbiJudgmentRequest.java
@@ -39,10 +39,7 @@ public class PutUbiJudgmentRequest extends PutJudgmentRequest {
         this.maxRank = maxRank;
         this.startDate = startDate;
         this.endDate = endDate;
-        // Default to standard UBI events index if not specified.
-        // Index existence and required fields (query_id, action_name, event_attributes.object.object_id)
-        // are validated at cluster level in PutJudgmentTransportAction before judgment processing begins.
-        this.ubiEventsIndex = ubiEventsIndex != null ? ubiEventsIndex : UBI_EVENTS_INDEX;
+        this.ubiEventsIndex = ubiEventsIndex;
     }
 
     public PutUbiJudgmentRequest(StreamInput in) throws IOException {
@@ -51,7 +48,7 @@ public class PutUbiJudgmentRequest extends PutJudgmentRequest {
         this.maxRank = in.readInt();
         this.startDate = in.readString();
         this.endDate = in.readString();
-        this.ubiEventsIndex = in.readString();
+        this.ubiEventsIndex = in.readOptionalString();
     }
 
     @Override
@@ -61,7 +58,7 @@ public class PutUbiJudgmentRequest extends PutJudgmentRequest {
         out.writeInt(maxRank);
         out.writeString(startDate);
         out.writeString(endDate);
-        out.writeString(ubiEventsIndex);
+        out.writeOptionalString(ubiEventsIndex);
     }
 
     public String getClickModel() {
@@ -81,6 +78,10 @@ public class PutUbiJudgmentRequest extends PutJudgmentRequest {
     }
 
     public String getUbiEventsIndex() {
-        return ubiEventsIndex;
+        return (ubiEventsIndex == null || ubiEventsIndex.isBlank()) ? UBI_EVENTS_INDEX : ubiEventsIndex;
+    }
+
+    public boolean isUbiEventsIndexProvided() {
+        return ubiEventsIndex != null && !ubiEventsIndex.isBlank();
     }
 }

--- a/src/test/java/org/opensearch/searchrelevance/transport/judgment/PutJudgmentTransportActionTests.java
+++ b/src/test/java/org/opensearch/searchrelevance/transport/judgment/PutJudgmentTransportActionTests.java
@@ -26,13 +26,17 @@ import org.mockito.MockitoAnnotations;
 import org.opensearch.action.index.IndexResponse;
 import org.opensearch.action.search.SearchResponse;
 import org.opensearch.action.support.ActionFilters;
+import org.opensearch.cluster.ClusterState;
+import org.opensearch.cluster.metadata.Metadata;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.core.action.ActionListener;
+import org.opensearch.core.rest.RestStatus;
 import org.opensearch.search.SearchHit;
 import org.opensearch.search.SearchHits;
 import org.opensearch.searchrelevance.dao.JudgmentDao;
 import org.opensearch.searchrelevance.dao.QuerySetDao;
 import org.opensearch.searchrelevance.dao.SearchConfigurationDao;
+import org.opensearch.searchrelevance.exception.SearchRelevanceException;
 import org.opensearch.searchrelevance.judgments.JudgmentsProcessorFactory;
 import org.opensearch.searchrelevance.model.JudgmentType;
 import org.opensearch.searchrelevance.model.LLMJudgmentRatingType;
@@ -506,5 +510,37 @@ public class PutJudgmentTransportActionTests extends OpenSearchTestCase {
         verify(responseListener).onFailure(exceptionCaptor.capture());
         assertTrue(exceptionCaptor.getValue().getMessage().contains("could not be resolved to a target index"));
         verify(judgmentDao, org.mockito.Mockito.never()).putJudgement(any(), any(ActionListener.class));
+    }
+
+    public void testValidation_UbiJudgment_EventsIndexNotFound_Returns400() {
+        ClusterState clusterState = mock(ClusterState.class);
+        Metadata metadata = mock(Metadata.class);
+        when(clusterService.state()).thenReturn(clusterState);
+        when(clusterState.metadata()).thenReturn(metadata);
+        when(metadata.hasIndex("ubi_events")).thenReturn(false);
+
+        PutUbiJudgmentRequest request = new PutUbiJudgmentRequest(
+            JudgmentType.UBI_JUDGMENT,
+            "my-implicit-judgments",
+            "test description",
+            "coec",
+            20,
+            "",
+            "",
+            null
+        );
+
+        ActionListener<IndexResponse> responseListener = mock(ActionListener.class);
+        action.doExecute(null, request, responseListener);
+
+        ArgumentCaptor<Exception> exceptionCaptor = ArgumentCaptor.forClass(Exception.class);
+        verify(responseListener).onFailure(exceptionCaptor.capture());
+        verify(judgmentDao, org.mockito.Mockito.never()).putJudgement(any(), any(ActionListener.class));
+
+        Exception exception = exceptionCaptor.getValue();
+        assertTrue(exception instanceof SearchRelevanceException);
+        assertEquals(RestStatus.BAD_REQUEST, ((SearchRelevanceException) exception).status());
+        assertTrue(exception.getMessage(), exception.getMessage().contains("UBI events index [ubi_events]"));
+        assertTrue(exception.getMessage(), exception.getMessage().contains("ubiEventsIndex"));
     }
 }

--- a/src/test/java/org/opensearch/searchrelevance/transport/judgment/PutJudgmentTransportActionTests.java
+++ b/src/test/java/org/opensearch/searchrelevance/transport/judgment/PutJudgmentTransportActionTests.java
@@ -27,6 +27,8 @@ import org.opensearch.action.index.IndexResponse;
 import org.opensearch.action.search.SearchResponse;
 import org.opensearch.action.support.ActionFilters;
 import org.opensearch.cluster.ClusterState;
+import org.opensearch.cluster.metadata.IndexMetadata;
+import org.opensearch.cluster.metadata.MappingMetadata;
 import org.opensearch.cluster.metadata.Metadata;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.core.action.ActionListener;
@@ -37,6 +39,7 @@ import org.opensearch.searchrelevance.dao.JudgmentDao;
 import org.opensearch.searchrelevance.dao.QuerySetDao;
 import org.opensearch.searchrelevance.dao.SearchConfigurationDao;
 import org.opensearch.searchrelevance.exception.SearchRelevanceException;
+import org.opensearch.searchrelevance.judgments.BaseJudgmentsProcessor;
 import org.opensearch.searchrelevance.judgments.JudgmentsProcessorFactory;
 import org.opensearch.searchrelevance.model.JudgmentType;
 import org.opensearch.searchrelevance.model.LLMJudgmentRatingType;
@@ -512,14 +515,29 @@ public class PutJudgmentTransportActionTests extends OpenSearchTestCase {
         verify(judgmentDao, org.mockito.Mockito.never()).putJudgement(any(), any(ActionListener.class));
     }
 
-    public void testValidation_UbiJudgment_EventsIndexNotFound_Returns400() {
+    private void stubIndexAbsent(String index) {
         ClusterState clusterState = mock(ClusterState.class);
         Metadata metadata = mock(Metadata.class);
         when(clusterService.state()).thenReturn(clusterState);
         when(clusterState.metadata()).thenReturn(metadata);
-        when(metadata.hasIndex("ubi_events")).thenReturn(false);
+        when(metadata.hasIndex(index)).thenReturn(false);
+    }
 
-        PutUbiJudgmentRequest request = new PutUbiJudgmentRequest(
+    private void stubIndexPresentWithMappingFields(String index, Map<String, Object> properties) {
+        ClusterState clusterState = mock(ClusterState.class);
+        Metadata metadata = mock(Metadata.class);
+        IndexMetadata indexMetadata = mock(IndexMetadata.class);
+        MappingMetadata mappingMetadata = mock(MappingMetadata.class);
+        when(clusterService.state()).thenReturn(clusterState);
+        when(clusterState.metadata()).thenReturn(metadata);
+        when(metadata.hasIndex(index)).thenReturn(true);
+        when(metadata.index(index)).thenReturn(indexMetadata);
+        when(indexMetadata.mapping()).thenReturn(mappingMetadata);
+        when(mappingMetadata.sourceAsMap()).thenReturn(Map.of("properties", properties));
+    }
+
+    private PutUbiJudgmentRequest ubiJudgmentRequest(String ubiEventsIndex) {
+        return new PutUbiJudgmentRequest(
             JudgmentType.UBI_JUDGMENT,
             "my-implicit-judgments",
             "test description",
@@ -527,9 +545,11 @@ public class PutJudgmentTransportActionTests extends OpenSearchTestCase {
             20,
             "",
             "",
-            null
+            ubiEventsIndex
         );
+    }
 
+    private SearchRelevanceException runUbiValidationExpectingFailure(PutUbiJudgmentRequest request) {
         ActionListener<IndexResponse> responseListener = mock(ActionListener.class);
         action.doExecute(null, request, responseListener);
 
@@ -540,7 +560,85 @@ public class PutJudgmentTransportActionTests extends OpenSearchTestCase {
         Exception exception = exceptionCaptor.getValue();
         assertTrue(exception instanceof SearchRelevanceException);
         assertEquals(RestStatus.BAD_REQUEST, ((SearchRelevanceException) exception).status());
-        assertTrue(exception.getMessage(), exception.getMessage().contains("UBI events index [ubi_events]"));
-        assertTrue(exception.getMessage(), exception.getMessage().contains("ubiEventsIndex"));
+        return (SearchRelevanceException) exception;
+    }
+
+    public void testValidation_UbiJudgment_DefaultEventsIndexNotFound_Returns400() {
+        stubIndexAbsent("ubi_events");
+
+        String message = runUbiValidationExpectingFailure(ubiJudgmentRequest(null)).getMessage();
+
+        assertTrue(message, message.contains("No 'ubiEventsIndex' parameter was provided"));
+        assertTrue(message, message.contains("default UBI events index [ubi_events]"));
+    }
+
+    public void testValidation_UbiJudgment_ExplicitEventsIndexNotFound_Returns400() {
+        stubIndexAbsent("my_custom_events");
+
+        String message = runUbiValidationExpectingFailure(ubiJudgmentRequest("my_custom_events")).getMessage();
+
+        assertTrue(message, message.contains("UBI events index [my_custom_events] set by the 'ubiEventsIndex' parameter"));
+        assertFalse(message, message.contains("No 'ubiEventsIndex' parameter was provided"));
+    }
+
+    public void testValidation_UbiJudgment_ExplicitDefaultEventsIndexNotFound_ReportedAsProvided_Returns400() {
+        stubIndexAbsent("ubi_events");
+
+        String message = runUbiValidationExpectingFailure(ubiJudgmentRequest("ubi_events")).getMessage();
+
+        assertTrue(message, message.contains("UBI events index [ubi_events] set by the 'ubiEventsIndex' parameter"));
+        assertFalse(message, message.contains("No 'ubiEventsIndex' parameter was provided"));
+    }
+
+    public void testValidation_UbiJudgment_NoParameter_ValidDefaultIndex_Succeeds() {
+        Map<String, Object> validProperties = Map.of(
+            "query_id",
+            Map.of("type", "keyword"),
+            "action_name",
+            Map.of("type", "keyword"),
+            "event_attributes",
+            Map.of("properties", Map.of("object", Map.of("properties", Map.of("object_id", Map.of("type", "keyword")))))
+        );
+        stubIndexPresentWithMappingFields("ubi_events", validProperties);
+
+        IndexResponse indexResponse = mock(IndexResponse.class);
+        doAnswer(invocation -> {
+            ActionListener<IndexResponse> listener = invocation.getArgument(1);
+            listener.onResponse(indexResponse);
+            return null;
+        }).when(judgmentDao).putJudgement(any(), any(ActionListener.class));
+
+        BaseJudgmentsProcessor processor = mock(BaseJudgmentsProcessor.class);
+        when(judgmentsProcessorFactory.getProcessor(any())).thenReturn(processor);
+        doAnswer(invocation -> {
+            ActionListener<List<Map<String, Object>>> listener = invocation.getArgument(1);
+            listener.onResponse(List.of());
+            return null;
+        }).when(processor).generateJudgmentRating(any(), any(ActionListener.class));
+
+        ActionListener<IndexResponse> responseListener = mock(ActionListener.class);
+        action.doExecute(null, ubiJudgmentRequest(null), responseListener);
+
+        verify(judgmentDao).putJudgement(any(), any(ActionListener.class));
+        verify(responseListener).onResponse(indexResponse);
+        verify(responseListener, org.mockito.Mockito.never()).onFailure(any());
+    }
+
+    public void testValidation_UbiJudgment_EventsIndexExistsButMissingRequiredField_Returns400() {
+        Map<String, Object> propertiesMissingObjectId = Map.of(
+            "query_id",
+            Map.of("type", "keyword"),
+            "action_name",
+            Map.of("type", "keyword")
+        );
+        stubIndexPresentWithMappingFields("my_custom_events", propertiesMissingObjectId);
+
+        String message = runUbiValidationExpectingFailure(ubiJudgmentRequest("my_custom_events")).getMessage();
+
+        assertTrue(message, message.contains("UBI events index [my_custom_events] set by the 'ubiEventsIndex' parameter"));
+        assertTrue(
+            message,
+            message.contains("missing required UBI event fields (query_id, action_name, event_attributes.object.object_id)")
+        );
     }
 }


### PR DESCRIPTION
### Description

Creating a `UBI_JUDGMENT` against a UBI events index that does not exist failed with a `500` ([dashboards-search-relevance#907](https://github.com/opensearch-project/dashboards-search-relevance/issues/907)) and an unhelpful message. This PR:

1. **Moves the validation into `doExecute()` so the `400` status survives.** Previously the check ran inside `buildMetadata()` → `createJudgment()`, whose `catch (Exception e)` re-wrapped it as `INTERNAL_SERVER_ERROR`.

2. **Returns two distinct error messages** depending on whether the caller provided the `ubiEventsIndex` parameter or relied on the default:

   | Scenario | Message |
   |---|---|
   | Parameter **not provided**, default `ubi_events` is unusable | `No 'ubiEventsIndex' parameter was provided and the default UBI events index [ubi_events] does not exist or is missing required UBI event fields (query_id, action_name, event_attributes.object.object_id). Ingest UBI events data into [ubi_events], or set the 'ubiEventsIndex' parameter to an existing UBI events index.` |
   | Parameter **provided** but the index is unusable | `The UBI events index [X] set by the 'ubiEventsIndex' parameter does not exist or is missing required UBI event fields (query_id, action_name, event_attributes.object.object_id). Ingest UBI events data into it, or set the 'ubiEventsIndex' parameter to an existing UBI events index.` |


### Issues Resolved

https://github.com/opensearch-project/dashboards-search-relevance/issues/907

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
