### PR TITLE
Fix transport-thread blocking and unhandled listener failure in async flows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### Bug Fixes
 - Return correct delete REST status codes and honor querySetSize for sampling ([#542](https://github.com/opensearch-project/search-relevance/pull/542))
+- Fix transport-thread blocking in experiment run and query set sampling, and notify listener on protected-index creation failure ([#PR](https://github.com/opensearch-project/search-relevance/pull/PR))
 
 ### Infrastructure
 

--- a/src/main/java/org/opensearch/searchrelevance/executors/ExperimentRunningManager.java
+++ b/src/main/java/org/opensearch/searchrelevance/executors/ExperimentRunningManager.java
@@ -19,7 +19,6 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -227,26 +226,29 @@ public class ExperimentRunningManager {
             configFutures.add(singleSearchConfigurationFuture);
         }
 
-        for (CompletableFuture<Entry<String, Object>> configFuture : configFutures) {
-            Entry<String, Object> configEntry;
+        CompletableFuture.allOf(configFutures.toArray(new CompletableFuture[0])).whenComplete((ignored, ex) -> {
             try {
-                // The config future will be waited on, but there is a chance the future might be null.
-                configEntry = configFuture.get();
-            } catch (InterruptedException e) {
-                handleFailure(e, hasFailure, context, actuallyFinished);
-                return;
-            } catch (ExecutionException e) {
+                for (CompletableFuture<Entry<String, Object>> configFuture : configFutures) {
+                    Entry<String, Object> configEntry = configFuture.join();
+                    searchConfigurations.put(configEntry.getKey(), (SearchConfigurationDetails) configEntry.getValue());
+                }
+            } catch (Exception e) {
                 handleFailure(e, hasFailure, context, actuallyFinished);
                 return;
             }
-            searchConfigurations.put(configEntry.getKey(), (SearchConfigurationDetails) configEntry.getValue());
-        }
 
-        if (queryEntries == null || searchConfigurations == null) {
-            throw new IllegalStateException("Missing required data for metrics calculation");
-        }
+            if (queryEntries == null || searchConfigurations == null) {
+                handleFailure(
+                    new IllegalStateException("Missing required data for metrics calculation"),
+                    hasFailure,
+                    context,
+                    actuallyFinished
+                );
+                return;
+            }
 
-        loadJudgmentsThenContinue(context, searchConfigurations, queryEntries, hasFailure, cancellationToken, actuallyFinished);
+            loadJudgmentsThenContinue(context, searchConfigurations, queryEntries, hasFailure, cancellationToken, actuallyFinished);
+        });
     }
 
     private void loadJudgmentsThenContinue(

--- a/src/main/java/org/opensearch/searchrelevance/indices/SearchRelevanceIndicesManager.java
+++ b/src/main/java/org/opensearch/searchrelevance/indices/SearchRelevanceIndicesManager.java
@@ -815,9 +815,7 @@ public class SearchRelevanceIndicesManager {
     ) {
         StepListener<Void> createIndexStep = new StepListener<>();
         createIndexIfAbsent(context.getIndex(), createIndexStep);
-        createIndexStep.whenComplete(v -> action.accept(context, listener), e -> {
-            throw e instanceof RuntimeException ? (RuntimeException) e : new IllegalStateException(e);
-        });
+        createIndexStep.whenComplete(v -> action.accept(context, listener), e -> listener.onFailure(e));
     }
 
     /**

--- a/src/main/java/org/opensearch/searchrelevance/transport/queryset/PostQuerySetTransportAction.java
+++ b/src/main/java/org/opensearch/searchrelevance/transport/queryset/PostQuerySetTransportAction.java
@@ -9,11 +9,8 @@ package org.opensearch.searchrelevance.transport.queryset;
 
 import static org.opensearch.searchrelevance.ubi.UbiValidator.checkUbiQueriesIndexExists;
 
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.UUID;
-import java.util.concurrent.ExecutionException;
 import java.util.stream.Collectors;
 
 import org.opensearch.action.index.IndexResponse;
@@ -77,28 +74,28 @@ public class PostQuerySetTransportAction extends HandledTransportAction<PostQuer
         // Given sampling type and querySetSize, build the queryset accordingly
         String sampling = request.getSampling();
         int querySetSize = request.getQuerySetSize();
-        QuerySampler querySampler = QuerySampler.create(sampling, querySetSize, client, ubiQueriesIndex);
-        Map<String, Integer> querySetQueries = new HashMap<>();
-        try {
-            querySetQueries = querySampler.sample().get();
-        } catch (InterruptedException | ExecutionException e) {
-            listener.onFailure(
-                new SearchRelevanceException("Failed to build querySetQueries. Request: " + request, RestStatus.BAD_REQUEST)
-            );
-        }
-
         if (name == null || name.trim().isEmpty()) {
             listener.onFailure(new SearchRelevanceException("Name cannot be null or empty. Request: " + request, RestStatus.BAD_REQUEST));
             return;
         }
 
-        // Convert Map<String, Integer> to List<QuerySetEntry> (discarding count values)
-        List<QuerySetEntry> querySetEntries = querySetQueries.entrySet()
-            .stream()
-            .map(entry -> QuerySetEntry.Builder.builder().queryText(entry.getKey()).build())
-            .collect(Collectors.toList());
+        QuerySampler querySampler = QuerySampler.create(sampling, querySetSize, client, ubiQueriesIndex);
+        querySampler.sample().whenComplete((querySetQueries, ex) -> {
+            if (ex != null) {
+                listener.onFailure(
+                    new SearchRelevanceException("Failed to build querySetQueries. Request: " + request, RestStatus.BAD_REQUEST)
+                );
+                return;
+            }
 
-        QuerySet querySet = new QuerySet(id, name, description, timestamp, sampling, querySetEntries);
-        querySetDao.putQuerySet(querySet, listener);
+            // Convert Map<String, Integer> to List<QuerySetEntry> (discarding count values)
+            List<QuerySetEntry> querySetEntries = querySetQueries.entrySet()
+                .stream()
+                .map(entry -> QuerySetEntry.Builder.builder().queryText(entry.getKey()).build())
+                .collect(Collectors.toList());
+
+            QuerySet querySet = new QuerySet(id, name, description, timestamp, sampling, querySetEntries);
+            querySetDao.putQuerySet(querySet, listener);
+        });
     }
 }

--- a/src/test/java/org/opensearch/searchrelevance/executors/ExperimentRunningManagerTests.java
+++ b/src/test/java/org/opensearch/searchrelevance/executors/ExperimentRunningManagerTests.java
@@ -217,6 +217,41 @@ public class ExperimentRunningManagerTests extends OpenSearchTestCase {
 
     }
 
+    public void testFetchSearchConfigurationsAsyncDoesNotBlockCallingThread() throws Exception {
+        PutExperimentRequest request = createExperimentRequest();
+        CountDownLatch actuallyFinished = new CountDownLatch(1);
+
+        doAnswer(invocation -> null).when(searchConfigurationDao).getSearchConfiguration(any(String.class), any(ActionListener.class));
+
+        ExperimentRunningManager.ExperimentContext context = new ExperimentRunningManager.ExperimentContext(
+            "experimentId",
+            request,
+            request.getName(),
+            request.getDescription(),
+            sampleQuerySet()
+        );
+
+        CountDownLatch returned = new CountDownLatch(1);
+        Thread caller = new Thread(() -> {
+            experimentRunningManager.fetchSearchConfigurationsAsync(
+                context,
+                List.of(new QuerySetEntry("querySetReference", Map.of())),
+                new ExperimentCancellationToken("scheduled-experiment-result-id"),
+                actuallyFinished
+            );
+            returned.countDown();
+        }, "srw-fetch-config-caller");
+        caller.start();
+
+        boolean returnedPromptly = returned.await(5, java.util.concurrent.TimeUnit.SECONDS);
+        if (!returnedPromptly) {
+            caller.interrupt();
+        }
+        assertTrue("fetchSearchConfigurationsAsync must not block the calling thread on a pending config future", returnedPromptly);
+
+        assertEquals(1, actuallyFinished.getCount());
+    }
+
     public void testStartExperimentRunReject() {
         // Make sure that only at most one experiment run for a given scheduled experiment run id
         // can be scheduled at a given time

--- a/src/test/java/org/opensearch/searchrelevance/indices/SearchRelevanceIndicesManagerTests.java
+++ b/src/test/java/org/opensearch/searchrelevance/indices/SearchRelevanceIndicesManagerTests.java
@@ -159,6 +159,26 @@ public class SearchRelevanceIndicesManagerTests extends OpenSearchTestCase {
         listenerCaptor.getValue().onFailure(exception);
     }
 
+    public void testPutDocOnProtectedIndexNotifiesListenerWhenIndexCreationFails() throws IOException {
+        QuerySet querySet = new QuerySet("test_id", "test_name", "test_description", "test_timestamp", "test_sampling", List.of());
+        XContentBuilder xContentBuilder = querySet.toXContent(XContentFactory.jsonBuilder(), ToXContent.EMPTY_PARAMS);
+
+        when(metadata.hasIndex(SearchRelevanceIndices.EXPERIMENT.getIndexName())).thenReturn(false);
+
+        @SuppressWarnings("unchecked")
+        ActionListener<DocWriteResponse> listener = mock(ActionListener.class);
+        indicesManager.putDoc("test_id", xContentBuilder, SearchRelevanceIndices.EXPERIMENT, listener);
+
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<ActionListener<CreateIndexResponse>> createListenerCaptor = ArgumentCaptor.forClass(ActionListener.class);
+        verify(indicesAdminClient).create(any(CreateIndexRequest.class), createListenerCaptor.capture());
+
+        RuntimeException creationFailure = new RuntimeException("Creation failed");
+        createListenerCaptor.getValue().onFailure(creationFailure);
+
+        verify(listener).onFailure(any(Exception.class));
+    }
+
     public void testPutDocWhenSucceeded() throws IOException {
         QuerySet querySet = new QuerySet("test_id", "test_name", "test_description", "test_timestamp", "test_sampling", List.of());
         XContentBuilder xContentBuilder = querySet.toXContent(XContentFactory.jsonBuilder(), ToXContent.EMPTY_PARAMS);


### PR DESCRIPTION
 ### Description

This PR fixes three async-correctness issues in the search-relevance plugin that could hang a node or silently drop a request.

**1. Transport-thread deadlock when running an experiment (`ExperimentRunningManager`)**

`fetchSearchConfigurationsAsync` aggregated the per-config futures with a blocking `configFuture.get()` loop. That method runs on a Netty `transport_worker` thread (the DAO listener callbacks are invoked on transport threads), so a config future that never completed parked the transport worker indefinitely. Because the responses needed to complete those futures are themselves delivered on the same event loop, the thread could self-deadlock — starving inter-node transport and fault detection while HTTP kept answering, leaving the node network-live but work-dead and never evicted.

Fixed by replacing the blocking loop with a non-blocking `CompletableFuture.allOf(...).whenComplete(...)` continuation, matching the existing pattern used elsewhere in the plugin (`BatchedAsyncExecutor`, `PointwiseExperimentProcessor`, `HybridOptimizerExperimentProcessor`). The futures are collected with `join()` inside the callback, where they are already complete. Failure and cancellation semantics are preserved via `handleFailure` and the existing `hasFailure` gate.

**2. Transport-thread blocking while sampling query sets (`PostQuerySetTransportAction`)**

`doExecute` called `querySampler.sample().get()`, blocking the transport thread until sampling finished, and on exception it did not stop before continuing with empty data. Reworked to chain off `sample().whenComplete(...)` so the transport thread is never blocked, and the name validation now fails fast before sampling starts.

**3. Unhandled listener failure on protected-index creation (`SearchRelevanceIndicesManager`)**

`executeWithIndexCreationAsynchronizedMode` threw from the `whenComplete` failure handler instead of notifying the listener. Since the throw happens on an async callback thread, the caller's `ActionListener` was never invoked and any future waiting on it would hang. Changed to call `listener.onFailure(e)` so the failure is propagated.



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
