### PR TITLE
Exclude vector fields from LLM judgment prompts when contextFields is unset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Add retry endpoint for failed LLM judgments, existingJudgments parameter for rating reuse, and remove broken global cache ([#525](https://github.com/opensearch-project/search-relevance/issues/525))
 
 ### Bug Fixes
-- Exclude vector fields (`knn_vector`, `rank_features`, `sparse_vector`) from LLM judgment prompts when `contextFields` is not specified ([#XXX](https://github.com/opensearch-project/search-relevance/pull/XXX))
+- Exclude vector fields (`knn_vector`, `rank_features`, `sparse_vector`) from LLM judgment prompts when `contextFields` is not specified ([#565](https://github.com/opensearch-project/search-relevance/pull/565))
 - Return correct delete REST status codes and honor querySetSize for sampling ([#542](https://github.com/opensearch-project/search-relevance/pull/542))
 - Fix transport-thread blocking in experiment run and query set sampling, and notify listener on protected-index creation failure ([#559](https://github.com/opensearch-project/search-relevance/pull/559))
 - Report an invalid UBI events index as a `400` naming the index and the `ubiEventsIndex` parameter instead of a `500` ([#558](https://github.com/opensearch-project/search-relevance/pull/558))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Inspired from [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 - Add retry endpoint for failed LLM judgments, existingJudgments parameter for rating reuse, and remove broken global cache ([#525](https://github.com/opensearch-project/search-relevance/issues/525))
 
 ### Bug Fixes
+- Exclude vector fields (`knn_vector`, `rank_features`, `sparse_vector`) from LLM judgment prompts when `contextFields` is not specified ([#XXX](https://github.com/opensearch-project/search-relevance/pull/XXX))
 - Return correct delete REST status codes and honor querySetSize for sampling ([#542](https://github.com/opensearch-project/search-relevance/pull/542))
 - Fix transport-thread blocking in experiment run and query set sampling, and notify listener on protected-index creation failure ([#559](https://github.com/opensearch-project/search-relevance/pull/559))
 - Report an invalid UBI events index as a `400` naming the index and the `ubiEventsIndex` parameter instead of a `500` ([#558](https://github.com/opensearch-project/search-relevance/pull/558))

--- a/src/main/java/org/opensearch/searchrelevance/judgments/JudgmentsProcessorFactory.java
+++ b/src/main/java/org/opensearch/searchrelevance/judgments/JudgmentsProcessorFactory.java
@@ -7,6 +7,7 @@
  */
 package org.opensearch.searchrelevance.judgments;
 
+import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.inject.Inject;
 import org.opensearch.searchrelevance.dao.JudgmentDao;
 import org.opensearch.searchrelevance.dao.QuerySetDao;
@@ -22,6 +23,7 @@ public class JudgmentsProcessorFactory {
     private final SearchConfigurationDao searchConfigurationDao;
     private final JudgmentDao judgmentDao;
     private final Client client;
+    private final ClusterService clusterService;
     private final ThreadPool threadPool;
 
     @Inject
@@ -31,6 +33,7 @@ public class JudgmentsProcessorFactory {
         SearchConfigurationDao searchConfigurationDao,
         JudgmentDao judgmentDao,
         Client client,
+        ClusterService clusterService,
         ThreadPool threadPool
     ) {
         this.mlAccessor = mlAccessor;
@@ -38,6 +41,7 @@ public class JudgmentsProcessorFactory {
         this.searchConfigurationDao = searchConfigurationDao;
         this.judgmentDao = judgmentDao;
         this.client = client;
+        this.clusterService = clusterService;
         this.threadPool = threadPool;
     }
 
@@ -49,6 +53,7 @@ public class JudgmentsProcessorFactory {
                 searchConfigurationDao,
                 judgmentDao,
                 client,
+                clusterService,
                 threadPool
             );
             case UBI_JUDGMENT -> new UbiJudgmentsProcessor(client);

--- a/src/main/java/org/opensearch/searchrelevance/judgments/LlmJudgmentsProcessor.java
+++ b/src/main/java/org/opensearch/searchrelevance/judgments/LlmJudgmentsProcessor.java
@@ -37,6 +37,9 @@ import org.opensearch.action.get.MultiGetResponse;
 import org.opensearch.action.search.SearchRequest;
 import org.opensearch.action.search.SearchResponse;
 import org.opensearch.action.support.PlainActionFuture;
+import org.opensearch.cluster.metadata.IndexMetadata;
+import org.opensearch.cluster.metadata.MappingMetadata;
+import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.inject.Inject;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.rest.RestStatus;
@@ -78,8 +81,12 @@ public class LlmJudgmentsProcessor implements BaseJudgmentsProcessor {
     private final SearchConfigurationDao searchConfigurationDao;
     private final JudgmentDao judgmentDao;
     private final Client client;
+    private final ClusterService clusterService;
     private final ThreadPool threadPool;
     private final LlmJudgmentTaskManager taskManager;
+
+    // Field types whose _source values are embeddings; dropped from the LLM prompt when contextFields is not set.
+    private static final Set<String> VECTOR_FIELD_TYPES = Set.of("knn_vector", "rank_features", "sparse_vector");
 
     @Inject
     public LlmJudgmentsProcessor(
@@ -88,6 +95,7 @@ public class LlmJudgmentsProcessor implements BaseJudgmentsProcessor {
         SearchConfigurationDao searchConfigurationDao,
         JudgmentDao judgmentDao,
         Client client,
+        ClusterService clusterService,
         ThreadPool threadPool
     ) {
         this.mlAccessor = mlAccessor;
@@ -95,6 +103,7 @@ public class LlmJudgmentsProcessor implements BaseJudgmentsProcessor {
         this.searchConfigurationDao = searchConfigurationDao;
         this.judgmentDao = judgmentDao;
         this.client = client;
+        this.clusterService = clusterService;
         this.threadPool = threadPool;
         this.taskManager = new LlmJudgmentTaskManager(threadPool);
     }
@@ -205,6 +214,8 @@ public class LlmJudgmentsProcessor implements BaseJudgmentsProcessor {
             // from the judgment's own metadata — same parsing used by the initial generation.
             ScoringConfig config = new ScoringConfig(metadata, searchConfigurationDao);
             String index = config.index;
+            // Resolve the vector fields to drop from the prompt once for the whole retry.
+            Set<String> excludedVectorFields = resolveExcludedVectorFields(index);
             List<Map<String, Object>> results = new ArrayList<>();
 
             // Pass 1: fetch every failed doc up front and detect any that no longer exist. If a
@@ -272,7 +283,8 @@ public class LlmJudgmentsProcessor implements BaseJudgmentsProcessor {
                     index,
                     docIdToScore,
                     config.promptTemplate,
-                    config.ratingType
+                    config.ratingType,
+                    excludedVectorFields
                 );
 
                 // Build result: use queryTextWithCustomInput as the key so it matches the original judgment
@@ -414,6 +426,9 @@ public class LlmJudgmentsProcessor implements BaseJudgmentsProcessor {
 
         log.info("Starting LLM judgment generation for {} total queries", totalQueries);
 
+        // Resolve the vector fields to drop from the prompt once for the whole run.
+        Set<String> excludedVectorFields = resolveExcludedVectorFields(searchConfigurations.get(0).index());
+
         taskManager.scheduleTasksAsync(querySetEntries, querySetEntry -> {
             try {
                 return processQueryTextAsync(
@@ -426,7 +441,8 @@ public class LlmJudgmentsProcessor implements BaseJudgmentsProcessor {
                     ignoreFailure,
                     promptTemplate,
                     ratingType,
-                    existingRatingsByQuery
+                    existingRatingsByQuery,
+                    excludedVectorFields
                 );
             } catch (Exception e) {
                 if (ignoreFailure) {
@@ -490,7 +506,8 @@ public class LlmJudgmentsProcessor implements BaseJudgmentsProcessor {
         boolean ignoreFailure,
         String promptTemplate,
         LLMJudgmentRatingType ratingType,
-        Map<String, Map<String, String>> existingRatingsByQuery
+        Map<String, Map<String, String>> existingRatingsByQuery,
+        Set<String> excludedVectorFields
     ) {
         String queryText = querySetEntry.queryText();
         Map<String, String> customFields = querySetEntry.customFields();
@@ -538,7 +555,8 @@ public class LlmJudgmentsProcessor implements BaseJudgmentsProcessor {
                     index,
                     docIdToScore,
                     promptTemplate,
-                    ratingType
+                    ratingType,
+                    excludedVectorFields
                 );
             }
 
@@ -668,7 +686,8 @@ public class LlmJudgmentsProcessor implements BaseJudgmentsProcessor {
         String index,
         ConcurrentMap<String, String> docIdToScore,
         String promptTemplate,
-        LLMJudgmentRatingType ratingType
+        LLMJudgmentRatingType ratingType,
+        Set<String> excludedVectorFields
     ) throws Exception {
         Map<String, String> unionHits = new HashMap<>();
 
@@ -676,7 +695,7 @@ public class LlmJudgmentsProcessor implements BaseJudgmentsProcessor {
         for (String docId : unprocessedDocIds) {
             SearchHit hit = allHits.get(docId);
             String compositeKey = combinedIndexAndDocId(index, docId);
-            String contextSource = getContextSource(hit, contextFields);
+            String contextSource = getContextSource(hit, contextFields, excludedVectorFields);
             unionHits.put(compositeKey, contextSource);
         }
 
@@ -855,7 +874,7 @@ public class LlmJudgmentsProcessor implements BaseJudgmentsProcessor {
         chunkResult.getFailedChunks().forEach((index, error) -> log.warn("Chunk {} failed: {}", index, error));
     }
 
-    private String getContextSource(SearchHit hit, List<String> contextFields) {
+    String getContextSource(SearchHit hit, List<String> contextFields, Set<String> excludedVectorFields) {
         try {
             if (contextFields != null && !contextFields.isEmpty()) {
                 Map<String, Object> filteredSource = new HashMap<>();
@@ -868,12 +887,77 @@ public class LlmJudgmentsProcessor implements BaseJudgmentsProcessor {
                 }
                 return OBJECT_MAPPER.writeValueAsString(filteredSource);
             }
-            return hit.getSourceAsString();
+
+            // Send the full _source minus any vector fields resolved from the mapping. When none were
+            // resolved (no vector fields, or the mapping could not be read), send _source unchanged.
+            if (excludedVectorFields.isEmpty()) {
+                return hit.getSourceAsString();
+            }
+            return OBJECT_MAPPER.writeValueAsString(removeFieldsByName(hit.getSourceAsMap(), excludedVectorFields));
 
         } catch (JacksonException e) {
             log.error("Failed to process context source for hit: {}", hit.getId(), e);
             throw new RuntimeException("Failed to process context source", e);
         }
+    }
+
+    /**
+     * Returns the names of the index's vector fields (knn_vector, rank_features and sparse_vector),
+     * descending into nested objects. The mapping is read from the node's local cluster state, so
+     * there is no network call. When the mapping cannot be read the result is an empty set, which
+     * makes the caller send the full document source unchanged. Package-private so the test in the
+     * same package can exercise it directly without widening the class's public surface.
+     */
+    @SuppressWarnings("unchecked")
+    Set<String> resolveExcludedVectorFields(String index) {
+        Set<String> vectorFields = new HashSet<>();
+        try {
+            IndexMetadata indexMetadata = clusterService.state().metadata().index(index);
+            MappingMetadata mappingMetadata = indexMetadata != null ? indexMetadata.mapping() : null;
+            Map<String, Object> mappingSource = mappingMetadata != null ? mappingMetadata.sourceAsMap() : null;
+            Object properties = mappingSource != null ? mappingSource.get("properties") : null;
+            if (properties instanceof Map) {
+                collectVectorFields((Map<String, Object>) properties, vectorFields);
+            }
+        } catch (Exception e) {
+            log.warn("Could not read mapping for index [{}]; sending full _source to the LLM", index, e);
+        }
+        return vectorFields;
+    }
+
+    @SuppressWarnings("unchecked")
+    private void collectVectorFields(Map<String, Object> properties, Set<String> out) {
+        for (Map.Entry<String, Object> entry : properties.entrySet()) {
+            if (!(entry.getValue() instanceof Map)) {
+                continue;
+            }
+            Map<String, Object> fieldDef = (Map<String, Object>) entry.getValue();
+            Object type = fieldDef.get("type");
+            if (type instanceof String && VECTOR_FIELD_TYPES.contains(type)) {
+                out.add(entry.getKey());
+            }
+            Object nested = fieldDef.get("properties");
+            if (nested instanceof Map) {
+                collectVectorFields((Map<String, Object>) nested, out);
+            }
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private Map<String, Object> removeFieldsByName(Map<String, Object> source, Set<String> namesToRemove) {
+        Map<String, Object> result = new LinkedHashMap<>();
+        for (Map.Entry<String, Object> entry : source.entrySet()) {
+            if (namesToRemove.contains(entry.getKey())) {
+                continue;
+            }
+            Object value = entry.getValue();
+            if (value instanceof Map) {
+                result.put(entry.getKey(), removeFieldsByName((Map<String, Object>) value, namesToRemove));
+            } else {
+                result.put(entry.getKey(), value);
+            }
+        }
+        return result;
     }
 
 }

--- a/src/test/java/org/opensearch/searchrelevance/judgments/ExistingJudgmentsDeduplicationTests.java
+++ b/src/test/java/org/opensearch/searchrelevance/judgments/ExistingJudgmentsDeduplicationTests.java
@@ -19,6 +19,7 @@ import org.junit.Before;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.opensearch.action.search.SearchResponse;
+import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.xcontent.XContentFactory;
 import org.opensearch.core.common.bytes.BytesReference;
 import org.opensearch.core.xcontent.XContentBuilder;
@@ -51,6 +52,8 @@ public class ExistingJudgmentsDeduplicationTests extends OpenSearchTestCase {
     @Mock
     private Client client;
     @Mock
+    private ClusterService clusterService;
+    @Mock
     private ThreadPool threadPool;
 
     private LlmJudgmentsProcessor processor;
@@ -64,7 +67,15 @@ public class ExistingJudgmentsDeduplicationTests extends OpenSearchTestCase {
             ((Runnable) invocation.getArgument(0)).run();
             return null;
         }).when(directExecutor).execute(org.mockito.ArgumentMatchers.any(Runnable.class));
-        processor = new LlmJudgmentsProcessor(mlAccessor, querySetDao, searchConfigurationDao, judgmentDao, client, threadPool);
+        processor = new LlmJudgmentsProcessor(
+            mlAccessor,
+            querySetDao,
+            searchConfigurationDao,
+            judgmentDao,
+            client,
+            clusterService,
+            threadPool
+        );
     }
 
     public void testFetchRatingsForQuery_JudgmentNotFound() {

--- a/src/test/java/org/opensearch/searchrelevance/judgments/LlmJudgmentsProcessorTests.java
+++ b/src/test/java/org/opensearch/searchrelevance/judgments/LlmJudgmentsProcessorTests.java
@@ -7,6 +7,7 @@
  */
 package org.opensearch.searchrelevance.judgments;
 
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import java.util.HashMap;
@@ -18,6 +19,13 @@ import java.util.concurrent.TimeUnit;
 import org.junit.Before;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+import org.opensearch.cluster.ClusterState;
+import org.opensearch.cluster.metadata.IndexMetadata;
+import org.opensearch.cluster.metadata.MappingMetadata;
+import org.opensearch.cluster.metadata.Metadata;
+import org.opensearch.cluster.service.ClusterService;
+import org.opensearch.core.common.bytes.BytesArray;
+import org.opensearch.search.SearchHit;
 import org.opensearch.searchrelevance.dao.JudgmentDao;
 import org.opensearch.searchrelevance.dao.QuerySetDao;
 import org.opensearch.searchrelevance.dao.SearchConfigurationDao;
@@ -55,6 +63,9 @@ public class LlmJudgmentsProcessorTests extends OpenSearchTestCase {
     private Client mockClient;
 
     @Mock
+    private ClusterService mockClusterService;
+
+    @Mock
     private SearchRelevanceSettingsAccessor mockSettingsAccessor;
 
     private EventStatsManager eventStatsManager;
@@ -80,6 +91,7 @@ public class LlmJudgmentsProcessorTests extends OpenSearchTestCase {
             mockSearchConfigurationDao,
             mockJudgmentDao,
             mockClient,
+            mockClusterService,
             threadPool
         );
     }
@@ -240,8 +252,113 @@ public class LlmJudgmentsProcessorTests extends OpenSearchTestCase {
     }
 
     // ============================================
+    // getContextSource — vector field exclusion
+    // ============================================
+
+    public void testGetContextSource_contextFieldsSpecified_sendsOnlyNamedFieldsIncludingVector() {
+        SearchHit hit = hit("{\"title\":\"Laptop\",\"embedding\":[0.1,0.2,0.3],\"category\":\"tech\"}");
+
+        // Explicit opt-in: a vector field named in contextFields is still sent; unnamed fields are not.
+        String out = processor.getContextSource(hit, List.of("title", "embedding"), Set.of("embedding"));
+
+        assertTrue(out.contains("title"));
+        assertTrue("explicitly named vector field must be sent", out.contains("embedding"));
+        assertFalse("field not named in contextFields must not be sent", out.contains("category"));
+    }
+
+    public void testGetContextSource_defaultPath_dropsMappedVectorField() {
+        SearchHit hit = hit("{\"title\":\"Laptop\",\"embedding\":[0.1,0.2,0.3],\"category\":\"tech\"}");
+
+        String out = processor.getContextSource(hit, null, Set.of("embedding"));
+
+        assertTrue(out.contains("title"));
+        assertTrue(out.contains("category"));
+        assertFalse("mapped vector field must be dropped from the default prompt", out.contains("embedding"));
+    }
+
+    public void testGetContextSource_defaultPath_noVectorFields_keepsEverything() {
+        SearchHit hit = hit("{\"title\":\"Laptop\",\"category\":\"tech\"}");
+
+        String out = processor.getContextSource(hit, null, Set.of());
+
+        assertTrue(out.contains("title"));
+        assertTrue(out.contains("category"));
+    }
+
+    public void testGetContextSource_defaultPath_dropsNestedVectorKeepsSiblings() {
+        SearchHit hit = hit("{\"title\":\"Laptop\",\"nested\":{\"passage_embedding\":[0.1,0.2],\"text\":\"body\"}}");
+
+        String out = processor.getContextSource(hit, null, Set.of("passage_embedding"));
+
+        assertTrue(out.contains("title"));
+        assertTrue("sibling of a nested vector field must survive", out.contains("body"));
+        assertFalse("nested vector field must be dropped", out.contains("passage_embedding"));
+    }
+
+    public void testGetContextSource_defaultPath_emptyExcluded_sendsFullSourceIncludingVector() {
+        SearchHit hit = hit("{\"title\":\"Laptop\",\"embedding\":[0.1,0.2,0.3]}");
+
+        // Empty set: no vector fields resolved (or mapping unreadable) => send _source unchanged.
+        String out = processor.getContextSource(hit, null, Set.of());
+
+        assertTrue(out.contains("title"));
+        assertTrue(out.contains("embedding"));
+    }
+
+    // ============================================
+    // resolveExcludedVectorFields — mapping walk
+    // ============================================
+
+    public void testResolveExcludedVectorFields_collectsVectorTypesIncludingNested() {
+        Map<String, Object> props = new HashMap<>();
+        props.put("title", Map.of("type", "text"));
+        props.put("embedding", Map.of("type", "knn_vector", "dimension", 768));
+        props.put("tokens", Map.of("type", "rank_features"));
+        Map<String, Object> nested = new HashMap<>();
+        nested.put("properties", Map.of("passage_embedding", Map.of("type", "knn_vector")));
+        props.put("nested", nested);
+        Map<String, Object> mappingSource = new HashMap<>();
+        mappingSource.put("properties", props);
+        mockMapping("products", mappingSource);
+
+        Set<String> excluded = processor.resolveExcludedVectorFields("products");
+
+        assertNotNull(excluded);
+        assertTrue(excluded.contains("embedding"));
+        assertTrue(excluded.contains("tokens"));
+        assertTrue("nested vector field must be collected", excluded.contains("passage_embedding"));
+        assertFalse(excluded.contains("title"));
+    }
+
+    public void testResolveExcludedVectorFields_missingIndex_returnsEmpty() {
+        ClusterState state = mock(ClusterState.class);
+        Metadata md = mock(Metadata.class);
+        when(mockClusterService.state()).thenReturn(state);
+        when(state.metadata()).thenReturn(md);
+        when(md.index("missing")).thenReturn(null);
+
+        assertTrue("unreadable mapping => empty set => full _source is sent", processor.resolveExcludedVectorFields("missing").isEmpty());
+    }
+
+    // ============================================
     // Helper Methods
     // ============================================
+
+    private static SearchHit hit(String sourceJson) {
+        return new SearchHit(1, "doc1", Map.of(), Map.of()).sourceRef(new BytesArray(sourceJson));
+    }
+
+    private void mockMapping(String index, Map<String, Object> mappingSource) {
+        ClusterState state = mock(ClusterState.class);
+        Metadata md = mock(Metadata.class);
+        IndexMetadata im = mock(IndexMetadata.class);
+        MappingMetadata mm = mock(MappingMetadata.class);
+        when(mockClusterService.state()).thenReturn(state);
+        when(state.metadata()).thenReturn(md);
+        when(md.index(index)).thenReturn(im);
+        when(im.mapping()).thenReturn(mm);
+        when(mm.sourceAsMap()).thenReturn(mappingSource);
+    }
 
     private Map<String, Object> createBasicMetadata() {
         Map<String, Object> metadata = new HashMap<>();


### PR DESCRIPTION
### Description

When `contextFields` is not specified on `PUT /_plugins/_search_relevance/judgments`, the plugin sent the entire document `_source` to the LLM. On a vector-enabled index that `_source` includes the embeddings, so vector values were sent as the document content to be judged. At 768 dimensions a single document exceeds the default 4000-token budget on its own — every document hits the truncation path, truncation can drop all the text and keep only floats, batching stops working, and ~99% of billed tokens carry no relevance signal.

This change resolves the index's vector fields (`knn_vector`, `rank_features`, `sparse_vector`) from the mapping and drops them from the default prompt content. Naming a field in `contextFields` is unchanged, so a document's embedding can still be sent by listing the field.

### Summary of changes

- `LlmJudgmentsProcessor`
  - Inject `ClusterService`; add `VECTOR_FIELD_TYPES = {knn_vector, rank_features, sparse_vector}`.
  - `resolveExcludedVectorFields(index)` reads the mapping from the node's local cluster state and walks `properties` (recursing into nested objects) to collect vector field names. Resolved **once per judgment run**, then threaded down to `getContextSource`.
  - `getContextSource` default path now returns `_source` minus the resolved vector fields (`removeFieldsByName`, recursive so a nested vector is dropped without dropping its siblings). When nothing is resolved — no vector fields, or the mapping could not be read — the full `_source` is sent unchanged.
  - The `contextFields`-specified path is untouched.
- `JudgmentsProcessorFactory`: pass `ClusterService` into the processor. No plugin wiring change (Guice injects `ClusterService`).

### Behavior matrix

Behavior is decided in two steps: first whether `contextFields` is set, then whether the document
has a vector field. The last column marks the rows this PR actually changes; every other row keeps
its existing behavior.

**`contextFields` is set** — the listed fields are sent, exactly as before:

| Example | `contextFields` | Content sent to the LLM | Change |
|---|---|---|---|
| `{"title":"Mouse","color":"black","embedding":[0.1,...]}` | `["title","color"]` | `{"title":"Mouse","color":"black"}` | unchanged |
| `{"title":"Mouse","color":"black","embedding":[0.1,...]}` | `["title","embedding"]` | `{"title":"Mouse","embedding":[0.1,...]}` | unchanged — a listed vector field is still sent |

**`contextFields` is not set** — previously the whole document was sent, including any vector. Now:

| Example | Document has a vector field? | Before this PR | After this PR | Change |
|---|---|---|---|---|
| `{"title":"Mouse","color":"black"}` | no | `{"title":"Mouse","color":"black"}` | same | unchanged |
| `{"title":"Mouse","embedding":[0.1,...]}` | yes | `{"title":"Mouse","embedding":[0.1,...]}` | `{"title":"Mouse"}` | **fixed — vector removed** |
| `{"title":"Mouse","spec":{"text":"wireless","embedding":[0.1,...]}}` | yes, nested in an object | `{"title":"Mouse","spec":{"text":"wireless","embedding":[0.1,...]}}` | `{"title":"Mouse","spec":{"text":"wireless"}}` | **fixed — nested vector removed, `spec.text` kept** |
| `{"title":"Mouse","embedding":[0.1,...]}` | yes, but the mapping cannot be read | `{"title":"Mouse","embedding":[0.1,...]}` | same | unchanged — nothing is guessed when the mapping is unavailable |

Vector fields are identified by their mapping `type`: `knn_vector` (dense), and `rank_features` /
`sparse_vector` (neural sparse). The mapping is read once per judgment run from the node's local
cluster state, and nested objects are walked recursively.

### End-to-end verification on a real cluster

The three "fixed" rows above were confirmed on a live cluster running `opensearch-knn`,
`neural-search`, `ml-commons` and `search-relevance`. For each vector shape, a document was indexed
and searched with `contextFields` not set; a default search returns the vector inside `_source`
(the "before" content that is sent to the LLM today). The production code was then run on the
`_source` taken directly from the cluster to produce the "after" content.

**1. A numeric vector field (`knn_vector`)**

```
before   {"title":"Apple MacBook Pro 14-inch","description":"M3 laptop with Liquid Retina XDR display","category":"laptops","embedding":[0.12,-0.98,0.44,0.31]}
after    {"title":"Apple MacBook Pro 14-inch","description":"M3 laptop with Liquid Retina XDR display","category":"laptops"}
```

**2. A neural-sparse field (`rank_features`)**

```
before   {"title":"Wireless Mouse","sparse_embedding":{"mouse":2.1,"wireless":1.7,"usb":0.4}}
after    {"title":"Wireless Mouse"}
```

**3. A vector nested inside an object**

```
before   {"title":"Standing Desk","passage":{"text":"adjustable height electric desk","passage_embedding":[0.5,0.1,0.9]}}
after    {"title":"Standing Desk","passage":{"text":"adjustable height electric desk"}}
```

The nested case keeps `passage.text` and drops only `passage.passage_embedding`, confirming the
mapping walk removes the vector without discarding the useful text beside it.

### Testing

- `./gradlew check` passes (unit tests, `integTest` + `yamlRestTest` on a real cluster, spotless, forbiddenApis, jacoco).
- Added unit tests in `LlmJudgmentsProcessorTests` covering: `contextFields` opt-in (vector kept), default path drops a mapped vector, no-vector index unchanged, nested vector dropped with siblings kept, empty/unreadable mapping sends full `_source`, and the mapping walk collecting nested vector types.

### Related Issue
#541 

### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented. <!-- docs-website update to follow separately -->
- [x] Commits are signed per the DCO using `--signoff`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
