### PR TITLE
Add boundary-aware truncation for oversized LLM judgment hits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### Enhancements
 - Add retry endpoint for failed LLM judgments, existingJudgments parameter for rating reuse, and remove broken global cache ([#525](https://github.com/opensearch-project/search-relevance/issues/525))
+- Truncate oversized LLM judgment hits at clean boundaries with a truncation marker and always truncate a solo-oversized hit regardless of ordering ([#563](https://github.com/opensearch-project/search-relevance/pull/563))
 
 ### Bug Fixes
 - Return correct delete REST status codes and honor querySetSize for sampling ([#542](https://github.com/opensearch-project/search-relevance/pull/542))

--- a/src/main/java/org/opensearch/searchrelevance/common/MLConstants.java
+++ b/src/main/java/org/opensearch/searchrelevance/common/MLConstants.java
@@ -141,6 +141,9 @@ public class MLConstants {
     public static final String INPUT_FORMAT_SEARCH = "SearchText - %s; Hits - %s";
     public static final String INPUT_FORMAT_SEARCH_WITH_REFERENCE = "SearchText: %s; Reference: %s; Hits: %s";
 
+    // appended to a hit's content when truncated, so the LLM knows the document is incomplete
+    public static final String TRUNCATION_MARKER = "...[content truncated]";
+
     public static String escapeJson(String str) {
         if (str == null) {
             return "";

--- a/src/main/java/org/opensearch/searchrelevance/ml/MLInputOutputTransformer.java
+++ b/src/main/java/org/opensearch/searchrelevance/ml/MLInputOutputTransformer.java
@@ -21,6 +21,7 @@ import static org.opensearch.searchrelevance.common.MLConstants.RESPONSE_CONTENT
 import static org.opensearch.searchrelevance.common.MLConstants.RESPONSE_FIELD;
 import static org.opensearch.searchrelevance.common.MLConstants.RESPONSE_FORMAT_TEMPLATE;
 import static org.opensearch.searchrelevance.common.MLConstants.RESPONSE_MESSAGE_FIELD;
+import static org.opensearch.searchrelevance.common.MLConstants.TRUNCATION_MARKER;
 import static org.opensearch.searchrelevance.common.MLConstants.escapeJson;
 
 import java.io.IOException;
@@ -50,6 +51,8 @@ import lombok.extern.log4j.Log4j2;
 @Log4j2
 public class MLInputOutputTransformer {
 
+    private static final int MAX_TRUNCATION_ATTEMPTS = 5;
+
     public List<MLInput> createMLInputs(
         int tokenLimit,
         String searchText,
@@ -69,11 +72,17 @@ public class MLInputOutputTransformer {
             int totalTokens = TokenizerUtil.countTokens(messages);
 
             if (totalTokens > tokenLimit) {
-                if (currentChunk.isEmpty()) {
-                    mlInputs.add(handleOversizedEntry(entry, searchText, referenceData, tokenLimit, promptTemplate, ratingType));
-                } else {
+                // flush the buffered chunk, then evaluate this entry on its own so a solo-oversized
+                // entry is always truncated regardless of its position in the unordered hits
+                if (!currentChunk.isEmpty()) {
                     mlInputs.add(createMLInput(searchText, referenceData, currentChunk, promptTemplate, ratingType));
                     currentChunk = new HashMap<>();
+                }
+                Map<String, String> singleEntry = Map.of(entry.getKey(), entry.getValue());
+                String singleMessages = buildMessagesArray(searchText, referenceData, singleEntry, promptTemplate, ratingType);
+                if (TokenizerUtil.countTokens(singleMessages) > tokenLimit) {
+                    mlInputs.add(handleOversizedEntry(entry, searchText, referenceData, tokenLimit, promptTemplate, ratingType));
+                } else {
                     currentChunk.put(entry.getKey(), entry.getValue());
                 }
             } else {
@@ -98,15 +107,54 @@ public class MLInputOutputTransformer {
     ) {
         log.warn("Entry with key {} causes total tokens to exceed limit of {}", entry.getKey(), tokenLimit);
 
-        Map<String, String> testChunk = Map.of(entry.getKey(), entry.getValue());
+        String originalValue = entry.getValue();
+        Map<String, String> testChunk = Map.of(entry.getKey(), originalValue);
         String testMessages = buildMessagesArray(searchText, referenceData, testChunk, promptTemplate, ratingType);
         int excessTokens = TokenizerUtil.countTokens(testMessages) - tokenLimit;
 
-        int currentTokens = TokenizerUtil.countTokens(entry.getValue());
-        String truncatedValue = TokenizerUtil.truncateString(entry.getValue(), Math.max(1, currentTokens - excessTokens));
+        int currentTokens = TokenizerUtil.countTokens(originalValue);
+        int markerTokens = TokenizerUtil.countTokens(TRUNCATION_MARKER);
+
+        // reserve room for the wrapping overhead and the appended marker
+        int targetValueTokens = Math.max(1, currentTokens - excessTokens - markerTokens);
+
+        // re-measure against the exact wrapped form and shrink until it fits; bounded and
+        // monotonically decreasing toward a floor of 1, so it always terminates
+        String truncatedValue = originalValue;
+        int finalTokens = 0;
+        for (int attempt = 0; attempt < MAX_TRUNCATION_ATTEMPTS; attempt++) {
+            String cut = TokenizerUtil.truncateStringAtBoundary(originalValue, targetValueTokens);
+            truncatedValue = appendTruncationMarker(cut, originalValue);
+
+            Map<String, String> candidateChunk = Map.of(entry.getKey(), truncatedValue);
+            finalTokens = TokenizerUtil.countTokens(
+                buildMessagesArray(searchText, referenceData, candidateChunk, promptTemplate, ratingType)
+            );
+            if (finalTokens <= tokenLimit || targetValueTokens <= 1) {
+                break;
+            }
+            targetValueTokens = Math.max(1, targetValueTokens - (finalTokens - tokenLimit) - 1);
+        }
+
+        if (finalTokens > tokenLimit) {
+            log.warn(
+                "Entry with key {} still exceeds limit {} after truncation ({} tokens); tokenLimit may be too small",
+                entry.getKey(),
+                tokenLimit,
+                finalTokens
+            );
+        }
 
         Map<String, String> singleEntryChunk = Map.of(entry.getKey(), truncatedValue);
         return createMLInput(searchText, referenceData, singleEntryChunk, promptTemplate, ratingType);
+    }
+
+    // mark only content that was actually shortened, so a hit that fits is never mislabeled
+    private static String appendTruncationMarker(String truncated, String original) {
+        if (truncated.length() < original.length()) {
+            return truncated + TRUNCATION_MARKER;
+        }
+        return truncated;
     }
 
     public MLInput createMLInput(

--- a/src/main/java/org/opensearch/searchrelevance/ml/TokenizerUtil.java
+++ b/src/main/java/org/opensearch/searchrelevance/ml/TokenizerUtil.java
@@ -25,6 +25,13 @@ public class TokenizerUtil {
     // cl100k_base is used by GPT-3.5/GPT-4 and is a good default choice
     private static final Encoding encoding = registry.getEncoding(EncodingType.CL100K_BASE);
 
+    // Cut-point separators, highest priority first: paragraph, line, sentence, clause, word.
+    private static final String[] BOUNDARY_SEPARATORS = { "\n\n", "\n", ". ", "! ", "? ", "; ", ", ", " " };
+    // Emitted when a token cut lands inside a multi-byte codepoint (e.g. CJK, emoji).
+    private static final char REPLACEMENT_CHAR = '\uFFFD';
+    // Lowest fraction of the fitting window to keep when backing up to a coarser boundary.
+    private static final double MIN_RETENTION_RATIO = 0.5;
+
     /**
      * helper method to count tokens if no model type is provided
      */
@@ -56,6 +63,49 @@ public class TokenizerUtil {
             tokenList.add(tokens.get(i));
         }
         return decode(tokenList.subList(0, tokenLimit));
+    }
+
+    /**
+     * helper method to truncate text to token limit at a clean separator boundary,
+     * falling back to a hard token cut when none fits
+     */
+    public static String truncateStringAtBoundary(String text, int tokenLimit) {
+        if (text == null || text.isEmpty()) {
+            return text;
+        }
+        if (tokenLimit <= 0) {
+            return "";
+        }
+        if (countTokens(text) <= tokenLimit) { // no truncation needed
+            return text;
+        }
+
+        // largest window that fits; any prefix of it is still within the budget
+        String window = stripTrailingReplacementChars(truncateString(text, tokenLimit));
+        if (window.isEmpty()) {
+            return window;
+        }
+
+        int minLength = (int) Math.floor(window.length() * MIN_RETENTION_RATIO);
+        for (String separator : BOUNDARY_SEPARATORS) {
+            int idx = window.lastIndexOf(separator);
+            if (idx <= 0) {
+                continue;
+            }
+            int cut = idx + separator.length(); // keep the separator with the retained text
+            if (cut >= minLength) {
+                return window.substring(0, cut);
+            }
+        }
+        return window; // no acceptable boundary: hard cut
+    }
+
+    private static String stripTrailingReplacementChars(String text) {
+        int end = text.length();
+        while (end > 0 && text.charAt(end - 1) == REPLACEMENT_CHAR) {
+            end--;
+        }
+        return text.substring(0, end);
     }
 
     // Method to decode tokens back to text

--- a/src/test/java/org/opensearch/searchrelevance/ml/MLInputOutputTransformerTests.java
+++ b/src/test/java/org/opensearch/searchrelevance/ml/MLInputOutputTransformerTests.java
@@ -10,6 +10,7 @@ package org.opensearch.searchrelevance.ml;
 import static org.mockito.Mockito.mock;
 
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -350,6 +351,134 @@ public class MLInputOutputTransformerTests extends OpenSearchTestCase {
             LLMJudgmentRatingType.SCORE0_1
         );
         assertTrue(inputs.isEmpty());
+    }
+
+    // ============================================
+    // Boundary-aware truncation tests
+    // ============================================
+
+    public void testCreateMLInputs_oversizedHitIsMarkedTruncated() {
+        int limit = overheadTokens() + 40;
+        Map<String, String> hits = new HashMap<>();
+        hits.put("doc1", longContent());
+
+        List<MLInput> inputs = transformer.createMLInputs(
+            limit,
+            "q",
+            new HashMap<>(),
+            hits,
+            "{{searchText}} {{hits}}",
+            LLMJudgmentRatingType.SCORE0_1
+        );
+
+        assertEquals(1, inputs.size());
+        assertTrue("truncated hit should carry the truncation marker", userPromptOf(inputs.get(0)).contains("[content truncated]"));
+    }
+
+    public void testCreateMLInputs_oversizedHitStaysWithinTokenLimitAfterWrapping() {
+        int limit = overheadTokens() + 40;
+        Map<String, String> hits = new HashMap<>();
+        hits.put("doc1", longContent());
+
+        List<MLInput> inputs = transformer.createMLInputs(
+            limit,
+            "q",
+            new HashMap<>(),
+            hits,
+            "{{searchText}} {{hits}}",
+            LLMJudgmentRatingType.SCORE0_1
+        );
+
+        assertEquals(1, inputs.size());
+        int actual = TokenizerUtil.countTokens(messagesOf(inputs.get(0)));
+        assertTrue("wrapped payload (" + actual + ") must not exceed the token limit (" + limit + ")", actual <= limit);
+    }
+
+    public void testCreateMLInputs_oversizedHitAfterNormalHitIsStillTruncated() {
+        int limit = overheadTokens() + 40;
+        // LinkedHashMap forces the oversized hit to be processed after a normal one
+        Map<String, String> hits = new LinkedHashMap<>();
+        hits.put("normal", "short content");
+        hits.put("oversized", longContent());
+
+        List<MLInput> inputs = transformer.createMLInputs(
+            limit,
+            "q",
+            new HashMap<>(),
+            hits,
+            "{{searchText}} {{hits}}",
+            LLMJudgmentRatingType.SCORE0_1
+        );
+
+        for (MLInput input : inputs) {
+            int actual = TokenizerUtil.countTokens(messagesOf(input));
+            assertTrue("every chunk must stay within the limit, but one was " + actual, actual <= limit);
+        }
+        boolean marked = inputs.stream().anyMatch(input -> userPromptOf(input).contains("[content truncated]"));
+        assertTrue("oversized hit following a normal hit must still be truncated and marked", marked);
+    }
+
+    public void testCreateMLInputs_normalSizedHitIsNotMarked() {
+        Map<String, String> hits = new HashMap<>();
+        hits.put("doc1", "a perfectly reasonable short description");
+
+        List<MLInput> inputs = transformer.createMLInputs(
+            10000,
+            "q",
+            new HashMap<>(),
+            hits,
+            "{{searchText}} {{hits}}",
+            LLMJudgmentRatingType.SCORE0_1
+        );
+
+        assertEquals(1, inputs.size());
+        assertFalse("content that fits must not be marked truncated", userPromptOf(inputs.get(0)).contains("[content truncated]"));
+    }
+
+    public void testCreateMLInputs_tinyLimitStillProducesMarkedBestEffortChunk() {
+        Map<String, String> hits = new HashMap<>();
+        hits.put("doc1", longContent());
+        // limit far below the fixed wrapping overhead: cannot truly fit, but must still return a
+        // single best-effort chunk (marked), without looping forever or throwing
+        List<MLInput> inputs = transformer.createMLInputs(
+            5,
+            "q",
+            new HashMap<>(),
+            hits,
+            "{{searchText}} {{hits}}",
+            LLMJudgmentRatingType.SCORE0_1
+        );
+
+        assertEquals(1, inputs.size());
+        assertTrue("best-effort truncated chunk should still be marked", userPromptOf(inputs.get(0)).contains("[content truncated]"));
+    }
+
+    // fixed wrapping overhead (system prompt + JSON shell + template) measured on a tiny hit
+    private int overheadTokens() {
+        MLInput tiny = transformer.createMLInput(
+            "q",
+            new HashMap<>(),
+            Map.of("d", "x"),
+            "{{searchText}} {{hits}}",
+            LLMJudgmentRatingType.SCORE0_1
+        );
+        return TokenizerUtil.countTokens(messagesOf(tiny));
+    }
+
+    private static String longContent() {
+        StringBuilder big = new StringBuilder();
+        for (int i = 0; i < 1000; i++) {
+            big.append("very long descriptive token text ");
+        }
+        return big.toString();
+    }
+
+    private static String messagesOf(MLInput input) {
+        return ((RemoteInferenceInputDataSet) input.getInputDataset()).getParameters().get("messages");
+    }
+
+    private static String userPromptOf(MLInput input) {
+        return ((RemoteInferenceInputDataSet) input.getInputDataset()).getParameters().get("user_prompt");
     }
 
     private static MLOutput outputWithDataMap(Map<String, ?> dataMap) {

--- a/src/test/java/org/opensearch/searchrelevance/ml/TokenizerUtilTests.java
+++ b/src/test/java/org/opensearch/searchrelevance/ml/TokenizerUtilTests.java
@@ -44,4 +44,96 @@ public class TokenizerUtilTests extends OpenSearchTestCase {
         assertEquals("", TokenizerUtil.truncateString(input, 0));
     }
 
+    // ============================================
+    // Boundary-aware truncation tests
+    // ============================================
+
+    public void testTruncateAtBoundaryWithinLimitReturnsUnchanged() {
+        String input = "This is a short sentence.";
+        assertEquals(input, TokenizerUtil.truncateStringAtBoundary(input, 50));
+    }
+
+    public void testTruncateAtBoundaryNullOrEmpty() {
+        assertNull(TokenizerUtil.truncateStringAtBoundary(null, 5));
+        assertEquals("", TokenizerUtil.truncateStringAtBoundary("", 5));
+    }
+
+    public void testTruncateAtBoundaryZeroLimitReturnsEmpty() {
+        assertEquals("", TokenizerUtil.truncateStringAtBoundary("Any text here", 0));
+    }
+
+    public void testTruncateAtBoundaryFitsAndIsPrefix() {
+        String input = "The quick brown fox jumps over the lazy dog and then keeps on running down the road.";
+        int limit = 6;
+        String result = TokenizerUtil.truncateStringAtBoundary(input, limit);
+        assertTrue("result must be a prefix of the input", input.startsWith(result));
+        assertTrue("result must fit within the token budget", TokenizerUtil.countTokens(result) <= limit);
+        assertTrue("result should be shorter than input", result.length() < input.length());
+    }
+
+    public void testTruncateAtBoundaryDoesNotEndMidWord() {
+        String input = "The quick brown fox jumps over the lazy dog and then keeps on running down the road.";
+        String result = TokenizerUtil.truncateStringAtBoundary(input, 6);
+        // whitespace-separated input: cut must land on whitespace, not inside a word
+        char lastKept = result.charAt(result.length() - 1);
+        assertTrue("cut should land on a whitespace boundary but ended with '" + lastKept + "'", Character.isWhitespace(lastKept));
+    }
+
+    public void testTruncateAtBoundaryPrefersParagraphBreak() {
+        String first = "First paragraph has several words in it right here.";
+        String input = first
+            + "\n\n"
+            + "Second paragraph continues on well past the available token budget with many extra words that overflow.";
+        // only a couple tokens past the break, so it stays within the retention window
+        int limit = TokenizerUtil.countTokens(first + "\n\n") + 2;
+        String result = TokenizerUtil.truncateStringAtBoundary(input, limit);
+        assertTrue("should keep the paragraph break", result.contains("\n\n"));
+        assertFalse("should not leak second-paragraph words past the break", result.contains("continues"));
+    }
+
+    public void testTruncateAtBoundaryPrefersSentenceOverWord() {
+        String firstSentence = "Alpha beta gamma delta epsilon zeta eta theta.";
+        String input = firstSentence + " Second sentence has even more words that push well beyond the limit.";
+        int limit = TokenizerUtil.countTokens(firstSentence) + 2;
+        String result = TokenizerUtil.truncateStringAtBoundary(input, limit);
+        assertTrue("should keep the first sentence", result.contains("epsilon"));
+        assertFalse("should not leak second-sentence words", result.contains("Second"));
+    }
+
+    public void testTruncateAtBoundaryFallsBackToHardCutWithoutSeparators() {
+        // no separators to back up to, so it falls back to the hard token cut
+        String input = "x".repeat(2000);
+        int limit = 5;
+        String result = TokenizerUtil.truncateStringAtBoundary(input, limit);
+        assertEquals(TokenizerUtil.truncateString(input, limit), result);
+        assertTrue(TokenizerUtil.countTokens(result) <= limit);
+    }
+
+    public void testTruncateAtBoundaryFallsBackWhenOnlySeparatorIsTooEarly() {
+        // separators exist only at the very start; the retention guard rejects them, so it hard-cuts
+        String input = "hi.\n\n" + "x".repeat(2000);
+        int limit = 20;
+        String result = TokenizerUtil.truncateStringAtBoundary(input, limit);
+        assertTrue("result must be a prefix of the input", input.startsWith(result));
+        assertTrue("result must fit within the token budget", TokenizerUtil.countTokens(result) <= limit);
+        assertTrue("cut should fall through to the hard cut", result.endsWith("x"));
+    }
+
+    public void testTruncateAtBoundaryDoesNotProduceMalformedMultibyteText() {
+        // multi-byte content built from code points (CJK + emoji); a cut inside a byte sequence
+        // decodes to U+FFFD, which must be stripped
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < 200; i++) {
+            sb.appendCodePoint(0x4E00 + (i % 100)); // CJK Unified Ideographs block
+        }
+        sb.appendCodePoint(0x1F600); // grinning face emoji
+
+        String input = sb.toString();
+        int limit = 8;
+        String result = TokenizerUtil.truncateStringAtBoundary(input, limit);
+        assertTrue("result must not contain the Unicode replacement character", result.indexOf('\uFFFD') < 0);
+        assertTrue("result must be a prefix of the input", input.startsWith(result));
+        assertTrue("result must fit within the token budget", TokenizerUtil.countTokens(result) <= limit);
+    }
+
 }


### PR DESCRIPTION
### Description
When a single search hit is too large to fit the configured LLM token budget, it is truncated before being sent for judgment. Today the cut is a blind fixed-index token cut: it can land mid-word, mid-sentence, or inside the formatting that joins fields; nothing marks the content as truncated; and the size is estimated before JSON wrapping so the final payload can still exceed the limit.

This change makes oversized-hit truncation boundary-aware, marks truncated content, and verifies the result against the exact wrapped payload. **Every document that is sent today is still sent** — only how an oversized hit is cut changes.

### Changes
- **Boundary-aware cut (P1)** — new `TokenizerUtil.truncateStringAtBoundary` backs up from the hard token cut to the highest-priority separator that still retains most of the fitting window: paragraph → line → sentence → clause → word, falling back to the previous hard cut when none qualifies. A `MIN_RETENTION_RATIO` guard prevents dropping most of the content just to reach a coarser boundary. The original `truncateString` is kept as that hard-cut fallback.
- **Truncation marker (P2)** — a `TRUNCATION_MARKER` (`...[content truncated]`) is appended to content that was actually shortened, so the LLM knows the document is incomplete.
- **Re-measure against the real payload (P3)** — `handleOversizedEntry` reserves budget for the marker, then re-measures the exact JSON-wrapped `messages` form and shrinks in a bounded loop until it fits (also strips trailing `U+FFFD` produced when a cut lands inside a multi-byte CJK/emoji codepoint).
 - **Routing fix** — previously an oversized hit processed *after* a normal hit fell through a branch that emitted it untruncated and over budget; since `hits` iteration order is non-deterministic, the same hit could be truncated on one run and sent whole on another. `createMLInputs` now re-checks each entry on its own so a solo-oversized hit is always truncated regardless of position.

### Testing
 - New unit tests in `TokenizerUtilTests` (boundary selection, prefix/fit invariants, mid-word avoidance, paragraph/sentence preference, guard fall-through to hard cut, multi-byte/`U+FFFD` handling, empty/zero-limit edges) and `MLInputOutputTransformerTests` (marker present/absent, within-limit-after-wrapping, oversized-after-normal-hit ordering, tiny-limit best-effort).
 - `./gradlew spotlessJavaCheck forbiddenApisMain test` passes locally.

### Backward compatibility
No API request/response fields change; no judgment-cache behavior change. Public method signatures are unchanged (`truncateStringAtBoundary` is additive).

### Related Issue
#539

### Check List
  - [x] New functionality includes testing.
  - [x] New functionality has been documented / described in the PR.
  - [x] Commits are signed per the DCO using `--signoff`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
