### PR TITLE
Retry the search-config write in the restart-upgrade BWC test until the upgraded cluster settles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### Infrastructure
 - Stabilize flaky restart-upgrade BWC tests by waiting for a stable cluster-manager before cluster-state writes, raising the test cluster's fault-detection/publish tolerances so a transient node stall does not trigger re-election churn, and pinning the test cluster heap to a fixed `2g` per node ([#562](https://github.com/opensearch-project/search-relevance/pull/562))
+- Retry the search-config write in the restart-upgrade BWC test until the upgraded cluster settles, so a transient cluster-manager re-election does not fail the mapping migration assertion ([#564](https://github.com/opensearch-project/search-relevance/pull/564))
 
 ### Documentation
 

--- a/qa/restart-upgrade/src/test/java/org/opensearch/searchrelevance/bwc/restart/SearchConfigMappingRestartIT.java
+++ b/qa/restart-upgrade/src/test/java/org/opensearch/searchrelevance/bwc/restart/SearchConfigMappingRestartIT.java
@@ -8,6 +8,7 @@
 package org.opensearch.searchrelevance.bwc.restart;
 
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 import org.opensearch.client.Request;
 import org.opensearch.client.Response;
@@ -66,29 +67,46 @@ public class SearchConfigMappingRestartIT extends AbstractSearchRelevanceRestart
             IndexMappingTestHelper.createIndexWithMapping(client(), TARGET_INDEX, "{\"properties\": {}}", logger);
         }
 
-        // Create via plugin API — triggers auto-migration
-        Request request = new Request("PUT", SEARCH_CONFIG_ENDPOINT);
-        request.setJsonEntity(
-            "{"
-                + "\"name\": \"bwc-restart-config\","
-                + "\"description\": \"Created after restart to test auto-migration\","
-                + "\"index\": \""
-                + TARGET_INDEX
-                + "\","
-                + "\"query\": \"{\\\"match_all\\\": {}}\""
-                + "}"
-        );
+        // Create via plugin API — triggers auto-migration of the search-config index mapping.
+        //
+        // The migration is a cluster-state change and needs a stable cluster-manager to durably
+        // commit. On resource-constrained CI runners the upgraded cluster can still be re-electing a
+        // cluster-manager when the write lands, so a single attempt may fail (HTTP 500) or silently
+        // no-op the migration (schema_version stays 0). Each request generates a fresh config id, so
+        // re-issuing the PUT is safe; retry until the cluster is stable enough for one attempt to
+        // durably commit the migration.
+        String requestBody = "{"
+            + "\"name\": \"bwc-restart-config\","
+            + "\"description\": \"Created after restart to test auto-migration\","
+            + "\"index\": \""
+            + TARGET_INDEX
+            + "\","
+            + "\"query\": \"{\\\"match_all\\\": {}}\""
+            + "}";
 
-        Response response = client().performRequest(request);
-        assertEquals("Plugin API should succeed after auto-migration", 200, response.getStatusLine().getStatusCode());
+        assertBusy(() -> {
+            try {
+                Request request = new Request("PUT", SEARCH_CONFIG_ENDPOINT);
+                request.setJsonEntity(requestBody);
+                Response response = client().performRequest(request);
+                assertEquals("Plugin API should succeed after auto-migration", 200, response.getStatusLine().getStatusCode());
 
-        // Verify mapping updated
-        Map<String, Object> mapping = IndexMappingTestHelper.getIndexMapping(client(), SEARCH_CONFIG_INDEX);
-        Map<String, Object> properties = IndexMappingTestHelper.getMappingProperties(mapping);
-        assertTrue("Mapping should have description field", properties.containsKey("description"));
+                Map<String, Object> mapping = IndexMappingTestHelper.getIndexMapping(client(), SEARCH_CONFIG_INDEX);
+                Map<String, Object> properties = IndexMappingTestHelper.getMappingProperties(mapping);
+                assertNotNull("Mapping properties should be present", properties);
+                assertTrue("Mapping should have description field", properties.containsKey("description"));
 
-        Map<String, Object> meta = IndexMappingTestHelper.getMappingMeta(mapping);
-        assertEquals("Schema version should be 1", 1, ((Number) meta.get("schema_version")).intValue());
+                Map<String, Object> meta = IndexMappingTestHelper.getMappingMeta(mapping);
+                assertNotNull("Mapping _meta should be present", meta);
+                assertNotNull("schema_version should be present", meta.get("schema_version"));
+                assertEquals("Schema version should be 1", 1, ((Number) meta.get("schema_version")).intValue());
+            } catch (Exception e) {
+                // Transient failure while the cluster settles (e.g. cluster_manager_not_discovered).
+                // Rethrow as AssertionError so assertBusy retries; genuine assertion failures above
+                // are AssertionErrors and propagate/retry the same way.
+                throw new AssertionError("search-config migration not committed yet while cluster settles: " + e.getMessage(), e);
+            }
+        }, 3, TimeUnit.MINUTES);
 
         // Old data still accessible
         oldDoc = IndexMappingTestHelper.getDocument(client(), SEARCH_CONFIG_INDEX, TEST_DOC_ID, logger);


### PR DESCRIPTION
### Description

Follow-up to #562. The restart-upgrade BWC test `SearchConfigMappingRestartIT` is still intermittently failing (e.g. the `3.3.0` cell), most visibly as `AssertionError: Schema version should be 1 but was 0`, and sometimes as a `500` (`cluster_manager_not_discovered`) on `PUT /_plugins/_search_relevance/search_configurations`.

**Root cause:** it is not a plugin or test-logic bug — it is resource contention on the CI runner. GitHub-hosted `ubuntu-latest` (4 vCPU) runs 3 OpenSearch nodes + Gradle + the test JVM. After the full restart the cluster forms, but under the test's write/shard-reroute load a node stalls, misses its follower-check, and the cluster-manager loses quorum and re-elects. The search-config mapping migration is a cluster-state change that needs a stable cluster-manager to durably commit; if the single `PUT` lands during that churn, the migration either fails (500) or is silently skipped (`schema_version` stays 0).

#562 added a stable-cluster-manager readiness gate and raised the cluster's fault-detection tolerances, which reduced the flakiness but did not eliminate it: the cluster can re-destabilize *after* the gate passes, once the write load hits it.

**This change** makes the test tolerate that transient re-election. Since each `PUT` generates a fresh config id, re-issuing it is safe, so the write + mapping assertion are wrapped in `assertBusy(..., 3, TimeUnit.MINUTES)`: transient failures (500 / `cluster_manager_not_discovered`) are retried until the cluster settles enough for one attempt to durably commit the migration and `schema_version` becomes `1`. No production code and no build config is touched — this is a test-only resilience change.

### Related Issues
Relates to [#561](https://github.com/opensearch-project/search-relevance/issues/561), follow-up to #562

### Check List
- [x] Commits are signed per the DCO using `--signoff`.
- [ ] Public documentation issue/PR created, if applicable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
