### PR TITLE
[Backport 3.8] Bump 1password/load-secrets-action to v5.0.1 (search-relevance)

### DIFF
--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -25,7 +25,7 @@ jobs:
           java-version: 21
 
       - name: Load secret
-        uses: 1password/load-secrets-action@3a12b0ab99d9cd590a3e9b5a90ea017210ed9556 # v4
+        uses: 1password/load-secrets-action@70062d7a876d3eb6334754fa26efd2fbd90c32f2 # v5.0.1
         with:
           # Export loaded secrets as environment variables
           export-env: true


### PR DESCRIPTION
Backport of #568 to \`3.8\`.

Bump \`1password/load-secrets-action\` to v5.0.1 (pinned to commit \`70062d7a876d3eb6334754fa26efd2fbd90c32f2\`).

The automated backport failed due to a merge conflict (the \`3.8\` branch was on v4); resolved manually.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
