### PR TITLE
Stabilize flaky restart-upgrade BWC tests: wait for a stable cluster-manager and raise fault-detection tolerances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Report an invalid UBI events index as a `400` naming the index and the `ubiEventsIndex` parameter instead of a `500` ([#558](https://github.com/opensearch-project/search-relevance/pull/558))
 
 ### Infrastructure
+- Stabilize flaky restart-upgrade BWC tests by waiting for a stable cluster-manager before cluster-state writes, raising the test cluster's fault-detection/publish tolerances so a transient node stall does not trigger re-election churn, and pinning the test cluster heap to a fixed `2g` per node ([#562](https://github.com/opensearch-project/search-relevance/pull/562))
 
 ### Documentation
 

--- a/qa/restart-upgrade/build.gradle
+++ b/qa/restart-upgrade/build.gradle
@@ -22,7 +22,7 @@ String baseName = "searchRelevanceBwcCluster-restart"
 testClusters {
     "${baseName}" {
         testDistribution = "ARCHIVE"
-        jvmArgs("-Xms1g", "-Xmx4g")
+        jvmArgs("-Xms2g", "-Xmx2g")
         numberOfNodes = 3
         if(ext.bwcBundleTest){
             versions = [ext.search_relevance_bwc_version, ext.currentBundleVersion]
@@ -60,6 +60,15 @@ testClusters {
         }
         setting 'path.repo', "${buildDir}/cluster/shared/repo/${baseName}"
         setting 'http.content_type.required', 'true'
+        // Tolerate transient node stalls (GC / CPU contention on constrained CI runners) after the
+        // restart upgrade: give the cluster-manager longer to commit cluster state and don't mark a
+        // briefly-unresponsive node faulty, so a stall does not trigger re-election churn that fails
+        // cluster-state writes such as the search-config mapping migration.
+        setting 'cluster.publish.timeout', '60s'
+        setting 'cluster.fault_detection.follower_check.timeout', '30s'
+        setting 'cluster.fault_detection.follower_check.retry_count', '4'
+        setting 'cluster.fault_detection.leader_check.timeout', '30s'
+        setting 'cluster.fault_detection.leader_check.retry_count', '4'
     }
 }
 

--- a/qa/restart-upgrade/src/test/java/org/opensearch/searchrelevance/bwc/restart/AbstractSearchRelevanceRestartUpgradeTestCase.java
+++ b/qa/restart-upgrade/src/test/java/org/opensearch/searchrelevance/bwc/restart/AbstractSearchRelevanceRestartUpgradeTestCase.java
@@ -40,12 +40,15 @@ public abstract class AbstractSearchRelevanceRestartUpgradeTestCase extends Open
     private static final int RESTART_UPGRADE_NODE_COUNT = 3;
 
     /**
-     * After a full-cluster version bump, wait until health reports enough nodes before REST tests run.
+     * After a full-cluster version bump, wait until the cluster has stably re-formed (elected
+     * cluster-manager, all nodes rejoined, green) before REST tests run. The timeout is generous
+     * because, on resource-constrained CI runners, the restarted nodes can take a few minutes to
+     * rediscover each other and settle on a cluster-manager.
      */
     @Before
     public void waitForUpgradedClusterWhenApplicable() throws Exception {
         if (getClusterType() == ClusterType.UPGRADED) {
-            IndexMappingTestHelper.waitForClusterNodesReady(client(), RESTART_UPGRADE_NODE_COUNT, 180, logger);
+            IndexMappingTestHelper.waitForClusterNodesReady(client(), RESTART_UPGRADE_NODE_COUNT, 300, logger);
         }
     }
 

--- a/qa/rolling-upgrade/build.gradle
+++ b/qa/rolling-upgrade/build.gradle
@@ -22,7 +22,7 @@ String baseName = "searchRelevanceBwcCluster-rolling"
 testClusters {
     "${baseName}" {
         testDistribution = "ARCHIVE"
-        jvmArgs("-Xms1g", "-Xmx4g")
+        jvmArgs("-Xms2g", "-Xmx2g")
         numberOfNodes = 3
         if(ext.bwcBundleTest){
             versions = [ext.search_relevance_bwc_version, ext.currentBundleVersion]
@@ -60,6 +60,15 @@ testClusters {
         }
         setting 'path.repo', "${buildDir}/cluster/shared/repo/${baseName}"
         setting 'http.content_type.required', 'true'
+        // Tolerate transient node stalls (GC / CPU contention on constrained CI runners) during the
+        // upgrade: give the cluster-manager longer to commit cluster state and don't mark a
+        // briefly-unresponsive node faulty, so a stall does not trigger re-election churn that fails
+        // cluster-state writes such as the search-config mapping migration.
+        setting 'cluster.publish.timeout', '60s'
+        setting 'cluster.fault_detection.follower_check.timeout', '30s'
+        setting 'cluster.fault_detection.follower_check.retry_count', '4'
+        setting 'cluster.fault_detection.leader_check.timeout', '30s'
+        setting 'cluster.fault_detection.leader_check.retry_count', '4'
     }
 }
 

--- a/qa/src/test/java/org/opensearch/searchrelevance/bwc/IndexMappingTestHelper.java
+++ b/qa/src/test/java/org/opensearch/searchrelevance/bwc/IndexMappingTestHelper.java
@@ -301,39 +301,96 @@ public final class IndexMappingTestHelper {
         logger.info("Updated mapping for index {}", indexName);
     }
 
+    /** Consecutive healthy polls required before the cluster is treated as stably re-formed. */
+    private static final int REQUIRED_CONSECUTIVE_STABLE_POLLS = 3;
+
     /**
-     * Polls {@code GET /_cluster/health} until {@code number_of_nodes >= minNodes} and status is not {@code red}.
-     * Used in restart-upgrade BWC after a full version bump, before REST assertions.
+     * Waits until the upgraded cluster has <em>stably</em> re-formed before REST assertions issue
+     * cluster-state-mutating requests (create-index, {@code PUT search_configuration}).
+     *
+     * <p>A plain "non-red with N nodes" check is insufficient for restart-upgrade: after a full
+     * restart the nodes are still rediscovering each other and re-electing a cluster-manager, and
+     * health can briefly report green with N nodes in between elections. Returning on that transient
+     * state lets a test write into a cluster with no stable cluster-manager, so the cluster-state
+     * change never durably commits — the mapping migration is silently skipped (leaving
+     * {@code schema_version} at 0) or the write fails with {@code cluster_manager_not_discovered}
+     * (HTTP 500). This gate closes that race by requiring, for
+     * {@value #REQUIRED_CONSECUTIVE_STABLE_POLLS} consecutive polls, that:
+     * <ul>
+     *   <li>the server-side wait ({@code wait_for_status=green}, {@code wait_for_nodes=ge(N)},
+     *       {@code wait_for_events=languid}) returns without timing out — languid only completes once
+     *       the elected cluster-manager has drained its pending cluster-state task queue;</li>
+     *   <li>status is {@code green}, at least {@code minNodes} nodes have (re)joined, and an elected
+     *       cluster-manager is reported ({@code discovered_cluster_manager}).</li>
+     * </ul>
      */
     public static void waitForClusterNodesReady(RestClient client, int minNodes, int maxWaitSeconds, Logger logger) throws Exception {
         final long deadline = System.currentTimeMillis() + maxWaitSeconds * 1000L;
+        int consecutiveStable = 0;
+        String lastObserved = "no successful health response yet";
         while (System.currentTimeMillis() < deadline) {
             try {
+                // Server-side gate: block (up to the per-call timeout) for the target state so we poll a
+                // settling cluster rather than busy-loop. languid only returns once the elected
+                // cluster-manager has drained its pending cluster-state tasks.
                 Request request = new Request("GET", "/_cluster/health");
+                request.addParameter("wait_for_status", "green");
+                request.addParameter("wait_for_nodes", "ge(" + minNodes + ")");
+                request.addParameter("wait_for_events", "languid");
+                request.addParameter("timeout", "10s");
+                request.addParameter("cluster_manager_timeout", "10s");
                 setPermissiveWarningsHandler(request);
                 Response response = client.performRequest(request);
-                if (response.getStatusLine().getStatusCode() != 200) {
-                    logger.debug("Cluster health HTTP {}", response.getStatusLine().getStatusCode());
-                } else {
+                if (response.getStatusLine().getStatusCode() == 200) {
                     Map<String, Object> map = parseResponse(response);
                     String status = map.get("status") != null ? map.get("status").toString() : "";
-                    int nodes = 0;
-                    Object nn = map.get("number_of_nodes");
-                    if (nn instanceof Number) {
-                        nodes = ((Number) nn).intValue();
+                    boolean timedOut = Boolean.TRUE.equals(map.get("timed_out"));
+                    int nodes = map.get("number_of_nodes") instanceof Number ? ((Number) map.get("number_of_nodes")).intValue() : 0;
+                    // discovered_cluster_manager (2.0+), discovered_master (older). Absent -> rely on green + languid.
+                    Object clusterManagerFlag = map.getOrDefault("discovered_cluster_manager", map.get("discovered_master"));
+                    boolean hasClusterManager = !Boolean.FALSE.equals(clusterManagerFlag);
+                    lastObserved = "status="
+                        + status
+                        + ", number_of_nodes="
+                        + nodes
+                        + ", timed_out="
+                        + timedOut
+                        + ", discovered_cluster_manager="
+                        + clusterManagerFlag;
+                    if (!timedOut && "green".equals(status) && nodes >= minNodes && hasClusterManager) {
+                        consecutiveStable++;
+                        if (consecutiveStable >= REQUIRED_CONSECUTIVE_STABLE_POLLS) {
+                            logger.info("Cluster stably formed for BWC ({} consecutive checks): {}", consecutiveStable, lastObserved);
+                            return;
+                        }
+                        logger.debug(
+                            "Cluster healthy, confirming stability ({}/{}): {}",
+                            consecutiveStable,
+                            REQUIRED_CONSECUTIVE_STABLE_POLLS,
+                            lastObserved
+                        );
+                    } else {
+                        consecutiveStable = 0;
+                        logger.debug("Cluster not stably ready yet: {}", lastObserved);
                     }
-                    if (!"red".equals(status) && nodes >= minNodes) {
-                        logger.info("Cluster ready for BWC: status={}, number_of_nodes={}", status, nodes);
-                        return;
-                    }
-                    logger.debug("Cluster not ready yet: status={}, number_of_nodes={} (need {})", status, nodes, minNodes);
+                } else {
+                    consecutiveStable = 0;
+                    logger.debug("Cluster health HTTP {}", response.getStatusLine().getStatusCode());
                 }
             } catch (Exception e) {
-                logger.debug("Cluster health poll failed: {}", e.getMessage());
+                consecutiveStable = 0;
+                logger.debug("Cluster readiness poll failed: {}", e.getMessage());
             }
             Thread.sleep(3000);
         }
-        throw new AssertionError("Timeout after " + maxWaitSeconds + "s waiting for >= " + minNodes + " nodes and non-red cluster health");
+        throw new AssertionError(
+            "Timeout after "
+                + maxWaitSeconds
+                + "s waiting for a stably-formed cluster (>= "
+                + minNodes
+                + " nodes, elected cluster-manager, green) for BWC; last observed: "
+                + lastObserved
+        );
     }
 
     /**


### PR DESCRIPTION
### Description

The BWC **restart-upgrade** jobs intermittently fail. After the version upgrade the plugin's `PUT /_plugins/_search_relevance/search_configurations` either returns `500` (`cluster_manager_not_discovered` / `Failed to update mapping ... after 3 attempts`) or the follow-up assertion fails with `Schema version should be 1 but was 0`. Both are the same root cause: the write reaches the upgraded 3-node cluster while it has **no stable cluster-manager**, so the search-config mapping migration (a cluster-state change) never durably commits.

CI logs showed the instability happens in **two distinct windows**, so the fix has three parts.

#### 1. Wait for a *stable* cluster-manager before cluster-state writes (primary)

The `@Before` readiness gate previously only required `status != red` and `number_of_nodes >= N`. During post-restart discovery, health can briefly report green *between* elections, so the gate returned on a transient false-green and the test wrote into a still-churning cluster.

`IndexMappingTestHelper.waitForClusterNodesReady` now requires, for **3 consecutive polls**, a server-side `wait_for_status=green` + `wait_for_nodes=ge(N)` + `wait_for_events=languid` (which only returns once the elected cluster-manager has drained its pending cluster-state task queue), `timed_out == false`, and `discovered_cluster_manager == true`. The restart-upgrade `@Before` timeout is raised `180s -> 300s` to cover the observed ~220s convergence on constrained runners.

#### 2. Tolerate transient node stalls under load (primary)

CI logs showed the cluster forming cleanly (gate passes), then re-electing ~30s later when the test's write/shard-reroute load hits it — the first `failed to commit cluster state version [N]` lands exactly at the default `cluster.publish.timeout` of 30s. On a 4-vCPU runner packing 3 nodes + Gradle + the test JVM, a node stalls (GC / CPU contention), misses its follower-check, and the cluster-manager loses quorum. The BWC test clusters now raise the coordination tolerances so a transient stall does not trigger re-election churn:

```groovy
setting 'cluster.publish.timeout', '60s'
setting 'cluster.fault_detection.follower_check.timeout', '30s'
setting 'cluster.fault_detection.follower_check.retry_count', '4'
setting 'cluster.fault_detection.leader_check.timeout', '30s'
setting 'cluster.fault_detection.leader_check.retry_count', '4'
```

#### 3. Pin the test cluster heap to a fixed `2g` per node (hygiene, [#561](https://github.com/opensearch-project/search-relevance/issues/561))

The BWC clusters ran `-Xms1g -Xmx4g` (min != max) on 3 nodes. Per OpenSearch's recommended heap configuration, min and max should be equal to avoid resize pauses (see the shipped [`jvm.options`](https://github.com/opensearch-project/OpenSearch/blob/main/distribution/src/config/jvm.options#L4-L14)). This pins both BWC test clusters to a fixed `2g`. Note: CI proved heap sizing is **not** the root cause of the flakiness (parts 1 and 2 are) — this is retained as hygiene only.

### Testing

- `:qa:spotlessJavaCheck`, `:qa:forbiddenApisTest`, `:qa:restart-upgrade:compileTestJava` pass locally.
- BWC suites cannot be reproduced reliably off-CI (the failure is timing/resource-dependent), so this must be validated by watching the restart-upgrade cells — especially the near-deterministic `3.3.0` cell — across several CI runs.

### Related Issues

Relates to [#561](https://github.com/opensearch-project/search-relevance/issues/561)

### Check List
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR created, if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
