### PR TITLE
 stop re-fetching judgments on every query for Hybrid and Pointwise experiments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 ### Features
 
 ### Enhancements
+- Stop re-fetching judgments on every query for Hybrid and Pointwise experiments ([#560](https://github.com/opensearch-project/search-relevance/pull/560))
 - Add retry endpoint for failed LLM judgments, existingJudgments parameter for rating reuse, and remove broken global cache ([#525](https://github.com/opensearch-project/search-relevance/issues/525))
 
 ### Bug Fixes

--- a/src/main/java/org/opensearch/searchrelevance/executors/ExperimentRunningManager.java
+++ b/src/main/java/org/opensearch/searchrelevance/executors/ExperimentRunningManager.java
@@ -35,6 +35,7 @@ import org.opensearch.searchrelevance.dao.ScheduledExperimentHistoryDao;
 import org.opensearch.searchrelevance.dao.SearchConfigurationDao;
 import org.opensearch.searchrelevance.exception.SearchRelevanceException;
 import org.opensearch.searchrelevance.experiment.HybridOptimizerExperimentProcessor;
+import org.opensearch.searchrelevance.experiment.JudgmentRatingsMapper;
 import org.opensearch.searchrelevance.experiment.PointwiseExperimentProcessor;
 import org.opensearch.searchrelevance.experiment.signature.ExperimentInputSignatureComputer;
 import org.opensearch.searchrelevance.metrics.MetricsHelper;
@@ -350,6 +351,7 @@ public class ExperimentRunningManager {
 
         List<Map<String, Object>> finalResults = Collections.synchronizedList(new ArrayList<>());
         AtomicInteger pendingQueries = new AtomicInteger(queryEntries.size());
+        Map<String, Map<String, String>> queryTextToDocIdToRatings = JudgmentRatingsMapper.buildQueryTextToDocIdRatingsMap(judgments);
         executeExperimentEvaluation(
             context,
             searchConfigurations,
@@ -358,6 +360,7 @@ public class ExperimentRunningManager {
             pendingQueries,
             hasFailure,
             context.getRequest().getJudgmentList(),
+            queryTextToDocIdToRatings,
             cancellationToken,
             actuallyFinished
         );
@@ -468,6 +471,7 @@ public class ExperimentRunningManager {
         AtomicInteger pendingQueries,
         AtomicBoolean hasFailure,
         List<String> judgmentList,
+        Map<String, Map<String, String>> queryTextToDocIdToRatings,
         ExperimentCancellationToken cancellationToken,
         CountDownLatch actuallyFinished
     ) {
@@ -519,6 +523,7 @@ public class ExperimentRunningManager {
                     queryEntry,
                     searchConfigurations,
                     judgmentList,
+                    queryTextToDocIdToRatings,
                     request.getSize(),
                     request.getScheduledExperimentResultId(),
                     cancellationToken,
@@ -544,6 +549,7 @@ public class ExperimentRunningManager {
                     queryEntry,
                     searchConfigurations,
                     judgmentList,
+                    queryTextToDocIdToRatings,
                     request.getSize(),
                     hasFailure,
                     request.getScheduledExperimentResultId(),

--- a/src/main/java/org/opensearch/searchrelevance/experiment/HybridOptimizerExperimentProcessor.java
+++ b/src/main/java/org/opensearch/searchrelevance/experiment/HybridOptimizerExperimentProcessor.java
@@ -21,9 +21,7 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-import org.opensearch.action.search.SearchResponse;
 import org.opensearch.core.action.ActionListener;
-import org.opensearch.searchrelevance.dao.JudgmentDao;
 import org.opensearch.searchrelevance.executors.ExperimentTaskManager;
 import org.opensearch.searchrelevance.model.AsyncStatus;
 import org.opensearch.searchrelevance.model.ExperimentType;
@@ -45,7 +43,6 @@ import lombok.extern.log4j.Log4j2;
 @AllArgsConstructor
 public class HybridOptimizerExperimentProcessor {
 
-    private final JudgmentDao judgmentDao;
     private final ExperimentTaskManager taskManager;
 
     /**
@@ -55,6 +52,7 @@ public class HybridOptimizerExperimentProcessor {
      * @param queryEntry QuerySetEntry containing query text and custom fields
      * @param searchConfigurations Map of search configuration IDs to SearchConfigurationDetails
      * @param judgmentList List of judgment IDs
+     * @param queryTextToDocIdToRatings Pre-built map of query text to doc id to rating
      * @param size Result size
      * @param scheduledRunId id for the experiment to be scheduled
      * @param cancellationToken token to indicate whether the task has been cancelled
@@ -66,6 +64,7 @@ public class HybridOptimizerExperimentProcessor {
         QuerySetEntry queryEntry,
         Map<String, SearchConfigurationDetails> searchConfigurations,
         List<String> judgmentList,
+        Map<String, Map<String, String>> queryTextToDocIdToRatings,
         int size,
         String scheduledRunId,
         ExperimentCancellationToken cancellationToken,
@@ -109,86 +108,27 @@ public class HybridOptimizerExperimentProcessor {
             experimentVariants.size()
         );
 
-        // Process judgments asynchronously
-        processJudgmentsAsync(queryText, judgmentList).thenAccept(docIdToScores -> {
-            log.info("Processing search configurations for query '{}' with {} document ratings", queryText, docIdToScores.size());
-
-            // Process search configurations with optimized task manager
-            processSearchConfigurationsAsync(
-                experimentId,
-                queryEntry,
-                searchConfigurations,
-                judgmentList,
-                size,
-                experimentVariants,
-                docIdToScores,
-                hasFailure,
-                scheduledRunId,
-                cancellationToken,
-                runningFutures,
-                listener
-            );
-        }).exceptionally(e -> {
-            if (hasFailure.compareAndSet(false, true)) {
-                listener.onFailure(new Exception("Failed to process judgments", e));
-            }
-            return null;
-        });
-    }
-
-    /**
-     * Process judgments asynchronously using CompletableFuture
-     */
-    private CompletableFuture<Map<String, String>> processJudgmentsAsync(String queryText, List<String> judgmentList) {
-        log.info("Processing {} judgments for query: {}", judgmentList.size(), queryText);
-
-        List<CompletableFuture<SearchResponse>> judgmentFutures = judgmentList.stream().map(judgmentId -> {
-            CompletableFuture<SearchResponse> future = new CompletableFuture<>();
-            judgmentDao.getJudgment(judgmentId, ActionListener.wrap(future::complete, future::completeExceptionally));
-            return future;
-        }).toList();
-
-        return CompletableFuture.allOf(judgmentFutures.toArray(new CompletableFuture[0])).thenApply(v -> {
-            Map<String, String> docIdToScores = new HashMap<>();
-            for (CompletableFuture<SearchResponse> future : judgmentFutures) {
-                SearchResponse response = future.join();
-                extractJudgmentScores(queryText, response, docIdToScores);
-            }
-
-            if (docIdToScores.isEmpty()) {
-                log.warn("No ratings found for query: {} in any judgment responses", queryText);
-            } else {
-                log.info("Found {} document ratings for query: {}", docIdToScores.size(), queryText);
-            }
-
-            return docIdToScores;
-        });
-    }
-
-    /**
-     * Extract judgment scores from SearchResponse
-     */
-    private void extractJudgmentScores(String queryText, SearchResponse response, Map<String, String> docIdToScores) {
-        if (response.getHits().getTotalHits().value() == 0) {
-            log.warn("No judgment found in response");
-            return;
+        Map<String, String> docIdToScores = queryTextToDocIdToRatings != null ? queryTextToDocIdToRatings.get(queryText) : null;
+        if (docIdToScores == null) {
+            docIdToScores = Collections.emptyMap();
         }
+        log.info("Processing search configurations for query '{}' with {} document ratings", queryText, docIdToScores.size());
 
-        Map<String, Object> sourceAsMap = response.getHits().getHits()[0].getSourceAsMap();
-        List<Map<String, Object>> judgmentRatings = (List<Map<String, Object>>) sourceAsMap.getOrDefault(
-            "judgmentRatings",
-            Collections.emptyList()
+        // Process search configurations with optimized task manager
+        processSearchConfigurationsAsync(
+            experimentId,
+            queryEntry,
+            searchConfigurations,
+            judgmentList,
+            size,
+            experimentVariants,
+            docIdToScores,
+            hasFailure,
+            scheduledRunId,
+            cancellationToken,
+            runningFutures,
+            listener
         );
-
-        for (Map<String, Object> rating : judgmentRatings) {
-            if (queryText.equals(rating.get("query"))) {
-                List<Map<String, String>> docScoreRatings = (List<Map<String, String>>) rating.get("ratings");
-                if (docScoreRatings != null) {
-                    docScoreRatings.forEach(docScoreRating -> docIdToScores.put(docScoreRating.get("docId"), docScoreRating.get("rating")));
-                }
-                break;
-            }
-        }
     }
 
     private boolean checkIfCancelled(ExperimentCancellationToken cancellationToken) {

--- a/src/main/java/org/opensearch/searchrelevance/experiment/JudgmentRatingsMapper.java
+++ b/src/main/java/org/opensearch/searchrelevance/experiment/JudgmentRatingsMapper.java
@@ -1,0 +1,66 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+package org.opensearch.searchrelevance.experiment;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.opensearch.searchrelevance.model.Judgment;
+
+/**
+ * Builds a once-loaded, query-keyed view of judgment ratings.
+ *
+ * <p>This avoids re-fetching the same large judgment document for every query
+ * in the hot path of HYBRID_OPTIMIZER and POINTWISE_EVALUATION experiments.
+ */
+public final class JudgmentRatingsMapper {
+
+    private JudgmentRatingsMapper() {}
+
+    /**
+     * Build a map of query text -&gt; doc id -&gt; rating from the already loaded judgments.
+     *
+     * @param judgments the full judgments loaded once before per-query processing
+     * @return a query-keyed map of document ratings; empty if judgments is null/empty
+     */
+    @SuppressWarnings("unchecked")
+    public static Map<String, Map<String, String>> buildQueryTextToDocIdRatingsMap(List<Judgment> judgments) {
+        if (judgments == null || judgments.isEmpty()) {
+            return Collections.emptyMap();
+        }
+
+        Map<String, Map<String, String>> queryTextToDocIdToRating = new HashMap<>();
+        for (Judgment judgment : judgments) {
+            List<Map<String, Object>> judgmentRatings = judgment.getJudgmentRatings();
+            if (judgmentRatings == null) {
+                continue;
+            }
+            for (Map<String, Object> judgmentRating : judgmentRatings) {
+                String queryText = (String) judgmentRating.get("query");
+                if (queryText == null) {
+                    continue;
+                }
+                List<Map<String, Object>> docScoreRatings = (List<Map<String, Object>>) judgmentRating.get("ratings");
+                if (docScoreRatings == null) {
+                    continue;
+                }
+                Map<String, String> docIdToRating = queryTextToDocIdToRating.computeIfAbsent(queryText, k -> new HashMap<>());
+                for (Map<String, Object> docScoreRating : docScoreRatings) {
+                    String docId = (String) docScoreRating.get("docId");
+                    String rating = (String) docScoreRating.get("rating");
+                    if (docId != null && rating != null) {
+                        docIdToRating.put(docId, rating);
+                    }
+                }
+            }
+        }
+        return queryTextToDocIdToRating;
+    }
+}

--- a/src/main/java/org/opensearch/searchrelevance/experiment/PointwiseExperimentProcessor.java
+++ b/src/main/java/org/opensearch/searchrelevance/experiment/PointwiseExperimentProcessor.java
@@ -11,7 +11,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Queue;
@@ -20,15 +19,9 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
-import org.opensearch.action.search.SearchResponse;
-import org.opensearch.common.cache.Cache;
-import org.opensearch.common.cache.CacheBuilder;
-import org.opensearch.common.unit.TimeValue;
 import org.opensearch.core.action.ActionListener;
-import org.opensearch.searchrelevance.dao.JudgmentDao;
 import org.opensearch.searchrelevance.executors.ExperimentTaskManager;
 import org.opensearch.searchrelevance.model.AsyncStatus;
 import org.opensearch.searchrelevance.model.ExperimentType;
@@ -46,25 +39,10 @@ import lombok.extern.log4j.Log4j2;
 @Log4j2
 public class PointwiseExperimentProcessor {
 
-    private final JudgmentDao judgmentDao;
     private final ExperimentTaskManager taskManager;
 
-    // Use OpenSearch's built-in cache implementation with bounded size
-    private final Cache<String, Map<String, String>> judgmentCache;
-
-    // Configuration constants
-    private static final long CACHE_SIZE = 100_000;
-    private static final TimeValue CACHE_EXPIRE_TIME = TimeValue.timeValueHours(1);
-
-    public PointwiseExperimentProcessor(JudgmentDao judgmentDao, ExperimentTaskManager taskManager) {
-        this.judgmentDao = judgmentDao;
+    public PointwiseExperimentProcessor(ExperimentTaskManager taskManager) {
         this.taskManager = taskManager;
-
-        // Initialize cache with size limit and TTL
-        this.judgmentCache = CacheBuilder.<String, Map<String, String>>builder()
-            .setMaximumWeight(CACHE_SIZE)
-            .setExpireAfterAccess(CACHE_EXPIRE_TIME)
-            .build();
     }
 
     /**
@@ -75,6 +53,7 @@ public class PointwiseExperimentProcessor {
         QuerySetEntry queryEntry,
         Map<String, SearchConfigurationDetails> searchConfigurations,
         List<String> judgmentList,
+        Map<String, Map<String, String>> queryTextToDocIdToRatings,
         int size,
         AtomicBoolean hasFailure,
         String scheduledRunId,
@@ -89,100 +68,23 @@ public class PointwiseExperimentProcessor {
             queryText
         );
 
-        // Load judgments once and cache them
-        loadJudgmentsAsync(experimentId, judgmentList, queryText).thenAccept(docIdToScores -> {
-            log.info("Loaded {} document ratings for experiment {}", docIdToScores.size(), experimentId);
-            processExperimentWithJudgments(
-                experimentId,
-                queryEntry,
-                searchConfigurations,
-                judgmentList,
-                size,
-                docIdToScores,
-                hasFailure,
-                scheduledRunId,
-                cancellationToken,
-                listener
-            );
-        }).exceptionally(e -> {
-            if (hasFailure.compareAndSet(false, true)) {
-                listener.onFailure(new Exception("Failed to load judgments", e));
-            }
-            return null;
-        });
-    }
-
-    /**
-     * Load and cache judgments for the experiment
-     */
-    private CompletableFuture<Map<String, String>> loadJudgmentsAsync(String experimentId, List<String> judgmentList, String queryText) {
-        String cacheKey = experimentId + ":" + queryText;
-        Map<String, String> cached = judgmentCache.get(cacheKey);
-        if (Objects.nonNull(cached)) {
-            return CompletableFuture.completedFuture(cached);
+        Map<String, String> docIdToScores = queryTextToDocIdToRatings != null ? queryTextToDocIdToRatings.get(queryText) : null;
+        if (docIdToScores == null) {
+            docIdToScores = Collections.emptyMap();
         }
-
-        AtomicInteger failureCount = new AtomicInteger(0);
-        int failureThreshold = Math.min(5, judgmentList.size());
-
-        // Load judgments in parallel
-        List<CompletableFuture<SearchResponse>> judgmentFutures = judgmentList.stream().map(judgmentId -> {
-            CompletableFuture<SearchResponse> future = new CompletableFuture<>();
-            judgmentDao.getJudgment(judgmentId, ActionListener.wrap(future::complete, future::completeExceptionally));
-            return future;
-        }).toList();
-
-        return CompletableFuture.allOf(judgmentFutures.toArray(new CompletableFuture[0])).thenApply(v -> {
-            Map<String, String> docIdToScores = new HashMap<>();
-
-            for (CompletableFuture<SearchResponse> future : judgmentFutures) {
-                try {
-                    SearchResponse response = future.join();
-                    extractJudgmentScores(queryText, response, docIdToScores);
-                } catch (Exception e) {
-                    log.error("Failed to process judgment response: {}", e.getMessage());
-                    if (failureCount.incrementAndGet() >= failureThreshold) {
-                        throw new RuntimeException(
-                            String.format(
-                                Locale.ROOT,
-                                "Failed to load judgments: exceeded failure threshold %d/%d",
-                                failureCount.get(),
-                                failureThreshold
-                            ),
-                            e
-                        );
-                    }
-                }
-            }
-
-            judgmentCache.put(cacheKey, docIdToScores);
-            return docIdToScores;
-        });
-    }
-
-    /**
-     * Extract judgment scores from SearchResponse
-     */
-    private void extractJudgmentScores(String queryText, SearchResponse response, Map<String, String> docIdToScores) {
-        if (Objects.isNull(response.getHits()) || response.getHits().getTotalHits().value() == 0) {
-            return;
-        }
-
-        Map<String, Object> sourceAsMap = response.getHits().getHits()[0].getSourceAsMap();
-        List<Map<String, Object>> judgmentRatings = (List<Map<String, Object>>) sourceAsMap.getOrDefault(
-            "judgmentRatings",
-            Collections.emptyList()
+        log.info("Loaded {} document ratings for experiment {}", docIdToScores.size(), experimentId);
+        processExperimentWithJudgments(
+            experimentId,
+            queryEntry,
+            searchConfigurations,
+            judgmentList,
+            size,
+            docIdToScores,
+            hasFailure,
+            scheduledRunId,
+            cancellationToken,
+            listener
         );
-
-        for (Map<String, Object> rating : judgmentRatings) {
-            if (queryText.equals(rating.get("query"))) {
-                List<Map<String, String>> docScoreRatings = (List<Map<String, String>>) rating.get("ratings");
-                if (Objects.nonNull(docScoreRatings)) {
-                    docScoreRatings.forEach(docScoreRating -> docIdToScores.put(docScoreRating.get("docId"), docScoreRating.get("rating")));
-                }
-                break;
-            }
-        }
     }
 
     /**

--- a/src/main/java/org/opensearch/searchrelevance/metrics/MetricsHelper.java
+++ b/src/main/java/org/opensearch/searchrelevance/metrics/MetricsHelper.java
@@ -44,7 +44,6 @@ import org.opensearch.core.action.ActionListener;
 import org.opensearch.search.SearchHit;
 import org.opensearch.searchrelevance.dao.EvaluationResultDao;
 import org.opensearch.searchrelevance.dao.ExperimentVariantDao;
-import org.opensearch.searchrelevance.dao.JudgmentDao;
 import org.opensearch.searchrelevance.model.AsyncStatus;
 import org.opensearch.searchrelevance.model.EvaluationResult;
 import org.opensearch.searchrelevance.model.ExperimentVariant;
@@ -63,7 +62,6 @@ import reactor.util.annotation.NonNull;
  */
 public class MetricsHelper {
     private final Client client;
-    private final JudgmentDao judgmentDao;
     private final EvaluationResultDao evaluationResultDao;
     private final ExperimentVariantDao experimentVariantDao;
 
@@ -71,12 +69,10 @@ public class MetricsHelper {
     public MetricsHelper(
         @NonNull ClusterService clusterService,
         @NonNull Client client,
-        @NonNull JudgmentDao judgmentDao,
         @NonNull EvaluationResultDao evaluationResultDao,
         @NonNull ExperimentVariantDao experimentVariantDao
     ) {
         this.client = client;
-        this.judgmentDao = judgmentDao;
         this.evaluationResultDao = evaluationResultDao;
         this.experimentVariantDao = experimentVariantDao;
     }
@@ -184,6 +180,7 @@ public class MetricsHelper {
         Map<String, List<String>> indexAndQueries,
         int size,
         List<String> judgmentIds,
+        Map<String, Map<String, String>> queryTextToDocIdToRatings,
         ActionListener<Map<String, Object>> listener,
         List<ExperimentVariant> experimentVariants
     ) {
@@ -194,79 +191,25 @@ public class MetricsHelper {
 
         try {
             Map<String, Object> configToEvalIds = Collections.synchronizedMap(new HashMap<>());
-            Map<String, String> docIdToRatings = new HashMap<>();
-            AtomicInteger completedJudgments = new AtomicInteger(0);
-
-            for (String judgmentId : judgmentIds) {
-                judgmentDao.getJudgment(judgmentId, new ActionListener<>() {
-                    @Override
-                    public void onResponse(SearchResponse judgmentResponse) {
-                        try {
-                            if (judgmentResponse.getHits().getTotalHits().value() == 0) {
-                                log.warn("No judgment found for ID: {}", judgmentId);
-                            } else {
-                                Map<String, Object> sourceAsMap = judgmentResponse.getHits().getHits()[0].getSourceAsMap();
-                                List<Map<String, Object>> judgmentRatings = (List<Map<String, Object>>) sourceAsMap.getOrDefault(
-                                    "judgmentRatings",
-                                    Collections.emptyList()
-                                );
-                                // TODO change this to more efficient approach, this is O(n) because we need to scan all list to find query
-                                for (Map<String, Object> rating : judgmentRatings) {
-                                    if (queryText.equals(rating.get("query"))) {
-                                        List<Map<String, String>> docScoreRatings = (List<Map<String, String>>) rating.get("ratings");
-                                        docScoreRatings.forEach(
-                                            docScoreRating -> docIdToRatings.put(docScoreRating.get("docId"), docScoreRating.get("rating"))
-                                        );
-                                        break;
-                                    }
-                                }
-                            }
-
-                            // Check if all judgments have been processed
-                            if (completedJudgments.incrementAndGet() == judgmentIds.size()) {
-                                if (docIdToRatings.isEmpty()) {
-                                    log.warn("No ratings found for query: {} in any judgments", queryText);
-                                }
-
-                                processSearchConfigurations(
-                                    queryText,
-                                    indexAndQueries,
-                                    size,
-                                    judgmentIds,
-                                    docIdToRatings,
-                                    configToEvalIds,
-                                    listener,
-                                    experimentVariants
-                                );
-                            }
-                        } catch (Exception e) {
-                            listener.onFailure(e);
-                        }
-                    }
-
-                    @Override
-                    public void onFailure(Exception e) {
-                        log.error("Failed to fetch judgment {}: {}", judgmentId, e);
-                        if (completedJudgments.incrementAndGet() == judgmentIds.size()) {
-                            if (docIdToRatings.isEmpty()) {
-                                listener.onFailure(new IllegalStateException("Failed to fetch any valid judgments"));
-                            } else {
-                                // Proceed with the judgments we were able to fetch
-                                processSearchConfigurations(
-                                    queryText,
-                                    indexAndQueries,
-                                    size,
-                                    judgmentIds,
-                                    docIdToRatings,
-                                    configToEvalIds,
-                                    listener,
-                                    experimentVariants
-                                );
-                            }
-                        }
-                    }
-                });
+            Map<String, String> docIdToRatings = queryTextToDocIdToRatings != null ? queryTextToDocIdToRatings.get(queryText) : null;
+            if (docIdToRatings == null) {
+                docIdToRatings = new HashMap<>();
             }
+
+            if (docIdToRatings.isEmpty()) {
+                log.warn("No ratings found for query: {} in any judgments", queryText);
+            }
+
+            processSearchConfigurations(
+                queryText,
+                indexAndQueries,
+                size,
+                judgmentIds,
+                docIdToRatings,
+                configToEvalIds,
+                listener,
+                experimentVariants
+            );
         } catch (Exception e) {
             log.error("Unexpected error in evaluateQueryTextAsync: {}", e.getMessage());
             listener.onFailure(e);

--- a/src/main/java/org/opensearch/searchrelevance/plugin/SearchRelevancePlugin.java
+++ b/src/main/java/org/opensearch/searchrelevance/plugin/SearchRelevancePlugin.java
@@ -236,7 +236,7 @@ public class SearchRelevancePlugin extends Plugin
             experimentVariantDao,
             threadPool
         );
-        this.metricsHelper = new MetricsHelper(clusterService, client, judgmentDao, evaluationResultDao, experimentVariantDao);
+        this.metricsHelper = new MetricsHelper(clusterService, client, evaluationResultDao, experimentVariantDao);
         this.settingsAccessor = new SearchRelevanceSettingsAccessor(clusterService, environment.settings());
         ClusterUtil.instance().initialize(clusterService);
         this.clusterUtil = ClusterUtil.instance();
@@ -251,8 +251,8 @@ public class SearchRelevancePlugin extends Plugin
             judgmentDao,
             scheduledExperimentHistoryDao,
             metricsHelper,
-            new HybridOptimizerExperimentProcessor(judgmentDao, experimentTaskManager),
-            new PointwiseExperimentProcessor(judgmentDao, experimentTaskManager),
+            new HybridOptimizerExperimentProcessor(experimentTaskManager),
+            new PointwiseExperimentProcessor(experimentTaskManager),
             threadPool,
             settingsAccessor
         );

--- a/src/main/java/org/opensearch/searchrelevance/transport/experiment/PutExperimentTransportAction.java
+++ b/src/main/java/org/opensearch/searchrelevance/transport/experiment/PutExperimentTransportAction.java
@@ -78,8 +78,8 @@ public class PutExperimentTransportAction extends HandledTransportAction<PutExpe
         this.searchConfigurationDao = searchConfigurationDao;
         this.judgmentDao = judgmentDao;
         this.metricsHelper = metricsHelper;
-        this.hybridOptimizerExperimentProcessor = new HybridOptimizerExperimentProcessor(judgmentDao, experimentTaskManager);
-        this.pointwiseExperimentProcessor = new PointwiseExperimentProcessor(judgmentDao, experimentTaskManager);
+        this.hybridOptimizerExperimentProcessor = new HybridOptimizerExperimentProcessor(experimentTaskManager);
+        this.pointwiseExperimentProcessor = new PointwiseExperimentProcessor(experimentTaskManager);
         this.experimentRunningManager = experimentRunningManager;
     }
 

--- a/src/test/java/org/opensearch/searchrelevance/executors/ExperimentRunningManagerTests.java
+++ b/src/test/java/org/opensearch/searchrelevance/executors/ExperimentRunningManagerTests.java
@@ -189,6 +189,7 @@ public class ExperimentRunningManagerTests extends OpenSearchTestCase {
             null,
             new AtomicBoolean(false),
             null,
+            Map.of(),
             cancellationToken,
             actuallyFinished
         );

--- a/src/test/java/org/opensearch/searchrelevance/experiment/HybridOptimizerExperimentProcessorTests.java
+++ b/src/test/java/org/opensearch/searchrelevance/experiment/HybridOptimizerExperimentProcessorTests.java
@@ -9,26 +9,25 @@ package org.opensearch.searchrelevance.experiment;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.when;
 
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicInteger;
 
 import org.junit.Before;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
-import org.opensearch.ResourceNotFoundException;
-import org.opensearch.action.search.SearchResponse;
 import org.opensearch.core.action.ActionListener;
-import org.opensearch.searchrelevance.dao.JudgmentDao;
 import org.opensearch.searchrelevance.executors.ExperimentTaskManager;
+import org.opensearch.searchrelevance.model.ExperimentType;
 import org.opensearch.searchrelevance.model.QuerySetEntry;
 import org.opensearch.searchrelevance.model.SearchConfigurationDetails;
 import org.opensearch.searchrelevance.scheduler.ExperimentCancellationToken;
@@ -37,8 +36,6 @@ import org.opensearch.test.OpenSearchTestCase;
 import lombok.SneakyThrows;
 
 public class HybridOptimizerExperimentProcessorTests extends OpenSearchTestCase {
-    @Mock
-    private JudgmentDao judgmentDao;
 
     @Mock
     private ExperimentTaskManager taskManager;
@@ -50,36 +47,48 @@ public class HybridOptimizerExperimentProcessorTests extends OpenSearchTestCase 
     public void setUp() {
         super.setUp();
         MockitoAnnotations.openMocks(this);
-        processor = new HybridOptimizerExperimentProcessor(judgmentDao, taskManager);
+        processor = new HybridOptimizerExperimentProcessor(taskManager);
     }
 
     /**
-     * Run experiment after deleting a judgment
+     * When ratings are missing for the query, the processor continues with an empty map.
      */
-    public void testRunExperimentAfterDeletedJudgment_TransitionsToError() throws InterruptedException {
-        // Setup test data
+    public void testRunExperimentWithNoRatingsForQuery_ContinuesWithEmptyRatings() throws InterruptedException {
         String experimentId = "exp1";
         String queryText = "hello world";
         List<String> judgmentList = List.of("judgment1");
+        Map<String, Map<String, String>> queryTextToDocIdToRatings = Map.of();
         Map<String, SearchConfigurationDetails> searchConfigs = Map.of(
             "config1",
             SearchConfigurationDetails.builder().index("idx").query("q").pipeline("p").build()
         );
 
-        // Mock deleted judgment
-        doAnswer(invocation -> {
-            ActionListener<SearchResponse> listener = invocation.getArgument(1);
-            listener.onFailure(new ResourceNotFoundException("Document not found"));
-            return null;
-        }).when(judgmentDao).getJudgment(any(), any());
+        when(
+            taskManager.scheduleTasksAsync(
+                any(ExperimentType.class),
+                any(),
+                any(),
+                any(),
+                any(),
+                any(QuerySetEntry.class),
+                any(Integer.class),
+                any(List.class),
+                any(List.class),
+                any(Map.class),
+                any(Map.class),
+                any(AtomicBoolean.class),
+                any(),
+                any(),
+                any(ExperimentCancellationToken.class)
+            )
+        ).thenReturn(CompletableFuture.completedFuture(Map.of("evaluationResults", List.of())));
 
-        AtomicBoolean failureTriggered = new AtomicBoolean(false);
         CountDownLatch latch = new CountDownLatch(1);
-
+        AtomicBoolean failureTriggered = new AtomicBoolean(false);
         ActionListener<Map<String, Object>> listener = new ActionListener<>() {
             @Override
             public void onResponse(Map<String, Object> response) {
-                fail("Experiment should not succeed when judgment is deleted");
+                latch.countDown();
             }
 
             @Override
@@ -94,6 +103,7 @@ public class HybridOptimizerExperimentProcessorTests extends OpenSearchTestCase 
             new QuerySetEntry(queryText, Map.of()),
             searchConfigs,
             judgmentList,
+            queryTextToDocIdToRatings,
             10,
             "run1",
             new ExperimentCancellationToken(experimentId),
@@ -101,61 +111,77 @@ public class HybridOptimizerExperimentProcessorTests extends OpenSearchTestCase 
             listener
         );
 
-        boolean completed = latch.await(1, TimeUnit.SECONDS);
-        assertTrue("Listener should complete within timeout", completed);
-        assertTrue("Failure listener should be triggered on deleted judgment", failureTriggered.get());
+        assertTrue("Listener should complete within timeout", latch.await(1, TimeUnit.SECONDS));
+        assertFalse("Failure listener should not be triggered when ratings are missing", failureTriggered.get());
     }
 
     /**
-     * Concurrent failures → single failure notification
+     * Verify pre-built ratings are passed to the task manager for the current query.
      */
-    public void testConcurrentDeletedJudgments_SingleFailureNotification() {
-        // Setup test data
+    public void testPreBuiltRatingsArePassedToTaskManager() throws InterruptedException {
         String experimentId = "exp2";
         String queryText = "query";
-        List<String> judgmentList = List.of("judgmentA", "judgmentB", "judgmentC");
+        String otherQueryText = "other query";
+        List<String> judgmentList = List.of("judgmentA");
+        Map<String, Map<String, String>> queryTextToDocIdToRatings = Map.of(
+            queryText,
+            Map.of("doc1", "5", "doc2", "3"),
+            otherQueryText,
+            Map.of("doc3", "1")
+        );
         Map<String, SearchConfigurationDetails> searchConfigs = Map.of(
             "config1",
             SearchConfigurationDetails.builder().index("i").query("q").pipeline("p").build()
         );
 
-        // Mock deleted judgment
+        AtomicBoolean captured = new AtomicBoolean(false);
         doAnswer(invocation -> {
-            ActionListener<SearchResponse> listener = invocation.getArgument(1);
-            listener.onFailure(new ResourceNotFoundException("Document not found"));
-            return null;
-        }).when(judgmentDao).getJudgment(any(), any());
+            @SuppressWarnings("unchecked")
+            Map<String, String> docIdToScores = invocation.getArgument(9);
+            captured.set(true);
+            assertEquals(2, docIdToScores.size());
+            assertEquals("5", docIdToScores.get("doc1"));
+            assertEquals("3", docIdToScores.get("doc2"));
+            assertNull(docIdToScores.get("doc3"));
+            return CompletableFuture.completedFuture(Map.of("evaluationResults", List.of()));
+        }).when(taskManager)
+            .scheduleTasksAsync(
+                any(ExperimentType.class),
+                any(),
+                any(),
+                any(),
+                any(),
+                any(QuerySetEntry.class),
+                any(Integer.class),
+                any(List.class),
+                any(List.class),
+                any(Map.class),
+                any(Map.class),
+                any(AtomicBoolean.class),
+                any(),
+                any(),
+                any(ExperimentCancellationToken.class)
+            );
 
-        AtomicInteger failureCount = new AtomicInteger(0);
-        ActionListener<Map<String, Object>> listener = new ActionListener<>() {
-            @Override
-            public void onResponse(Map<String, Object> response) {
-                fail("Experiment should not succeed when judgment is deleted");
-            }
-
-            @Override
-            public void onFailure(Exception e) {
-                failureCount.incrementAndGet();
-            }
-        };
-
+        CountDownLatch latch = new CountDownLatch(1);
         processor.processHybridOptimizerExperiment(
             experimentId,
             new QuerySetEntry(queryText, Map.of()),
             searchConfigs,
             judgmentList,
+            queryTextToDocIdToRatings,
             10,
             "run2",
             new ExperimentCancellationToken(experimentId),
             new ConcurrentHashMap<>(),
-            listener
+            ActionListener.wrap(r -> latch.countDown(), e -> latch.countDown())
         );
 
-        assertEquals("Only one onFailure() should trigger for concurrent failures", 1L, failureCount.get());
+        assertTrue("Listener should complete within timeout", latch.await(1, TimeUnit.SECONDS));
+        assertTrue("Task manager should have been invoked with ratings", captured.get());
     }
 
     public void testCancelWhenProcessingSearchConfigs() {
-        // Setup test data
         String experimentId = "test-experiment-id";
         String queryText = "test query";
         Map<String, SearchConfigurationDetails> searchConfigurations = new HashMap<>();

--- a/src/test/java/org/opensearch/searchrelevance/experiment/JudgmentRatingsMapperTests.java
+++ b/src/test/java/org/opensearch/searchrelevance/experiment/JudgmentRatingsMapperTests.java
@@ -1,0 +1,100 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+package org.opensearch.searchrelevance.experiment;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.opensearch.searchrelevance.model.AsyncStatus;
+import org.opensearch.searchrelevance.model.Judgment;
+import org.opensearch.searchrelevance.model.JudgmentType;
+import org.opensearch.test.OpenSearchTestCase;
+
+public class JudgmentRatingsMapperTests extends OpenSearchTestCase {
+
+    public void testBuildQueryTextToDocIdRatingsMap_EmptyJudgments() {
+        assertTrue(JudgmentRatingsMapper.buildQueryTextToDocIdRatingsMap(null).isEmpty());
+        assertTrue(JudgmentRatingsMapper.buildQueryTextToDocIdRatingsMap(Collections.emptyList()).isEmpty());
+    }
+
+    public void testBuildQueryTextToDocIdRatingsMap_MergesMultipleJudgments() {
+        Judgment judgment1 = new Judgment(
+            "j1",
+            "ts",
+            "name",
+            AsyncStatus.COMPLETED,
+            JudgmentType.IMPORT_JUDGMENT,
+            Map.of(),
+            Arrays.asList(
+                Map.of("query", "q1", "ratings", Arrays.asList(Map.of("docId", "d1", "rating", "5"), Map.of("docId", "d2", "rating", "3"))),
+                Map.of("query", "q2", "ratings", Arrays.asList(Map.of("docId", "d3", "rating", "1")))
+            )
+        );
+
+        Judgment judgment2 = new Judgment(
+            "j2",
+            "ts",
+            "name",
+            AsyncStatus.COMPLETED,
+            JudgmentType.IMPORT_JUDGMENT,
+            Map.of(),
+            Arrays.asList(
+                Map.of("query", "q1", "ratings", Arrays.asList(Map.of("docId", "d2", "rating", "4"), Map.of("docId", "d4", "rating", "2")))
+            )
+        );
+
+        Map<String, Map<String, String>> result = JudgmentRatingsMapper.buildQueryTextToDocIdRatingsMap(
+            Arrays.asList(judgment1, judgment2)
+        );
+
+        assertEquals(2, result.size());
+        Map<String, String> q1Ratings = result.get("q1");
+        assertEquals(3, q1Ratings.size());
+        assertEquals("5", q1Ratings.get("d1"));
+        assertEquals("4", q1Ratings.get("d2")); // later judgment overwrites earlier rating
+        assertEquals("2", q1Ratings.get("d4"));
+
+        Map<String, String> q2Ratings = result.get("q2");
+        assertEquals(1, q2Ratings.size());
+        assertEquals("1", q2Ratings.get("d3"));
+    }
+
+    public void testBuildQueryTextToDocIdRatingsMap_SkipsNullEntries() {
+        Map<String, Object> nullQueryRating = new HashMap<>();
+        nullQueryRating.put("query", null);
+        nullQueryRating.put("ratings", Arrays.asList(Map.of("docId", "d2", "rating", "3")));
+
+        Map<String, Object> nullRatingsEntry = new HashMap<>();
+        nullRatingsEntry.put("query", "q2");
+        nullRatingsEntry.put("ratings", null);
+
+        Judgment judgment = new Judgment(
+            "j1",
+            "ts",
+            "name",
+            AsyncStatus.COMPLETED,
+            JudgmentType.IMPORT_JUDGMENT,
+            Map.of(),
+            Arrays.asList(
+                Map.of("query", "q1", "ratings", Arrays.asList(Map.of("docId", "d1", "rating", "5"))),
+                nullQueryRating,
+                nullRatingsEntry
+            )
+        );
+
+        Map<String, Map<String, String>> result = JudgmentRatingsMapper.buildQueryTextToDocIdRatingsMap(List.of(judgment));
+
+        assertEquals(1, result.size());
+        assertTrue(result.containsKey("q1"));
+        assertFalse(result.containsKey("q2"));
+        assertEquals("5", result.get("q1").get("d1"));
+    }
+}

--- a/src/test/java/org/opensearch/searchrelevance/experiment/PointwiseExperimentProcessorTests.java
+++ b/src/test/java/org/opensearch/searchrelevance/experiment/PointwiseExperimentProcessorTests.java
@@ -8,11 +8,7 @@
 package org.opensearch.searchrelevance.experiment;
 
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.doAnswer;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.util.Arrays;
@@ -27,9 +23,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import org.junit.Before;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
-import org.opensearch.action.search.SearchResponse;
 import org.opensearch.core.action.ActionListener;
-import org.opensearch.searchrelevance.dao.JudgmentDao;
 import org.opensearch.searchrelevance.executors.ExperimentTaskManager;
 import org.opensearch.searchrelevance.model.ExperimentType;
 import org.opensearch.searchrelevance.model.QuerySetEntry;
@@ -44,9 +38,6 @@ import lombok.SneakyThrows;
 public class PointwiseExperimentProcessorTests extends OpenSearchTestCase {
 
     @Mock
-    private JudgmentDao judgmentDao;
-
-    @Mock
     private ExperimentTaskManager taskManager;
 
     private PointwiseExperimentProcessor processor;
@@ -56,7 +47,7 @@ public class PointwiseExperimentProcessorTests extends OpenSearchTestCase {
     public void setUp() {
         super.setUp();
         MockitoAnnotations.openMocks(this);
-        processor = new PointwiseExperimentProcessor(judgmentDao, taskManager);
+        processor = new PointwiseExperimentProcessor(taskManager);
     }
 
     @SneakyThrows
@@ -70,29 +61,28 @@ public class PointwiseExperimentProcessorTests extends OpenSearchTestCase {
             SearchConfigurationDetails.builder().index("test-index").query("test-query").pipeline("test-pipeline").build()
         );
         List<String> judgmentList = Arrays.asList("judgment1");
+        Map<String, Map<String, String>> queryTextToDocIdToRatings = Map.of(queryText, Map.of("doc1", "5", "doc2", "3"));
         int size = 10;
         AtomicBoolean hasFailure = new AtomicBoolean(false);
 
-        // Mock successful judgment response with actual judgment data
+        AtomicBoolean captured = new AtomicBoolean(false);
         doAnswer(invocation -> {
-            ActionListener<SearchResponse> listener = invocation.getArgument(1);
-            SearchResponse mockResponse = mock(SearchResponse.class);
-            when(mockResponse.getHits()).thenReturn(null);
-            listener.onResponse(mockResponse);
-            return null;
-        }).when(judgmentDao).getJudgment(anyString(), any(ActionListener.class));
-
-        // Mock task manager response
-        CompletableFuture<Map<String, Object>> mockFuture = CompletableFuture.completedFuture(
-            Map.of("evaluationResults", List.of(Map.of("evaluationId", "eval1", "variantId", "var1")))
-        );
-        when(
-            taskManager.scheduleTasksAsync(
+            @SuppressWarnings("unchecked")
+            Map<String, String> docIdToScores = invocation.getArgument(9);
+            captured.set(true);
+            assertEquals(2, docIdToScores.size());
+            assertEquals("5", docIdToScores.get("doc1"));
+            assertEquals("3", docIdToScores.get("doc2"));
+            return CompletableFuture.completedFuture(
+                Map.of("evaluationResults", List.of(Map.of("evaluationId", "eval1", "variantId", "var1")))
+            );
+        }).when(taskManager)
+            .scheduleTasksAsync(
                 any(ExperimentType.class),
-                anyString(),
-                anyString(),
-                anyString(),
-                anyString(),
+                any(),
+                any(),
+                any(),
+                any(),
                 any(QuerySetEntry.class),
                 any(Integer.class),
                 any(List.class),
@@ -100,11 +90,10 @@ public class PointwiseExperimentProcessorTests extends OpenSearchTestCase {
                 any(Map.class),
                 any(Map.class),
                 any(AtomicBoolean.class),
-                isNull(),
-                isNull(),
-                isNull()
-            )
-        ).thenReturn(mockFuture);
+                any(),
+                any(),
+                any()
+            );
 
         // Mock ActionListener with CountDownLatch to wait for completion
         CountDownLatch latch = new CountDownLatch(1);
@@ -129,6 +118,7 @@ public class PointwiseExperimentProcessorTests extends OpenSearchTestCase {
             new QuerySetEntry(queryText, Map.of()),
             searchConfigurations,
             judgmentList,
+            queryTextToDocIdToRatings,
             size,
             hasFailure,
             null,
@@ -138,13 +128,11 @@ public class PointwiseExperimentProcessorTests extends OpenSearchTestCase {
 
         // Wait for async operation to complete
         assertTrue("Async operation should complete within timeout", latch.await(5, TimeUnit.SECONDS));
-
-        // Verify interactions
-        verify(judgmentDao).getJudgment(anyString(), any(ActionListener.class));
+        assertTrue("Task manager should have been invoked with ratings", captured.get());
     }
 
     @SneakyThrows
-    public void testProcessPointwiseExperiment_JudgmentFailure() {
+    public void testProcessPointwiseExperiment_MissingRatingsForQuery() {
         // Setup test data
         String experimentId = "test-experiment-id";
         String queryText = "test query";
@@ -154,28 +142,44 @@ public class PointwiseExperimentProcessorTests extends OpenSearchTestCase {
             SearchConfigurationDetails.builder().index("test-index").query("test-query").pipeline(null).build()
         );
         List<String> judgmentList = Arrays.asList("judgment1");
+        Map<String, Map<String, String>> queryTextToDocIdToRatings = Map.of();
         int size = 10;
         AtomicBoolean hasFailure = new AtomicBoolean(false);
 
-        // Mock judgment failure
-        doAnswer(invocation -> {
-            ActionListener<SearchResponse> listener = invocation.getArgument(1);
-            listener.onFailure(new RuntimeException("Judgment fetch failed"));
-            return null;
-        }).when(judgmentDao).getJudgment(anyString(), any(ActionListener.class));
+        when(
+            taskManager.scheduleTasksAsync(
+                any(ExperimentType.class),
+                any(),
+                any(),
+                any(),
+                any(),
+                any(QuerySetEntry.class),
+                any(Integer.class),
+                any(List.class),
+                any(List.class),
+                any(Map.class),
+                any(Map.class),
+                any(AtomicBoolean.class),
+                any(),
+                any(),
+                any()
+            )
+        ).thenReturn(
+            CompletableFuture.completedFuture(Map.of("evaluationResults", List.of(Map.of("evaluationId", "eval1", "variantId", "var1"))))
+        );
 
         // Mock ActionListener with CountDownLatch to wait for completion
         CountDownLatch latch = new CountDownLatch(1);
         ActionListener<Map<String, Object>> listener = new ActionListener<Map<String, Object>>() {
             @Override
             public void onResponse(Map<String, Object> response) {
-                fail("Should have failed, but got response");
+                assertNotNull(response);
                 latch.countDown();
             }
 
             @Override
             public void onFailure(Exception e) {
-                assertNotNull(e);
+                fail("Should not have failed: " + e.getMessage());
                 latch.countDown();
             }
         };
@@ -186,6 +190,7 @@ public class PointwiseExperimentProcessorTests extends OpenSearchTestCase {
             new QuerySetEntry(queryText, Map.of()),
             searchConfigurations,
             judgmentList,
+            queryTextToDocIdToRatings,
             size,
             hasFailure,
             null,
@@ -200,9 +205,6 @@ public class PointwiseExperimentProcessorTests extends OpenSearchTestCase {
     public void testCreatePointwiseVariants() {
         // Test constructor to ensure processor is properly initialized
         assertNotNull("Processor should be initialized", processor);
-
-        // Test that the processor has proper dependencies
-        assertNotNull("JudgmentDao should be injected", judgmentDao);
         assertNotNull("TaskManager should be injected", taskManager);
     }
 }

--- a/src/test/java/org/opensearch/searchrelevance/metrics/MetricsHelperTests.java
+++ b/src/test/java/org/opensearch/searchrelevance/metrics/MetricsHelperTests.java
@@ -26,17 +26,14 @@ import org.opensearch.action.search.SearchRequest;
 import org.opensearch.action.search.SearchResponse;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.settings.Settings;
-import org.opensearch.common.xcontent.XContentFactory;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.common.bytes.BytesArray;
-import org.opensearch.core.common.bytes.BytesReference;
 import org.opensearch.core.xcontent.NamedXContentRegistry;
 import org.opensearch.search.SearchHit;
 import org.opensearch.search.SearchHits;
 import org.opensearch.search.SearchModule;
 import org.opensearch.searchrelevance.dao.EvaluationResultDao;
 import org.opensearch.searchrelevance.dao.ExperimentVariantDao;
-import org.opensearch.searchrelevance.dao.JudgmentDao;
 import org.opensearch.searchrelevance.model.QuerySetEntry;
 import org.opensearch.searchrelevance.model.SearchConfigurationDetails;
 import org.opensearch.searchrelevance.model.builder.SearchRequestBuilder;
@@ -47,7 +44,6 @@ public class MetricsHelperTests extends OpenSearchTestCase {
 
     private ClusterService clusterService;
     private Client client;
-    private JudgmentDao judgmentDao;
     private EvaluationResultDao evaluationResultDao;
     private ExperimentVariantDao experimentVariantDao;
     private MetricsHelper metricsHelper;
@@ -57,10 +53,9 @@ public class MetricsHelperTests extends OpenSearchTestCase {
         super.setUp();
         clusterService = mock(ClusterService.class);
         client = mock(Client.class);
-        judgmentDao = mock(JudgmentDao.class);
         evaluationResultDao = mock(EvaluationResultDao.class);
         experimentVariantDao = mock(ExperimentVariantDao.class);
-        metricsHelper = new MetricsHelper(clusterService, client, judgmentDao, evaluationResultDao, experimentVariantDao);
+        metricsHelper = new MetricsHelper(clusterService, client, evaluationResultDao, experimentVariantDao);
 
         // Initialize SearchRequestBuilder NamedXContentRegistry for tests
         NamedXContentRegistry reg = new NamedXContentRegistry(
@@ -231,17 +226,10 @@ public class MetricsHelperTests extends OpenSearchTestCase {
         String queryText = "test query";
         int size = 10;
         List<String> judgmentIds = Arrays.asList("judgment1");
+        Map<String, Map<String, String>> queryTextToDocIdToRatings = Map.of(queryText, Map.of("doc1", "5", "doc2", "3"));
 
         Map<String, List<String>> indexAndQueries = new HashMap<>();
         indexAndQueries.put("config1", Arrays.asList("index1", "{\"query\":{\"match\":{\"title\":\"%SearchText%\"}}}", "pipeline1"));
-
-        // Mock judgment response
-        SearchResponse judgmentResponse = createMockJudgmentResponse(queryText);
-        doAnswer(invocation -> {
-            ActionListener<SearchResponse> listener = invocation.getArgument(1);
-            listener.onResponse(judgmentResponse);
-            return null;
-        }).when(judgmentDao).getJudgment(any(String.class), any(ActionListener.class));
 
         // Mock search response
         SearchResponse mockResponse = createMockSearchResponse("doc1", "doc2");
@@ -264,7 +252,15 @@ public class MetricsHelperTests extends OpenSearchTestCase {
 
         // Execute the method
         ActionListener<Map<String, Object>> resultListener = mock(ActionListener.class);
-        metricsHelper.processEvaluationMetrics(queryText, indexAndQueries, size, judgmentIds, resultListener, null);
+        metricsHelper.processEvaluationMetrics(
+            queryText,
+            indexAndQueries,
+            size,
+            judgmentIds,
+            queryTextToDocIdToRatings,
+            resultListener,
+            null
+        );
 
         // Verify pipeline is passed correctly
         verify(client, times(1)).search(
@@ -278,17 +274,10 @@ public class MetricsHelperTests extends OpenSearchTestCase {
         String queryText = "test query";
         int size = 10;
         List<String> judgmentIds = Arrays.asList("judgment1");
+        Map<String, Map<String, String>> queryTextToDocIdToRatings = Map.of(queryText, Map.of("doc1", "5", "doc2", "3"));
 
         Map<String, List<String>> indexAndQueries = new HashMap<>();
         indexAndQueries.put("config1", Arrays.asList("index1", "{\"query\":{\"match\":{\"title\":\"%SearchText%\"}}}", ""));
-
-        // Mock judgment response
-        SearchResponse judgmentResponse = createMockJudgmentResponse(queryText);
-        doAnswer(invocation -> {
-            ActionListener<SearchResponse> listener = invocation.getArgument(1);
-            listener.onResponse(judgmentResponse);
-            return null;
-        }).when(judgmentDao).getJudgment(any(String.class), any(ActionListener.class));
 
         // Mock search response
         SearchResponse mockResponse = createMockSearchResponse("doc1", "doc2");
@@ -311,7 +300,15 @@ public class MetricsHelperTests extends OpenSearchTestCase {
 
         // Execute the method
         ActionListener<Map<String, Object>> resultListener = mock(ActionListener.class);
-        metricsHelper.processEvaluationMetrics(queryText, indexAndQueries, size, judgmentIds, resultListener, null);
+        metricsHelper.processEvaluationMetrics(
+            queryText,
+            indexAndQueries,
+            size,
+            judgmentIds,
+            queryTextToDocIdToRatings,
+            resultListener,
+            null
+        );
 
         // Verify empty pipeline is handled correctly
         verify(client, times(1)).search(
@@ -335,31 +332,4 @@ public class MetricsHelperTests extends OpenSearchTestCase {
         return response;
     }
 
-    private SearchResponse createMockJudgmentResponse(String queryText) {
-        SearchResponse response = mock(SearchResponse.class);
-
-        Map<String, Object> sourceMap = new HashMap<>();
-        List<Map<String, Object>> judgmentRatings = Arrays.asList(
-            Map.of(
-                "query",
-                queryText,
-                "ratings",
-                Arrays.asList(Map.of("docId", "doc1", "rating", "5"), Map.of("docId", "doc2", "rating", "3"))
-            )
-        );
-        sourceMap.put("judgmentRatings", judgmentRatings);
-
-        SearchHit hit = new SearchHit(1, "judgment1", Map.of(), Map.of());
-        try {
-            BytesReference sourceBytes = BytesReference.bytes(XContentFactory.jsonBuilder().map(sourceMap));
-            hit.sourceRef(sourceBytes);
-        } catch (Exception e) {
-            throw new RuntimeException("Failed to create judgment response", e);
-        }
-
-        SearchHits hits = new SearchHits(new SearchHit[] { hit }, new TotalHits(1, TotalHits.Relation.EQUAL_TO), 1.0f);
-
-        when(response.getHits()).thenReturn(hits);
-        return response;
-    }
 }


### PR DESCRIPTION
ExperimentRunningManager.loadJudgmentsThenContinue already loads the full List<Judgment> once, but the actual judgment data was only used for input signature computation and then discarded. executeExperimentEvaluation passed only the judgment IDs down to the processors, which then re-fetched the same judgment documents for every query text:

HybridOptimizerExperimentProcessor.processJudgmentsAsync called judgmentDao.getJudgment() once per query per judgment.
PointwiseExperimentProcessor did the same (with a local cache keyed by experimentId:queryText, but still re-fetched on first access).
MetricsHelper.processEvaluationMetrics repeated the same pattern.
For each fetch, extractJudgmentScores also did a linear scan over judgmentRatings to find the matching query.

Cost: Q queries × J judgments redundant GETs of large judgment docs + Q × O(ratings) scans.

so built Map<queryText, Map<docId, rating>> once from the already-loaded List<Judgment> and passed it into the Hybrid and Pointwise processors (and the legacy MetricsHelper path).