### PR TITLE
Add SPDX license header checker and missing headers

### DIFF
--- a/.github/workflows/license-header-checker.yml
+++ b/.github/workflows/license-header-checker.yml
@@ -1,0 +1,12 @@
+---
+name: License Header Checker
+
+on: [push, pull_request]
+
+jobs:
+  license-header-checker:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - name: Add License Header
+        run: npx @kt3k/license-checker

--- a/.github/workflows/license-header-checker.yml
+++ b/.github/workflows/license-header-checker.yml
@@ -9,4 +9,4 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Add License Header
-        run: npx @kt3k/license-checker
+        run: npx @kt3k/license-checker@3.2.2

--- a/.licenserc.json
+++ b/.licenserc.json
@@ -1,0 +1,38 @@
+{
+  "**/*.*": [
+    " Copyright OpenSearch Contributors",
+    " SPDX-License-Identifier: Apache-2.0"
+  ],
+  "ignore": [
+    ".md",
+    ".json",
+    ".yml",
+    ".yaml",
+    ".txt",
+    ".xml",
+    ".config",
+    ".png",
+    ".jar",
+    ".gz",
+    ".zip",
+    ".ndjson",
+    ".lock",
+    ".toml",
+    ".ini",
+    ".bat",
+    ".properties",
+    ".policy",
+    ".git",
+    ".gitignore",
+    ".whitesource",
+    ".gradle",
+    "gradle/wrapper",
+    "settings.gradle",
+    "**/build/",
+    "licenses/",
+    "src/test/resources/",
+    "**/test/resources/",
+    "LICENSE",
+    "NOTICE"
+  ]
+}

--- a/qa/restart-upgrade/src/test/java/org/opensearch/searchrelevance/bwc/restart/AbstractSearchRelevanceRestartUpgradeTestCase.java
+++ b/qa/restart-upgrade/src/test/java/org/opensearch/searchrelevance/bwc/restart/AbstractSearchRelevanceRestartUpgradeTestCase.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/qa/restart-upgrade/src/test/java/org/opensearch/searchrelevance/bwc/restart/IndexMappingRestartIT.java
+++ b/qa/restart-upgrade/src/test/java/org/opensearch/searchrelevance/bwc/restart/IndexMappingRestartIT.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/qa/restart-upgrade/src/test/java/org/opensearch/searchrelevance/bwc/restart/SearchConfigMappingRestartIT.java
+++ b/qa/restart-upgrade/src/test/java/org/opensearch/searchrelevance/bwc/restart/SearchConfigMappingRestartIT.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/qa/rolling-upgrade/src/test/java/org/opensearch/searchrelevance/bwc/rolling/AbstractSearchRelevanceRollingUpgradeTestCase.java
+++ b/qa/rolling-upgrade/src/test/java/org/opensearch/searchrelevance/bwc/rolling/AbstractSearchRelevanceRollingUpgradeTestCase.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/qa/rolling-upgrade/src/test/java/org/opensearch/searchrelevance/bwc/rolling/IndexMappingBWCIT.java
+++ b/qa/rolling-upgrade/src/test/java/org/opensearch/searchrelevance/bwc/rolling/IndexMappingBWCIT.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/qa/rolling-upgrade/src/test/java/org/opensearch/searchrelevance/bwc/rolling/LlmJudgmentBWCIT.java
+++ b/qa/rolling-upgrade/src/test/java/org/opensearch/searchrelevance/bwc/rolling/LlmJudgmentBWCIT.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/qa/rolling-upgrade/src/test/java/org/opensearch/searchrelevance/bwc/rolling/SearchConfigMappingBWCIT.java
+++ b/qa/rolling-upgrade/src/test/java/org/opensearch/searchrelevance/bwc/rolling/SearchConfigMappingBWCIT.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/qa/src/test/java/org/opensearch/searchrelevance/bwc/IndexMappingTestHelper.java
+++ b/qa/src/test/java/org/opensearch/searchrelevance/bwc/IndexMappingTestHelper.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/searchrelevance/common/MLConstants.java
+++ b/src/main/java/org/opensearch/searchrelevance/common/MLConstants.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/searchrelevance/common/MetricsConstants.java
+++ b/src/main/java/org/opensearch/searchrelevance/common/MetricsConstants.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/searchrelevance/common/MinClusterVersionUtil.java
+++ b/src/main/java/org/opensearch/searchrelevance/common/MinClusterVersionUtil.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/searchrelevance/common/PluginConstants.java
+++ b/src/main/java/org/opensearch/searchrelevance/common/PluginConstants.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/searchrelevance/dao/EvaluationResultDao.java
+++ b/src/main/java/org/opensearch/searchrelevance/dao/EvaluationResultDao.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/searchrelevance/dao/ExperimentDao.java
+++ b/src/main/java/org/opensearch/searchrelevance/dao/ExperimentDao.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/searchrelevance/dao/ExperimentVariantDao.java
+++ b/src/main/java/org/opensearch/searchrelevance/dao/ExperimentVariantDao.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/searchrelevance/dao/JudgmentDao.java
+++ b/src/main/java/org/opensearch/searchrelevance/dao/JudgmentDao.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/searchrelevance/dao/QuerySetDao.java
+++ b/src/main/java/org/opensearch/searchrelevance/dao/QuerySetDao.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/searchrelevance/dao/ScheduledExperimentHistoryDao.java
+++ b/src/main/java/org/opensearch/searchrelevance/dao/ScheduledExperimentHistoryDao.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/searchrelevance/dao/ScheduledJobsDao.java
+++ b/src/main/java/org/opensearch/searchrelevance/dao/ScheduledJobsDao.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/searchrelevance/dao/SearchConfigurationDao.java
+++ b/src/main/java/org/opensearch/searchrelevance/dao/SearchConfigurationDao.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/searchrelevance/exception/SearchRelevanceException.java
+++ b/src/main/java/org/opensearch/searchrelevance/exception/SearchRelevanceException.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/searchrelevance/executors/BatchedAsyncExecutor.java
+++ b/src/main/java/org/opensearch/searchrelevance/executors/BatchedAsyncExecutor.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/searchrelevance/executors/ExperimentRunningManager.java
+++ b/src/main/java/org/opensearch/searchrelevance/executors/ExperimentRunningManager.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/searchrelevance/executors/ExperimentTaskContext.java
+++ b/src/main/java/org/opensearch/searchrelevance/executors/ExperimentTaskContext.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/searchrelevance/executors/ExperimentTaskManager.java
+++ b/src/main/java/org/opensearch/searchrelevance/executors/ExperimentTaskManager.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/searchrelevance/executors/JudgmentResponseProcessor.java
+++ b/src/main/java/org/opensearch/searchrelevance/executors/JudgmentResponseProcessor.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/searchrelevance/executors/JudgmentTaskContext.java
+++ b/src/main/java/org/opensearch/searchrelevance/executors/JudgmentTaskContext.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/searchrelevance/executors/LlmJudgmentTaskManager.java
+++ b/src/main/java/org/opensearch/searchrelevance/executors/LlmJudgmentTaskManager.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/searchrelevance/executors/PointwiseTaskParameters.java
+++ b/src/main/java/org/opensearch/searchrelevance/executors/PointwiseTaskParameters.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/searchrelevance/executors/SearchRelevanceExecutor.java
+++ b/src/main/java/org/opensearch/searchrelevance/executors/SearchRelevanceExecutor.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/searchrelevance/executors/SearchResponseProcessor.java
+++ b/src/main/java/org/opensearch/searchrelevance/executors/SearchResponseProcessor.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/searchrelevance/executors/VariantTaskParameters.java
+++ b/src/main/java/org/opensearch/searchrelevance/executors/VariantTaskParameters.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/searchrelevance/experiment/EmptyExperimentOptions.java
+++ b/src/main/java/org/opensearch/searchrelevance/experiment/EmptyExperimentOptions.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/searchrelevance/experiment/ExperimentOptions.java
+++ b/src/main/java/org/opensearch/searchrelevance/experiment/ExperimentOptions.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/searchrelevance/experiment/ExperimentOptionsFactory.java
+++ b/src/main/java/org/opensearch/searchrelevance/experiment/ExperimentOptionsFactory.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/searchrelevance/experiment/ExperimentOptionsForHybridSearch.java
+++ b/src/main/java/org/opensearch/searchrelevance/experiment/ExperimentOptionsForHybridSearch.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/searchrelevance/experiment/ExperimentVariantHybridSearchDTO.java
+++ b/src/main/java/org/opensearch/searchrelevance/experiment/ExperimentVariantHybridSearchDTO.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/searchrelevance/experiment/ExperimentVariantHybridSearchDTOFactory.java
+++ b/src/main/java/org/opensearch/searchrelevance/experiment/ExperimentVariantHybridSearchDTOFactory.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/searchrelevance/experiment/HybridOptimizerExperimentProcessor.java
+++ b/src/main/java/org/opensearch/searchrelevance/experiment/HybridOptimizerExperimentProcessor.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/searchrelevance/experiment/HybridSearchConfig.java
+++ b/src/main/java/org/opensearch/searchrelevance/experiment/HybridSearchConfig.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/searchrelevance/experiment/JudgmentRatingsMapper.java
+++ b/src/main/java/org/opensearch/searchrelevance/experiment/JudgmentRatingsMapper.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/searchrelevance/experiment/PointwiseExperimentProcessor.java
+++ b/src/main/java/org/opensearch/searchrelevance/experiment/PointwiseExperimentProcessor.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/searchrelevance/experiment/QuerySourceUtil.java
+++ b/src/main/java/org/opensearch/searchrelevance/experiment/QuerySourceUtil.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/searchrelevance/experiment/RRFExperimentVariantHybridSearchDTO.java
+++ b/src/main/java/org/opensearch/searchrelevance/experiment/RRFExperimentVariantHybridSearchDTO.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/searchrelevance/experiment/RRFHybridSearchConfig.java
+++ b/src/main/java/org/opensearch/searchrelevance/experiment/RRFHybridSearchConfig.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/searchrelevance/experiment/ScoreBasedExperimentVariantHybridSearchDTO.java
+++ b/src/main/java/org/opensearch/searchrelevance/experiment/ScoreBasedExperimentVariantHybridSearchDTO.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/searchrelevance/experiment/ScoreBasedHybridSearchConfig.java
+++ b/src/main/java/org/opensearch/searchrelevance/experiment/ScoreBasedHybridSearchConfig.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/searchrelevance/experiment/signature/ExperimentInputSignatureComputer.java
+++ b/src/main/java/org/opensearch/searchrelevance/experiment/signature/ExperimentInputSignatureComputer.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/searchrelevance/indices/SearchRelevanceIndices.java
+++ b/src/main/java/org/opensearch/searchrelevance/indices/SearchRelevanceIndices.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/searchrelevance/indices/SearchRelevanceIndicesManager.java
+++ b/src/main/java/org/opensearch/searchrelevance/indices/SearchRelevanceIndicesManager.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/searchrelevance/judgments/BaseJudgmentsProcessor.java
+++ b/src/main/java/org/opensearch/searchrelevance/judgments/BaseJudgmentsProcessor.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/searchrelevance/judgments/ImportJudgmentsProcessor.java
+++ b/src/main/java/org/opensearch/searchrelevance/judgments/ImportJudgmentsProcessor.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/searchrelevance/judgments/JudgmentDataTransformer.java
+++ b/src/main/java/org/opensearch/searchrelevance/judgments/JudgmentDataTransformer.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/searchrelevance/judgments/JudgmentsProcessorFactory.java
+++ b/src/main/java/org/opensearch/searchrelevance/judgments/JudgmentsProcessorFactory.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/searchrelevance/judgments/LlmJudgmentsProcessor.java
+++ b/src/main/java/org/opensearch/searchrelevance/judgments/LlmJudgmentsProcessor.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/searchrelevance/judgments/UbiJudgmentsProcessor.java
+++ b/src/main/java/org/opensearch/searchrelevance/judgments/UbiJudgmentsProcessor.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/searchrelevance/judgments/clickmodel/ClickModel.java
+++ b/src/main/java/org/opensearch/searchrelevance/judgments/clickmodel/ClickModel.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/searchrelevance/judgments/clickmodel/ClickModelParameters.java
+++ b/src/main/java/org/opensearch/searchrelevance/judgments/clickmodel/ClickModelParameters.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/searchrelevance/judgments/clickmodel/coec/CoecClickModel.java
+++ b/src/main/java/org/opensearch/searchrelevance/judgments/clickmodel/coec/CoecClickModel.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/searchrelevance/judgments/clickmodel/coec/CoecClickModelParameters.java
+++ b/src/main/java/org/opensearch/searchrelevance/judgments/clickmodel/coec/CoecClickModelParameters.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/searchrelevance/judgments/queryhash/IncrementalUserQueryHash.java
+++ b/src/main/java/org/opensearch/searchrelevance/judgments/queryhash/IncrementalUserQueryHash.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/searchrelevance/judgments/queryhash/UserQueryHash.java
+++ b/src/main/java/org/opensearch/searchrelevance/judgments/queryhash/UserQueryHash.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/searchrelevance/metrics/EvaluationMetrics.java
+++ b/src/main/java/org/opensearch/searchrelevance/metrics/EvaluationMetrics.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/searchrelevance/metrics/MetricsHelper.java
+++ b/src/main/java/org/opensearch/searchrelevance/metrics/MetricsHelper.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/searchrelevance/metrics/PairwiseComparisonMetrics.java
+++ b/src/main/java/org/opensearch/searchrelevance/metrics/PairwiseComparisonMetrics.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/searchrelevance/metrics/calculator/Evaluation.java
+++ b/src/main/java/org/opensearch/searchrelevance/metrics/calculator/Evaluation.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/searchrelevance/metrics/calculator/JudgmentThresholdCalculator.java
+++ b/src/main/java/org/opensearch/searchrelevance/metrics/calculator/JudgmentThresholdCalculator.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/searchrelevance/metrics/calculator/PairComparison.java
+++ b/src/main/java/org/opensearch/searchrelevance/metrics/calculator/PairComparison.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/searchrelevance/ml/ChunkProcessingContext.java
+++ b/src/main/java/org/opensearch/searchrelevance/ml/ChunkProcessingContext.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/searchrelevance/ml/ChunkResult.java
+++ b/src/main/java/org/opensearch/searchrelevance/ml/ChunkResult.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/searchrelevance/ml/MLAccessor.java
+++ b/src/main/java/org/opensearch/searchrelevance/ml/MLAccessor.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/searchrelevance/ml/MLInputOutputTransformer.java
+++ b/src/main/java/org/opensearch/searchrelevance/ml/MLInputOutputTransformer.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/searchrelevance/ml/TokenizerUtil.java
+++ b/src/main/java/org/opensearch/searchrelevance/ml/TokenizerUtil.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/searchrelevance/ml/UserPromptFactory.java
+++ b/src/main/java/org/opensearch/searchrelevance/ml/UserPromptFactory.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/searchrelevance/model/AsyncStatus.java
+++ b/src/main/java/org/opensearch/searchrelevance/model/AsyncStatus.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/searchrelevance/model/ClickthroughRate.java
+++ b/src/main/java/org/opensearch/searchrelevance/model/ClickthroughRate.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/searchrelevance/model/EvaluationResult.java
+++ b/src/main/java/org/opensearch/searchrelevance/model/EvaluationResult.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/searchrelevance/model/Experiment.java
+++ b/src/main/java/org/opensearch/searchrelevance/model/Experiment.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/searchrelevance/model/ExperimentBatchStatus.java
+++ b/src/main/java/org/opensearch/searchrelevance/model/ExperimentBatchStatus.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/searchrelevance/model/ExperimentDocumentParser.java
+++ b/src/main/java/org/opensearch/searchrelevance/model/ExperimentDocumentParser.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/searchrelevance/model/ExperimentInputSignature.java
+++ b/src/main/java/org/opensearch/searchrelevance/model/ExperimentInputSignature.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/searchrelevance/model/ExperimentType.java
+++ b/src/main/java/org/opensearch/searchrelevance/model/ExperimentType.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/searchrelevance/model/ExperimentVariant.java
+++ b/src/main/java/org/opensearch/searchrelevance/model/ExperimentVariant.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/searchrelevance/model/Judgment.java
+++ b/src/main/java/org/opensearch/searchrelevance/model/Judgment.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/searchrelevance/model/JudgmentBatchStatus.java
+++ b/src/main/java/org/opensearch/searchrelevance/model/JudgmentBatchStatus.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/searchrelevance/model/JudgmentType.java
+++ b/src/main/java/org/opensearch/searchrelevance/model/JudgmentType.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/searchrelevance/model/LLMJudgmentRatingType.java
+++ b/src/main/java/org/opensearch/searchrelevance/model/LLMJudgmentRatingType.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/searchrelevance/model/QuerySet.java
+++ b/src/main/java/org/opensearch/searchrelevance/model/QuerySet.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/searchrelevance/model/QuerySetEntry.java
+++ b/src/main/java/org/opensearch/searchrelevance/model/QuerySetEntry.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/searchrelevance/model/QueryWithReference.java
+++ b/src/main/java/org/opensearch/searchrelevance/model/QueryWithReference.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/searchrelevance/model/ScheduledExperimentResult.java
+++ b/src/main/java/org/opensearch/searchrelevance/model/ScheduledExperimentResult.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/searchrelevance/model/ScheduledJob.java
+++ b/src/main/java/org/opensearch/searchrelevance/model/ScheduledJob.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/searchrelevance/model/SearchConfiguration.java
+++ b/src/main/java/org/opensearch/searchrelevance/model/SearchConfiguration.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/searchrelevance/model/SearchConfigurationDetails.java
+++ b/src/main/java/org/opensearch/searchrelevance/model/SearchConfigurationDetails.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/searchrelevance/model/SearchParams.java
+++ b/src/main/java/org/opensearch/searchrelevance/model/SearchParams.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/searchrelevance/model/SystemIndexConverters.java
+++ b/src/main/java/org/opensearch/searchrelevance/model/SystemIndexConverters.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/searchrelevance/model/builder/SearchRequestBuilder.java
+++ b/src/main/java/org/opensearch/searchrelevance/model/builder/SearchRequestBuilder.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/searchrelevance/model/ubi/event/EventAttributes.java
+++ b/src/main/java/org/opensearch/searchrelevance/model/ubi/event/EventAttributes.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/searchrelevance/model/ubi/event/EventObject.java
+++ b/src/main/java/org/opensearch/searchrelevance/model/ubi/event/EventObject.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/searchrelevance/model/ubi/event/Position.java
+++ b/src/main/java/org/opensearch/searchrelevance/model/ubi/event/Position.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/searchrelevance/model/ubi/event/UbiEvent.java
+++ b/src/main/java/org/opensearch/searchrelevance/model/ubi/event/UbiEvent.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/searchrelevance/model/ubi/query/QueryResponse.java
+++ b/src/main/java/org/opensearch/searchrelevance/model/ubi/query/QueryResponse.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/searchrelevance/model/ubi/query/UbiQuery.java
+++ b/src/main/java/org/opensearch/searchrelevance/model/ubi/query/UbiQuery.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/searchrelevance/plugin/SearchRelevancePlugin.java
+++ b/src/main/java/org/opensearch/searchrelevance/plugin/SearchRelevancePlugin.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/searchrelevance/rest/RestCreateQuerySetAction.java
+++ b/src/main/java/org/opensearch/searchrelevance/rest/RestCreateQuerySetAction.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/searchrelevance/rest/RestDeleteExperimentAction.java
+++ b/src/main/java/org/opensearch/searchrelevance/rest/RestDeleteExperimentAction.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/searchrelevance/rest/RestDeleteJudgmentAction.java
+++ b/src/main/java/org/opensearch/searchrelevance/rest/RestDeleteJudgmentAction.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/searchrelevance/rest/RestDeleteQuerySetAction.java
+++ b/src/main/java/org/opensearch/searchrelevance/rest/RestDeleteQuerySetAction.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/searchrelevance/rest/RestDeleteScheduledExperimentAction.java
+++ b/src/main/java/org/opensearch/searchrelevance/rest/RestDeleteScheduledExperimentAction.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/searchrelevance/rest/RestDeleteSearchConfigurationAction.java
+++ b/src/main/java/org/opensearch/searchrelevance/rest/RestDeleteSearchConfigurationAction.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/searchrelevance/rest/RestGetExperimentAction.java
+++ b/src/main/java/org/opensearch/searchrelevance/rest/RestGetExperimentAction.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/searchrelevance/rest/RestGetJudgmentAction.java
+++ b/src/main/java/org/opensearch/searchrelevance/rest/RestGetJudgmentAction.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/searchrelevance/rest/RestGetQuerySetAction.java
+++ b/src/main/java/org/opensearch/searchrelevance/rest/RestGetQuerySetAction.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/searchrelevance/rest/RestGetScheduledExperimentAction.java
+++ b/src/main/java/org/opensearch/searchrelevance/rest/RestGetScheduledExperimentAction.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/searchrelevance/rest/RestGetSearchConfigurationAction.java
+++ b/src/main/java/org/opensearch/searchrelevance/rest/RestGetSearchConfigurationAction.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/searchrelevance/rest/RestPatchExperimentAction.java
+++ b/src/main/java/org/opensearch/searchrelevance/rest/RestPatchExperimentAction.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/searchrelevance/rest/RestPostScheduledExperimentAction.java
+++ b/src/main/java/org/opensearch/searchrelevance/rest/RestPostScheduledExperimentAction.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/searchrelevance/rest/RestPutExperimentAction.java
+++ b/src/main/java/org/opensearch/searchrelevance/rest/RestPutExperimentAction.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/searchrelevance/rest/RestPutJudgmentAction.java
+++ b/src/main/java/org/opensearch/searchrelevance/rest/RestPutJudgmentAction.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/searchrelevance/rest/RestPutQuerySetAction.java
+++ b/src/main/java/org/opensearch/searchrelevance/rest/RestPutQuerySetAction.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/searchrelevance/rest/RestPutSearchConfigurationAction.java
+++ b/src/main/java/org/opensearch/searchrelevance/rest/RestPutSearchConfigurationAction.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/searchrelevance/rest/RestRetryFailedJudgmentAction.java
+++ b/src/main/java/org/opensearch/searchrelevance/rest/RestRetryFailedJudgmentAction.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/searchrelevance/rest/RestSearchExperimentAction.java
+++ b/src/main/java/org/opensearch/searchrelevance/rest/RestSearchExperimentAction.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/searchrelevance/rest/RestSearchJudgmentAction.java
+++ b/src/main/java/org/opensearch/searchrelevance/rest/RestSearchJudgmentAction.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/searchrelevance/rest/RestSearchQuerySetAction.java
+++ b/src/main/java/org/opensearch/searchrelevance/rest/RestSearchQuerySetAction.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/searchrelevance/rest/RestSearchRelevanceStatsAction.java
+++ b/src/main/java/org/opensearch/searchrelevance/rest/RestSearchRelevanceStatsAction.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/searchrelevance/rest/RestSearchSearchConfigurationAction.java
+++ b/src/main/java/org/opensearch/searchrelevance/rest/RestSearchSearchConfigurationAction.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/searchrelevance/rest/RestUpdateJudgmentRatingsAction.java
+++ b/src/main/java/org/opensearch/searchrelevance/rest/RestUpdateJudgmentRatingsAction.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/searchrelevance/rest/RestValidateExperimentAction.java
+++ b/src/main/java/org/opensearch/searchrelevance/rest/RestValidateExperimentAction.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/searchrelevance/scheduler/ExperimentCancellationToken.java
+++ b/src/main/java/org/opensearch/searchrelevance/scheduler/ExperimentCancellationToken.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/searchrelevance/scheduler/ScheduledExperimentRunnerManager.java
+++ b/src/main/java/org/opensearch/searchrelevance/scheduler/ScheduledExperimentRunnerManager.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/searchrelevance/scheduler/SearchRelevanceJobParameters.java
+++ b/src/main/java/org/opensearch/searchrelevance/scheduler/SearchRelevanceJobParameters.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/searchrelevance/scheduler/SearchRelevanceJobRunner.java
+++ b/src/main/java/org/opensearch/searchrelevance/scheduler/SearchRelevanceJobRunner.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/searchrelevance/settings/SearchRelevanceSettings.java
+++ b/src/main/java/org/opensearch/searchrelevance/settings/SearchRelevanceSettings.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/searchrelevance/settings/SearchRelevanceSettingsAccessor.java
+++ b/src/main/java/org/opensearch/searchrelevance/settings/SearchRelevanceSettingsAccessor.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/searchrelevance/shared/StashedThreadContext.java
+++ b/src/main/java/org/opensearch/searchrelevance/shared/StashedThreadContext.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/searchrelevance/stats/SearchRelevanceStatsInput.java
+++ b/src/main/java/org/opensearch/searchrelevance/stats/SearchRelevanceStatsInput.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/searchrelevance/stats/common/StatName.java
+++ b/src/main/java/org/opensearch/searchrelevance/stats/common/StatName.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/searchrelevance/stats/common/StatSnapshot.java
+++ b/src/main/java/org/opensearch/searchrelevance/stats/common/StatSnapshot.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/searchrelevance/stats/common/StatType.java
+++ b/src/main/java/org/opensearch/searchrelevance/stats/common/StatType.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/searchrelevance/stats/events/EventStat.java
+++ b/src/main/java/org/opensearch/searchrelevance/stats/events/EventStat.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/searchrelevance/stats/events/EventStatName.java
+++ b/src/main/java/org/opensearch/searchrelevance/stats/events/EventStatName.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/searchrelevance/stats/events/EventStatType.java
+++ b/src/main/java/org/opensearch/searchrelevance/stats/events/EventStatType.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/searchrelevance/stats/events/EventStatsManager.java
+++ b/src/main/java/org/opensearch/searchrelevance/stats/events/EventStatsManager.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/searchrelevance/stats/events/TimestampedEventStat.java
+++ b/src/main/java/org/opensearch/searchrelevance/stats/events/TimestampedEventStat.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/searchrelevance/stats/events/TimestampedEventStatSnapshot.java
+++ b/src/main/java/org/opensearch/searchrelevance/stats/events/TimestampedEventStatSnapshot.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/searchrelevance/stats/info/CountableInfoStatSnapshot.java
+++ b/src/main/java/org/opensearch/searchrelevance/stats/info/CountableInfoStatSnapshot.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/searchrelevance/stats/info/InfoStatName.java
+++ b/src/main/java/org/opensearch/searchrelevance/stats/info/InfoStatName.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/searchrelevance/stats/info/InfoStatType.java
+++ b/src/main/java/org/opensearch/searchrelevance/stats/info/InfoStatType.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/searchrelevance/stats/info/InfoStatsManager.java
+++ b/src/main/java/org/opensearch/searchrelevance/stats/info/InfoStatsManager.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/searchrelevance/stats/info/SettableInfoStatSnapshot.java
+++ b/src/main/java/org/opensearch/searchrelevance/stats/info/SettableInfoStatSnapshot.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/searchrelevance/transport/OpenSearchDocRequest.java
+++ b/src/main/java/org/opensearch/searchrelevance/transport/OpenSearchDocRequest.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/searchrelevance/transport/experiment/DeleteExperimentAction.java
+++ b/src/main/java/org/opensearch/searchrelevance/transport/experiment/DeleteExperimentAction.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/searchrelevance/transport/experiment/DeleteExperimentTransportAction.java
+++ b/src/main/java/org/opensearch/searchrelevance/transport/experiment/DeleteExperimentTransportAction.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/searchrelevance/transport/experiment/GetExperimentAction.java
+++ b/src/main/java/org/opensearch/searchrelevance/transport/experiment/GetExperimentAction.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/searchrelevance/transport/experiment/GetExperimentTransportAction.java
+++ b/src/main/java/org/opensearch/searchrelevance/transport/experiment/GetExperimentTransportAction.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/searchrelevance/transport/experiment/PatchExperimentAction.java
+++ b/src/main/java/org/opensearch/searchrelevance/transport/experiment/PatchExperimentAction.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/searchrelevance/transport/experiment/PatchExperimentRequest.java
+++ b/src/main/java/org/opensearch/searchrelevance/transport/experiment/PatchExperimentRequest.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/searchrelevance/transport/experiment/PatchExperimentTransportAction.java
+++ b/src/main/java/org/opensearch/searchrelevance/transport/experiment/PatchExperimentTransportAction.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/searchrelevance/transport/experiment/PutExperimentAction.java
+++ b/src/main/java/org/opensearch/searchrelevance/transport/experiment/PutExperimentAction.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/searchrelevance/transport/experiment/PutExperimentRequest.java
+++ b/src/main/java/org/opensearch/searchrelevance/transport/experiment/PutExperimentRequest.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/searchrelevance/transport/experiment/PutExperimentTransportAction.java
+++ b/src/main/java/org/opensearch/searchrelevance/transport/experiment/PutExperimentTransportAction.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/searchrelevance/transport/experiment/SearchExperimentAction.java
+++ b/src/main/java/org/opensearch/searchrelevance/transport/experiment/SearchExperimentAction.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/searchrelevance/transport/experiment/SearchExperimentTransportAction.java
+++ b/src/main/java/org/opensearch/searchrelevance/transport/experiment/SearchExperimentTransportAction.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/searchrelevance/transport/experiment/ValidateExperimentAction.java
+++ b/src/main/java/org/opensearch/searchrelevance/transport/experiment/ValidateExperimentAction.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/searchrelevance/transport/experiment/ValidateExperimentResponse.java
+++ b/src/main/java/org/opensearch/searchrelevance/transport/experiment/ValidateExperimentResponse.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/searchrelevance/transport/experiment/ValidateExperimentTransportAction.java
+++ b/src/main/java/org/opensearch/searchrelevance/transport/experiment/ValidateExperimentTransportAction.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/searchrelevance/transport/judgment/DeleteJudgmentAction.java
+++ b/src/main/java/org/opensearch/searchrelevance/transport/judgment/DeleteJudgmentAction.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/searchrelevance/transport/judgment/DeleteJudgmentTransportAction.java
+++ b/src/main/java/org/opensearch/searchrelevance/transport/judgment/DeleteJudgmentTransportAction.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/searchrelevance/transport/judgment/GetJudgmentAction.java
+++ b/src/main/java/org/opensearch/searchrelevance/transport/judgment/GetJudgmentAction.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/searchrelevance/transport/judgment/GetJudgmentTransportAction.java
+++ b/src/main/java/org/opensearch/searchrelevance/transport/judgment/GetJudgmentTransportAction.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/searchrelevance/transport/judgment/PutImportJudgmentRequest.java
+++ b/src/main/java/org/opensearch/searchrelevance/transport/judgment/PutImportJudgmentRequest.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/searchrelevance/transport/judgment/PutJudgmentAction.java
+++ b/src/main/java/org/opensearch/searchrelevance/transport/judgment/PutJudgmentAction.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/searchrelevance/transport/judgment/PutJudgmentRequest.java
+++ b/src/main/java/org/opensearch/searchrelevance/transport/judgment/PutJudgmentRequest.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/searchrelevance/transport/judgment/PutJudgmentTransportAction.java
+++ b/src/main/java/org/opensearch/searchrelevance/transport/judgment/PutJudgmentTransportAction.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/searchrelevance/transport/judgment/PutLlmJudgmentRequest.java
+++ b/src/main/java/org/opensearch/searchrelevance/transport/judgment/PutLlmJudgmentRequest.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/searchrelevance/transport/judgment/PutUbiJudgmentRequest.java
+++ b/src/main/java/org/opensearch/searchrelevance/transport/judgment/PutUbiJudgmentRequest.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/searchrelevance/transport/judgment/RatingAdjustment.java
+++ b/src/main/java/org/opensearch/searchrelevance/transport/judgment/RatingAdjustment.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/searchrelevance/transport/judgment/RetryFailedJudgmentAction.java
+++ b/src/main/java/org/opensearch/searchrelevance/transport/judgment/RetryFailedJudgmentAction.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/searchrelevance/transport/judgment/RetryFailedJudgmentRequest.java
+++ b/src/main/java/org/opensearch/searchrelevance/transport/judgment/RetryFailedJudgmentRequest.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/searchrelevance/transport/judgment/RetryFailedJudgmentTransportAction.java
+++ b/src/main/java/org/opensearch/searchrelevance/transport/judgment/RetryFailedJudgmentTransportAction.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/searchrelevance/transport/judgment/SearchJudgmentAction.java
+++ b/src/main/java/org/opensearch/searchrelevance/transport/judgment/SearchJudgmentAction.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/searchrelevance/transport/judgment/SearchJudgmentTransportAction.java
+++ b/src/main/java/org/opensearch/searchrelevance/transport/judgment/SearchJudgmentTransportAction.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/searchrelevance/transport/judgment/UpdateJudgmentRatingsAction.java
+++ b/src/main/java/org/opensearch/searchrelevance/transport/judgment/UpdateJudgmentRatingsAction.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/searchrelevance/transport/judgment/UpdateJudgmentRatingsRequest.java
+++ b/src/main/java/org/opensearch/searchrelevance/transport/judgment/UpdateJudgmentRatingsRequest.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/searchrelevance/transport/judgment/UpdateJudgmentRatingsTransportAction.java
+++ b/src/main/java/org/opensearch/searchrelevance/transport/judgment/UpdateJudgmentRatingsTransportAction.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/searchrelevance/transport/queryset/DeleteQuerySetAction.java
+++ b/src/main/java/org/opensearch/searchrelevance/transport/queryset/DeleteQuerySetAction.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/searchrelevance/transport/queryset/DeleteQuerySetTransportAction.java
+++ b/src/main/java/org/opensearch/searchrelevance/transport/queryset/DeleteQuerySetTransportAction.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/searchrelevance/transport/queryset/GetQuerySetAction.java
+++ b/src/main/java/org/opensearch/searchrelevance/transport/queryset/GetQuerySetAction.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/searchrelevance/transport/queryset/GetQuerySetTransportAction.java
+++ b/src/main/java/org/opensearch/searchrelevance/transport/queryset/GetQuerySetTransportAction.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/searchrelevance/transport/queryset/PostQuerySetAction.java
+++ b/src/main/java/org/opensearch/searchrelevance/transport/queryset/PostQuerySetAction.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/searchrelevance/transport/queryset/PostQuerySetRequest.java
+++ b/src/main/java/org/opensearch/searchrelevance/transport/queryset/PostQuerySetRequest.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/searchrelevance/transport/queryset/PostQuerySetTransportAction.java
+++ b/src/main/java/org/opensearch/searchrelevance/transport/queryset/PostQuerySetTransportAction.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/searchrelevance/transport/queryset/PostUbiQuerySetRequest.java
+++ b/src/main/java/org/opensearch/searchrelevance/transport/queryset/PostUbiQuerySetRequest.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/searchrelevance/transport/queryset/PutQuerySetAction.java
+++ b/src/main/java/org/opensearch/searchrelevance/transport/queryset/PutQuerySetAction.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/searchrelevance/transport/queryset/PutQuerySetRequest.java
+++ b/src/main/java/org/opensearch/searchrelevance/transport/queryset/PutQuerySetRequest.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/searchrelevance/transport/queryset/PutQuerySetTransportAction.java
+++ b/src/main/java/org/opensearch/searchrelevance/transport/queryset/PutQuerySetTransportAction.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/searchrelevance/transport/queryset/SearchQuerySetAction.java
+++ b/src/main/java/org/opensearch/searchrelevance/transport/queryset/SearchQuerySetAction.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/searchrelevance/transport/queryset/SearchQuerySetTransportAction.java
+++ b/src/main/java/org/opensearch/searchrelevance/transport/queryset/SearchQuerySetTransportAction.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/searchrelevance/transport/scheduledJob/DeleteScheduledExperimentAction.java
+++ b/src/main/java/org/opensearch/searchrelevance/transport/scheduledJob/DeleteScheduledExperimentAction.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/searchrelevance/transport/scheduledJob/DeleteScheduledExperimentTransportAction.java
+++ b/src/main/java/org/opensearch/searchrelevance/transport/scheduledJob/DeleteScheduledExperimentTransportAction.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/searchrelevance/transport/scheduledJob/GetScheduledExperimentAction.java
+++ b/src/main/java/org/opensearch/searchrelevance/transport/scheduledJob/GetScheduledExperimentAction.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/searchrelevance/transport/scheduledJob/GetScheduledExperimentTransportAction.java
+++ b/src/main/java/org/opensearch/searchrelevance/transport/scheduledJob/GetScheduledExperimentTransportAction.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/searchrelevance/transport/scheduledJob/PostScheduledExperimentAction.java
+++ b/src/main/java/org/opensearch/searchrelevance/transport/scheduledJob/PostScheduledExperimentAction.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/searchrelevance/transport/scheduledJob/PostScheduledExperimentRequest.java
+++ b/src/main/java/org/opensearch/searchrelevance/transport/scheduledJob/PostScheduledExperimentRequest.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/searchrelevance/transport/scheduledJob/PostScheduledExperimentTransportAction.java
+++ b/src/main/java/org/opensearch/searchrelevance/transport/scheduledJob/PostScheduledExperimentTransportAction.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/searchrelevance/transport/searchConfiguration/DeleteSearchConfigurationAction.java
+++ b/src/main/java/org/opensearch/searchrelevance/transport/searchConfiguration/DeleteSearchConfigurationAction.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/searchrelevance/transport/searchConfiguration/DeleteSearchConfigurationTransportAction.java
+++ b/src/main/java/org/opensearch/searchrelevance/transport/searchConfiguration/DeleteSearchConfigurationTransportAction.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/searchrelevance/transport/searchConfiguration/GetSearchConfigurationAction.java
+++ b/src/main/java/org/opensearch/searchrelevance/transport/searchConfiguration/GetSearchConfigurationAction.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/searchrelevance/transport/searchConfiguration/GetSearchConfigurationTransportAction.java
+++ b/src/main/java/org/opensearch/searchrelevance/transport/searchConfiguration/GetSearchConfigurationTransportAction.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/searchrelevance/transport/searchConfiguration/PutSearchConfigurationAction.java
+++ b/src/main/java/org/opensearch/searchrelevance/transport/searchConfiguration/PutSearchConfigurationAction.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/searchrelevance/transport/searchConfiguration/PutSearchConfigurationRequest.java
+++ b/src/main/java/org/opensearch/searchrelevance/transport/searchConfiguration/PutSearchConfigurationRequest.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/searchrelevance/transport/searchConfiguration/PutSearchConfigurationTransportAction.java
+++ b/src/main/java/org/opensearch/searchrelevance/transport/searchConfiguration/PutSearchConfigurationTransportAction.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/searchrelevance/transport/searchConfiguration/SearchSearchConfigurationAction.java
+++ b/src/main/java/org/opensearch/searchrelevance/transport/searchConfiguration/SearchSearchConfigurationAction.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/searchrelevance/transport/searchConfiguration/SearchSearchConfigurationTransportAction.java
+++ b/src/main/java/org/opensearch/searchrelevance/transport/searchConfiguration/SearchSearchConfigurationTransportAction.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/searchrelevance/transport/stats/SearchRelevanceStatsAction.java
+++ b/src/main/java/org/opensearch/searchrelevance/transport/stats/SearchRelevanceStatsAction.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/searchrelevance/transport/stats/SearchRelevanceStatsNodeRequest.java
+++ b/src/main/java/org/opensearch/searchrelevance/transport/stats/SearchRelevanceStatsNodeRequest.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/searchrelevance/transport/stats/SearchRelevanceStatsNodeResponse.java
+++ b/src/main/java/org/opensearch/searchrelevance/transport/stats/SearchRelevanceStatsNodeResponse.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/searchrelevance/transport/stats/SearchRelevanceStatsRequest.java
+++ b/src/main/java/org/opensearch/searchrelevance/transport/stats/SearchRelevanceStatsRequest.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/searchrelevance/transport/stats/SearchRelevanceStatsResponse.java
+++ b/src/main/java/org/opensearch/searchrelevance/transport/stats/SearchRelevanceStatsResponse.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/searchrelevance/transport/stats/SearchRelevanceStatsTransportAction.java
+++ b/src/main/java/org/opensearch/searchrelevance/transport/stats/SearchRelevanceStatsTransportAction.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/searchrelevance/ubi/ProbabilityProportionalToSizeQuerySampler.java
+++ b/src/main/java/org/opensearch/searchrelevance/ubi/ProbabilityProportionalToSizeQuerySampler.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/searchrelevance/ubi/QuerySampler.java
+++ b/src/main/java/org/opensearch/searchrelevance/ubi/QuerySampler.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/searchrelevance/ubi/RandomQuerySampler.java
+++ b/src/main/java/org/opensearch/searchrelevance/ubi/RandomQuerySampler.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/searchrelevance/ubi/TopNQuerySampler.java
+++ b/src/main/java/org/opensearch/searchrelevance/ubi/TopNQuerySampler.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/searchrelevance/ubi/UbiValidator.java
+++ b/src/main/java/org/opensearch/searchrelevance/ubi/UbiValidator.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/searchrelevance/utils/ClusterUtil.java
+++ b/src/main/java/org/opensearch/searchrelevance/utils/ClusterUtil.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/searchrelevance/utils/ConcurrencyUtil.java
+++ b/src/main/java/org/opensearch/searchrelevance/utils/ConcurrencyUtil.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/searchrelevance/utils/CronUtil.java
+++ b/src/main/java/org/opensearch/searchrelevance/utils/CronUtil.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/searchrelevance/utils/DateValidationUtil.java
+++ b/src/main/java/org/opensearch/searchrelevance/utils/DateValidationUtil.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/searchrelevance/utils/JsonUtils.java
+++ b/src/main/java/org/opensearch/searchrelevance/utils/JsonUtils.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/searchrelevance/utils/MathUtils.java
+++ b/src/main/java/org/opensearch/searchrelevance/utils/MathUtils.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/searchrelevance/utils/ParserUtils.java
+++ b/src/main/java/org/opensearch/searchrelevance/utils/ParserUtils.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/searchrelevance/utils/RatingOutputProcessor.java
+++ b/src/main/java/org/opensearch/searchrelevance/utils/RatingOutputProcessor.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/searchrelevance/utils/ReferenceValidationUtil.java
+++ b/src/main/java/org/opensearch/searchrelevance/utils/ReferenceValidationUtil.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/searchrelevance/utils/TextValidationUtil.java
+++ b/src/main/java/org/opensearch/searchrelevance/utils/TextValidationUtil.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/main/java/org/opensearch/searchrelevance/utils/TimeUtils.java
+++ b/src/main/java/org/opensearch/searchrelevance/utils/TimeUtils.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/test/java/org/opensearch/searchrelevance/BaseSearchRelevanceIT.java
+++ b/src/test/java/org/opensearch/searchrelevance/BaseSearchRelevanceIT.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/test/java/org/opensearch/searchrelevance/action/ReferenceValidationIT.java
+++ b/src/test/java/org/opensearch/searchrelevance/action/ReferenceValidationIT.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/test/java/org/opensearch/searchrelevance/action/experiments/DeleteExperimentActionTests.java
+++ b/src/test/java/org/opensearch/searchrelevance/action/experiments/DeleteExperimentActionTests.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/test/java/org/opensearch/searchrelevance/action/experiments/GetExperimentActionTests.java
+++ b/src/test/java/org/opensearch/searchrelevance/action/experiments/GetExperimentActionTests.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/test/java/org/opensearch/searchrelevance/action/experiments/PatchExperimentActionTests.java
+++ b/src/test/java/org/opensearch/searchrelevance/action/experiments/PatchExperimentActionTests.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/test/java/org/opensearch/searchrelevance/action/experiments/PutExperimentActionTests.java
+++ b/src/test/java/org/opensearch/searchrelevance/action/experiments/PutExperimentActionTests.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/test/java/org/opensearch/searchrelevance/action/judgment/CalculateJudgmentsIT.java
+++ b/src/test/java/org/opensearch/searchrelevance/action/judgment/CalculateJudgmentsIT.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/test/java/org/opensearch/searchrelevance/action/judgment/DeleteJudgmentActionTests.java
+++ b/src/test/java/org/opensearch/searchrelevance/action/judgment/DeleteJudgmentActionTests.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/test/java/org/opensearch/searchrelevance/action/judgment/GetJudgmentActionTests.java
+++ b/src/test/java/org/opensearch/searchrelevance/action/judgment/GetJudgmentActionTests.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/test/java/org/opensearch/searchrelevance/action/judgment/JudgmentsIT.java
+++ b/src/test/java/org/opensearch/searchrelevance/action/judgment/JudgmentsIT.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/test/java/org/opensearch/searchrelevance/action/judgment/LlmJudgmentTemplateIT.java
+++ b/src/test/java/org/opensearch/searchrelevance/action/judgment/LlmJudgmentTemplateIT.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/test/java/org/opensearch/searchrelevance/action/judgment/PutJudgmentActionTests.java
+++ b/src/test/java/org/opensearch/searchrelevance/action/judgment/PutJudgmentActionTests.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/test/java/org/opensearch/searchrelevance/action/queryset/CreateQuerySetActionTests.java
+++ b/src/test/java/org/opensearch/searchrelevance/action/queryset/CreateQuerySetActionTests.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/test/java/org/opensearch/searchrelevance/action/queryset/DeleteQuerySetActionTests.java
+++ b/src/test/java/org/opensearch/searchrelevance/action/queryset/DeleteQuerySetActionTests.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/test/java/org/opensearch/searchrelevance/action/queryset/GetQuerySetActionTests.java
+++ b/src/test/java/org/opensearch/searchrelevance/action/queryset/GetQuerySetActionTests.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/test/java/org/opensearch/searchrelevance/action/queryset/PutQuerySetActionTests.java
+++ b/src/test/java/org/opensearch/searchrelevance/action/queryset/PutQuerySetActionTests.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/test/java/org/opensearch/searchrelevance/action/queryset/QuerySetIT.java
+++ b/src/test/java/org/opensearch/searchrelevance/action/queryset/QuerySetIT.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/test/java/org/opensearch/searchrelevance/action/scheduledJob/DeleteScheduledExperimentActionTests.java
+++ b/src/test/java/org/opensearch/searchrelevance/action/scheduledJob/DeleteScheduledExperimentActionTests.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/test/java/org/opensearch/searchrelevance/action/scheduledJob/GetScheduledExperimentActionTests.java
+++ b/src/test/java/org/opensearch/searchrelevance/action/scheduledJob/GetScheduledExperimentActionTests.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/test/java/org/opensearch/searchrelevance/action/scheduledJob/PostScheduledExperimentActionTests.java
+++ b/src/test/java/org/opensearch/searchrelevance/action/scheduledJob/PostScheduledExperimentActionTests.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/test/java/org/opensearch/searchrelevance/action/scheduledJob/ScheduledJobsIT.java
+++ b/src/test/java/org/opensearch/searchrelevance/action/scheduledJob/ScheduledJobsIT.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/test/java/org/opensearch/searchrelevance/action/searchConfiguration/DeleteSearchConfigurationActionTests.java
+++ b/src/test/java/org/opensearch/searchrelevance/action/searchConfiguration/DeleteSearchConfigurationActionTests.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/test/java/org/opensearch/searchrelevance/action/searchConfiguration/GetSearchConfigurationActionTests.java
+++ b/src/test/java/org/opensearch/searchrelevance/action/searchConfiguration/GetSearchConfigurationActionTests.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/test/java/org/opensearch/searchrelevance/action/searchConfiguration/PutSearchConfigurationActionTests.java
+++ b/src/test/java/org/opensearch/searchrelevance/action/searchConfiguration/PutSearchConfigurationActionTests.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/test/java/org/opensearch/searchrelevance/action/searchConfiguration/SearchConfigurationIT.java
+++ b/src/test/java/org/opensearch/searchrelevance/action/searchConfiguration/SearchConfigurationIT.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/test/java/org/opensearch/searchrelevance/common/MLConstantsTests.java
+++ b/src/test/java/org/opensearch/searchrelevance/common/MLConstantsTests.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/test/java/org/opensearch/searchrelevance/dao/ExperimentDaoTests.java
+++ b/src/test/java/org/opensearch/searchrelevance/dao/ExperimentDaoTests.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/test/java/org/opensearch/searchrelevance/executors/BatchedAsyncExecutorTests.java
+++ b/src/test/java/org/opensearch/searchrelevance/executors/BatchedAsyncExecutorTests.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/test/java/org/opensearch/searchrelevance/executors/ExperimentRunningManagerTests.java
+++ b/src/test/java/org/opensearch/searchrelevance/executors/ExperimentRunningManagerTests.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/test/java/org/opensearch/searchrelevance/executors/ExperimentTaskContextTests.java
+++ b/src/test/java/org/opensearch/searchrelevance/executors/ExperimentTaskContextTests.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/test/java/org/opensearch/searchrelevance/executors/ExperimentTaskManagerTests.java
+++ b/src/test/java/org/opensearch/searchrelevance/executors/ExperimentTaskManagerTests.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/test/java/org/opensearch/searchrelevance/executors/JudgmentDataTransformerTests.java
+++ b/src/test/java/org/opensearch/searchrelevance/executors/JudgmentDataTransformerTests.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/test/java/org/opensearch/searchrelevance/executors/JudgmentResponseProcessorTests.java
+++ b/src/test/java/org/opensearch/searchrelevance/executors/JudgmentResponseProcessorTests.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/test/java/org/opensearch/searchrelevance/executors/JudgmentTaskContextTests.java
+++ b/src/test/java/org/opensearch/searchrelevance/executors/JudgmentTaskContextTests.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/test/java/org/opensearch/searchrelevance/executors/LlmJudgmentTaskManagerThreadStarvationTests.java
+++ b/src/test/java/org/opensearch/searchrelevance/executors/LlmJudgmentTaskManagerThreadStarvationTests.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/test/java/org/opensearch/searchrelevance/executors/SearchRelevanceExecutorTests.java
+++ b/src/test/java/org/opensearch/searchrelevance/executors/SearchRelevanceExecutorTests.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/test/java/org/opensearch/searchrelevance/experiment/BaseExperimentIT.java
+++ b/src/test/java/org/opensearch/searchrelevance/experiment/BaseExperimentIT.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/test/java/org/opensearch/searchrelevance/experiment/ExperimentOptionsFactoryTests.java
+++ b/src/test/java/org/opensearch/searchrelevance/experiment/ExperimentOptionsFactoryTests.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/test/java/org/opensearch/searchrelevance/experiment/ExperimentOptionsForHybridSearchTests.java
+++ b/src/test/java/org/opensearch/searchrelevance/experiment/ExperimentOptionsForHybridSearchTests.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/test/java/org/opensearch/searchrelevance/experiment/HybridOptimizerExperimentIT.java
+++ b/src/test/java/org/opensearch/searchrelevance/experiment/HybridOptimizerExperimentIT.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/test/java/org/opensearch/searchrelevance/experiment/HybridOptimizerExperimentProcessorTests.java
+++ b/src/test/java/org/opensearch/searchrelevance/experiment/HybridOptimizerExperimentProcessorTests.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/test/java/org/opensearch/searchrelevance/experiment/JudgmentRatingsMapperTests.java
+++ b/src/test/java/org/opensearch/searchrelevance/experiment/JudgmentRatingsMapperTests.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/test/java/org/opensearch/searchrelevance/experiment/PointwiseExperimentIT.java
+++ b/src/test/java/org/opensearch/searchrelevance/experiment/PointwiseExperimentIT.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/test/java/org/opensearch/searchrelevance/experiment/PointwiseExperimentProcessorTests.java
+++ b/src/test/java/org/opensearch/searchrelevance/experiment/PointwiseExperimentProcessorTests.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/test/java/org/opensearch/searchrelevance/experiment/QuerySourceUtilTests.java
+++ b/src/test/java/org/opensearch/searchrelevance/experiment/QuerySourceUtilTests.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/test/java/org/opensearch/searchrelevance/experiment/SearchEvaluationExperimentIT.java
+++ b/src/test/java/org/opensearch/searchrelevance/experiment/SearchEvaluationExperimentIT.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/test/java/org/opensearch/searchrelevance/experiment/signature/ExperimentInputSignatureComputerTests.java
+++ b/src/test/java/org/opensearch/searchrelevance/experiment/signature/ExperimentInputSignatureComputerTests.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/test/java/org/opensearch/searchrelevance/indices/SearchRelevanceIndicesManagerTests.java
+++ b/src/test/java/org/opensearch/searchrelevance/indices/SearchRelevanceIndicesManagerTests.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/test/java/org/opensearch/searchrelevance/indices/SearchRelevanceIndicesTests.java
+++ b/src/test/java/org/opensearch/searchrelevance/indices/SearchRelevanceIndicesTests.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/test/java/org/opensearch/searchrelevance/integration/AutoExpandReplicasIT.java
+++ b/src/test/java/org/opensearch/searchrelevance/integration/AutoExpandReplicasIT.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/test/java/org/opensearch/searchrelevance/integration/IndexMappingVersionIT.java
+++ b/src/test/java/org/opensearch/searchrelevance/integration/IndexMappingVersionIT.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/test/java/org/opensearch/searchrelevance/integration/LtrSltrRescoreIT.java
+++ b/src/test/java/org/opensearch/searchrelevance/integration/LtrSltrRescoreIT.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/test/java/org/opensearch/searchrelevance/judgments/ExistingJudgmentsDeduplicationTests.java
+++ b/src/test/java/org/opensearch/searchrelevance/judgments/ExistingJudgmentsDeduplicationTests.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/test/java/org/opensearch/searchrelevance/judgments/ImportJudgmentsProcessorTests.java
+++ b/src/test/java/org/opensearch/searchrelevance/judgments/ImportJudgmentsProcessorTests.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/test/java/org/opensearch/searchrelevance/judgments/LlmJudgmentsProcessorRatingConversionTests.java
+++ b/src/test/java/org/opensearch/searchrelevance/judgments/LlmJudgmentsProcessorRatingConversionTests.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/test/java/org/opensearch/searchrelevance/judgments/LlmJudgmentsProcessorTests.java
+++ b/src/test/java/org/opensearch/searchrelevance/judgments/LlmJudgmentsProcessorTests.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/test/java/org/opensearch/searchrelevance/judgments/clickmodel/coec/CoecClickModelParametersTests.java
+++ b/src/test/java/org/opensearch/searchrelevance/judgments/clickmodel/coec/CoecClickModelParametersTests.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/test/java/org/opensearch/searchrelevance/metrics/MetricsHelperTests.java
+++ b/src/test/java/org/opensearch/searchrelevance/metrics/MetricsHelperTests.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/test/java/org/opensearch/searchrelevance/metrics/calculator/EvaluationTests.java
+++ b/src/test/java/org/opensearch/searchrelevance/metrics/calculator/EvaluationTests.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/test/java/org/opensearch/searchrelevance/metrics/calculator/JudgmentThresholdCalculatorTests.java
+++ b/src/test/java/org/opensearch/searchrelevance/metrics/calculator/JudgmentThresholdCalculatorTests.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/test/java/org/opensearch/searchrelevance/metrics/calculator/PairComparisonTests.java
+++ b/src/test/java/org/opensearch/searchrelevance/metrics/calculator/PairComparisonTests.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/test/java/org/opensearch/searchrelevance/ml/ChunkProcessingContextTests.java
+++ b/src/test/java/org/opensearch/searchrelevance/ml/ChunkProcessingContextTests.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/test/java/org/opensearch/searchrelevance/ml/MLAccessorIntegrationTests.java
+++ b/src/test/java/org/opensearch/searchrelevance/ml/MLAccessorIntegrationTests.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/test/java/org/opensearch/searchrelevance/ml/MLAccessorTests.java
+++ b/src/test/java/org/opensearch/searchrelevance/ml/MLAccessorTests.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/test/java/org/opensearch/searchrelevance/ml/MLInputOutputTransformerTests.java
+++ b/src/test/java/org/opensearch/searchrelevance/ml/MLInputOutputTransformerTests.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/test/java/org/opensearch/searchrelevance/ml/TokenizerUtilTests.java
+++ b/src/test/java/org/opensearch/searchrelevance/ml/TokenizerUtilTests.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/test/java/org/opensearch/searchrelevance/ml/UserPromptFactoryTests.java
+++ b/src/test/java/org/opensearch/searchrelevance/ml/UserPromptFactoryTests.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/test/java/org/opensearch/searchrelevance/model/ExperimentBatchStatusTests.java
+++ b/src/test/java/org/opensearch/searchrelevance/model/ExperimentBatchStatusTests.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/test/java/org/opensearch/searchrelevance/model/ExperimentDocumentParserTests.java
+++ b/src/test/java/org/opensearch/searchrelevance/model/ExperimentDocumentParserTests.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/test/java/org/opensearch/searchrelevance/model/ExperimentTests.java
+++ b/src/test/java/org/opensearch/searchrelevance/model/ExperimentTests.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/test/java/org/opensearch/searchrelevance/model/ExperimentVariantTests.java
+++ b/src/test/java/org/opensearch/searchrelevance/model/ExperimentVariantTests.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/test/java/org/opensearch/searchrelevance/model/JudgmentTests.java
+++ b/src/test/java/org/opensearch/searchrelevance/model/JudgmentTests.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/test/java/org/opensearch/searchrelevance/model/QuerySetEntryTests.java
+++ b/src/test/java/org/opensearch/searchrelevance/model/QuerySetEntryTests.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/test/java/org/opensearch/searchrelevance/model/builder/MustacheTemplateRenderTests.java
+++ b/src/test/java/org/opensearch/searchrelevance/model/builder/MustacheTemplateRenderTests.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/test/java/org/opensearch/searchrelevance/model/builder/SearchRequestBuilderTests.java
+++ b/src/test/java/org/opensearch/searchrelevance/model/builder/SearchRequestBuilderTests.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/test/java/org/opensearch/searchrelevance/plugin/SearchRelevancePluginIT.java
+++ b/src/test/java/org/opensearch/searchrelevance/plugin/SearchRelevancePluginIT.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/test/java/org/opensearch/searchrelevance/plugin/SearchRelevancePluginTests.java
+++ b/src/test/java/org/opensearch/searchrelevance/plugin/SearchRelevancePluginTests.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/test/java/org/opensearch/searchrelevance/plugin/SearchRelevanceRestTestCase.java
+++ b/src/test/java/org/opensearch/searchrelevance/plugin/SearchRelevanceRestTestCase.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/test/java/org/opensearch/searchrelevance/rest/RestCreateQuerySetActionTests.java
+++ b/src/test/java/org/opensearch/searchrelevance/rest/RestCreateQuerySetActionTests.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/test/java/org/opensearch/searchrelevance/rest/RestDeleteQuerySetActionTests.java
+++ b/src/test/java/org/opensearch/searchrelevance/rest/RestDeleteQuerySetActionTests.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/test/java/org/opensearch/searchrelevance/rest/RestDeleteScheduledExperimentActionTests.java
+++ b/src/test/java/org/opensearch/searchrelevance/rest/RestDeleteScheduledExperimentActionTests.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/test/java/org/opensearch/searchrelevance/rest/RestDeleteSearchConfigurationActionTests.java
+++ b/src/test/java/org/opensearch/searchrelevance/rest/RestDeleteSearchConfigurationActionTests.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/test/java/org/opensearch/searchrelevance/rest/RestGetJudgmentActionTests.java
+++ b/src/test/java/org/opensearch/searchrelevance/rest/RestGetJudgmentActionTests.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/test/java/org/opensearch/searchrelevance/rest/RestGetQuerySetActionTests.java
+++ b/src/test/java/org/opensearch/searchrelevance/rest/RestGetQuerySetActionTests.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/test/java/org/opensearch/searchrelevance/rest/RestGetScheduledExperimentActionTests.java
+++ b/src/test/java/org/opensearch/searchrelevance/rest/RestGetScheduledExperimentActionTests.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/test/java/org/opensearch/searchrelevance/rest/RestGetSearchConfigurationActionTests.java
+++ b/src/test/java/org/opensearch/searchrelevance/rest/RestGetSearchConfigurationActionTests.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/test/java/org/opensearch/searchrelevance/rest/RestPatchExperimentActionTests.java
+++ b/src/test/java/org/opensearch/searchrelevance/rest/RestPatchExperimentActionTests.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/test/java/org/opensearch/searchrelevance/rest/RestPostScheduledExperimentActionTests.java
+++ b/src/test/java/org/opensearch/searchrelevance/rest/RestPostScheduledExperimentActionTests.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/test/java/org/opensearch/searchrelevance/rest/RestPutExperimentActionTests.java
+++ b/src/test/java/org/opensearch/searchrelevance/rest/RestPutExperimentActionTests.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/test/java/org/opensearch/searchrelevance/rest/RestPutJudgmentActionTests.java
+++ b/src/test/java/org/opensearch/searchrelevance/rest/RestPutJudgmentActionTests.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/test/java/org/opensearch/searchrelevance/rest/RestPutQuerySetActionTests.java
+++ b/src/test/java/org/opensearch/searchrelevance/rest/RestPutQuerySetActionTests.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/test/java/org/opensearch/searchrelevance/rest/RestPutSearchConfigurationActionTests.java
+++ b/src/test/java/org/opensearch/searchrelevance/rest/RestPutSearchConfigurationActionTests.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/test/java/org/opensearch/searchrelevance/rest/RestSearchExperimentActionTests.java
+++ b/src/test/java/org/opensearch/searchrelevance/rest/RestSearchExperimentActionTests.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/test/java/org/opensearch/searchrelevance/rest/RestSearchJudgmentActionTests.java
+++ b/src/test/java/org/opensearch/searchrelevance/rest/RestSearchJudgmentActionTests.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/test/java/org/opensearch/searchrelevance/rest/RestSearchQuerySetActionTests.java
+++ b/src/test/java/org/opensearch/searchrelevance/rest/RestSearchQuerySetActionTests.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/test/java/org/opensearch/searchrelevance/rest/RestSearchRelevanceStatsActionTests.java
+++ b/src/test/java/org/opensearch/searchrelevance/rest/RestSearchRelevanceStatsActionTests.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/test/java/org/opensearch/searchrelevance/rest/RestSearchSearchConfigurationActionTests.java
+++ b/src/test/java/org/opensearch/searchrelevance/rest/RestSearchSearchConfigurationActionTests.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/test/java/org/opensearch/searchrelevance/scheduler/ExperimentCancellationTokenTests.java
+++ b/src/test/java/org/opensearch/searchrelevance/scheduler/ExperimentCancellationTokenTests.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/test/java/org/opensearch/searchrelevance/scheduler/ScheduledExperimentRunnerManagerTests.java
+++ b/src/test/java/org/opensearch/searchrelevance/scheduler/ScheduledExperimentRunnerManagerTests.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/test/java/org/opensearch/searchrelevance/scheduler/SearchRelevanceJobRunnerTests.java
+++ b/src/test/java/org/opensearch/searchrelevance/scheduler/SearchRelevanceJobRunnerTests.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/test/java/org/opensearch/searchrelevance/stats/SearchRelevanceStatsInputTests.java
+++ b/src/test/java/org/opensearch/searchrelevance/stats/SearchRelevanceStatsInputTests.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/test/java/org/opensearch/searchrelevance/stats/events/EventStatNameTests.java
+++ b/src/test/java/org/opensearch/searchrelevance/stats/events/EventStatNameTests.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/test/java/org/opensearch/searchrelevance/stats/events/EventStatsManagerTests.java
+++ b/src/test/java/org/opensearch/searchrelevance/stats/events/EventStatsManagerTests.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/test/java/org/opensearch/searchrelevance/stats/events/TimestampedEventStatSnapshotTests.java
+++ b/src/test/java/org/opensearch/searchrelevance/stats/events/TimestampedEventStatSnapshotTests.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/test/java/org/opensearch/searchrelevance/stats/events/TimestampedEventStatTests.java
+++ b/src/test/java/org/opensearch/searchrelevance/stats/events/TimestampedEventStatTests.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/test/java/org/opensearch/searchrelevance/stats/info/CountableInfoStatSnapshotTests.java
+++ b/src/test/java/org/opensearch/searchrelevance/stats/info/CountableInfoStatSnapshotTests.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/test/java/org/opensearch/searchrelevance/stats/info/InfoStatNameTests.java
+++ b/src/test/java/org/opensearch/searchrelevance/stats/info/InfoStatNameTests.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/test/java/org/opensearch/searchrelevance/stats/info/InfoStatsManagerTests.java
+++ b/src/test/java/org/opensearch/searchrelevance/stats/info/InfoStatsManagerTests.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/test/java/org/opensearch/searchrelevance/stats/info/SettableInfoStatSnapshotTests.java
+++ b/src/test/java/org/opensearch/searchrelevance/stats/info/SettableInfoStatSnapshotTests.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/test/java/org/opensearch/searchrelevance/transport/experiment/DeleteExperimentTransportActionTests.java
+++ b/src/test/java/org/opensearch/searchrelevance/transport/experiment/DeleteExperimentTransportActionTests.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/test/java/org/opensearch/searchrelevance/transport/experiment/PatchExperimentTransportActionTests.java
+++ b/src/test/java/org/opensearch/searchrelevance/transport/experiment/PatchExperimentTransportActionTests.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/test/java/org/opensearch/searchrelevance/transport/experiment/PutExperimentRequestSerializationTests.java
+++ b/src/test/java/org/opensearch/searchrelevance/transport/experiment/PutExperimentRequestSerializationTests.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/test/java/org/opensearch/searchrelevance/transport/experiment/PutExperimentTransportActionTests.java
+++ b/src/test/java/org/opensearch/searchrelevance/transport/experiment/PutExperimentTransportActionTests.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/test/java/org/opensearch/searchrelevance/transport/experiment/SearchExperimentTransportActionTests.java
+++ b/src/test/java/org/opensearch/searchrelevance/transport/experiment/SearchExperimentTransportActionTests.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/test/java/org/opensearch/searchrelevance/transport/experiment/ValidateExperimentTransportActionTests.java
+++ b/src/test/java/org/opensearch/searchrelevance/transport/experiment/ValidateExperimentTransportActionTests.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/test/java/org/opensearch/searchrelevance/transport/judgment/DeleteJudgmentTransportActionTests.java
+++ b/src/test/java/org/opensearch/searchrelevance/transport/judgment/DeleteJudgmentTransportActionTests.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/test/java/org/opensearch/searchrelevance/transport/judgment/PutJudgmentTransportActionTests.java
+++ b/src/test/java/org/opensearch/searchrelevance/transport/judgment/PutJudgmentTransportActionTests.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/test/java/org/opensearch/searchrelevance/transport/judgment/RetryFailedJudgmentTransportActionTests.java
+++ b/src/test/java/org/opensearch/searchrelevance/transport/judgment/RetryFailedJudgmentTransportActionTests.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/test/java/org/opensearch/searchrelevance/transport/judgment/SearchJudgmentTransportActionTests.java
+++ b/src/test/java/org/opensearch/searchrelevance/transport/judgment/SearchJudgmentTransportActionTests.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/test/java/org/opensearch/searchrelevance/transport/judgment/UpdateJudgmentRatingsTransportActionTests.java
+++ b/src/test/java/org/opensearch/searchrelevance/transport/judgment/UpdateJudgmentRatingsTransportActionTests.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/test/java/org/opensearch/searchrelevance/transport/queryset/DeleteQuerySetTransportActionTests.java
+++ b/src/test/java/org/opensearch/searchrelevance/transport/queryset/DeleteQuerySetTransportActionTests.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/test/java/org/opensearch/searchrelevance/transport/queryset/SearchQuerySetTransportActionTests.java
+++ b/src/test/java/org/opensearch/searchrelevance/transport/queryset/SearchQuerySetTransportActionTests.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/test/java/org/opensearch/searchrelevance/transport/searchConfiguration/DeleteSearchConfigurationTransportActionTests.java
+++ b/src/test/java/org/opensearch/searchrelevance/transport/searchConfiguration/DeleteSearchConfigurationTransportActionTests.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/test/java/org/opensearch/searchrelevance/transport/searchConfiguration/PutSearchConfigurationTransportActionTests.java
+++ b/src/test/java/org/opensearch/searchrelevance/transport/searchConfiguration/PutSearchConfigurationTransportActionTests.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/test/java/org/opensearch/searchrelevance/transport/searchConfiguration/SearchSearchConfigurationTransportActionTests.java
+++ b/src/test/java/org/opensearch/searchrelevance/transport/searchConfiguration/SearchSearchConfigurationTransportActionTests.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/test/java/org/opensearch/searchrelevance/transport/stats/SearchRelevanceStatsResponseTests.java
+++ b/src/test/java/org/opensearch/searchrelevance/transport/stats/SearchRelevanceStatsResponseTests.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/test/java/org/opensearch/searchrelevance/transport/stats/SearchRelevanceStatsTransportActionTests.java
+++ b/src/test/java/org/opensearch/searchrelevance/transport/stats/SearchRelevanceStatsTransportActionTests.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/test/java/org/opensearch/searchrelevance/ubi/UbiValidatorTests.java
+++ b/src/test/java/org/opensearch/searchrelevance/ubi/UbiValidatorTests.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/test/java/org/opensearch/searchrelevance/util/TestUtils.java
+++ b/src/test/java/org/opensearch/searchrelevance/util/TestUtils.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/test/java/org/opensearch/searchrelevance/util/TextValidationUtilTests.java
+++ b/src/test/java/org/opensearch/searchrelevance/util/TextValidationUtilTests.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/test/java/org/opensearch/searchrelevance/utils/ParserUtilsTests.java
+++ b/src/test/java/org/opensearch/searchrelevance/utils/ParserUtilsTests.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/test/java/org/opensearch/searchrelevance/utils/RatingOutputProcessorTests.java
+++ b/src/test/java/org/opensearch/searchrelevance/utils/RatingOutputProcessorTests.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to

--- a/src/test/scripts/create_judgments_with_manual_input.sh
+++ b/src/test/scripts/create_judgments_with_manual_input.sh
@@ -1,3 +1,6 @@
+# Copyright OpenSearch Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 curl -s -X PUT "localhost:9200/_plugins/_search_relevance/judgments" \
 -H "Content-type: application/json" \
 -d'{

--- a/src/test/scripts/create_pairwise_experiment.sh
+++ b/src/test/scripts/create_pairwise_experiment.sh
@@ -1,3 +1,6 @@
+# Copyright OpenSearch Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 curl -s -X PUT "localhost:9200/_plugins/_search_relevance/experiments" \
 -H "Content-type: application/json" \
 -d'{

--- a/src/test/scripts/create_pointwise_experiment.sh
+++ b/src/test/scripts/create_pointwise_experiment.sh
@@ -1,3 +1,6 @@
+# Copyright OpenSearch Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 query_set_id=9ac2d25a-d4df-444d-8008-9aeadfe70927
 search_configuration_id=161c9023-bb0e-44c9-b347-3aa5a1bf66af
 judgement_list_id=c0343cd1-2dca-43b0-9ebf-7a927d21ef4b

--- a/src/test/scripts/create_query_set_with_manual_input.sh
+++ b/src/test/scripts/create_query_set_with_manual_input.sh
@@ -1,3 +1,6 @@
+# Copyright OpenSearch Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 curl -s -X PUT "localhost:9200/_plugins/_search_relevance/query_sets" \
 -H "Content-type: application/json" \
 -d'{

--- a/src/test/scripts/create_query_set_with_sampling.sh
+++ b/src/test/scripts/create_query_set_with_sampling.sh
@@ -1,3 +1,6 @@
+# Copyright OpenSearch Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 curl -s -X POST "localhost:9200/_plugins/_search_relevance/query_sets" \
 -H "Content-type: application/json" \
 -d'{

--- a/src/test/scripts/create_sample_index_docs.sh
+++ b/src/test/scripts/create_sample_index_docs.sh
@@ -1,3 +1,6 @@
+# Copyright OpenSearch Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 curl -s -X POST "http://localhost:9200/sample_index/_doc/1" \
 -H "Content-type: application/json" \
 -d'{

--- a/src/test/scripts/create_search_config_baseline.sh
+++ b/src/test/scripts/create_search_config_baseline.sh
@@ -1,3 +1,6 @@
+# Copyright OpenSearch Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 curl -s -X PUT "http://localhost:9200/_plugins/_search_relevance/search_configurations" \
 -H "Content-type: application/json" \
 -d'{

--- a/src/test/scripts/create_search_config_hybrid_search.sh
+++ b/src/test/scripts/create_search_config_hybrid_search.sh
@@ -1,3 +1,6 @@
+# Copyright OpenSearch Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 curl -s -X PUT "http://localhost:9200/_plugins/_search_relevance/search_configurations" \
 -H "Content-type: application/json" \
 -d'{

--- a/src/test/scripts/demo.sh
+++ b/src/test/scripts/demo.sh
@@ -1,5 +1,8 @@
 #!/bin/sh
 
+# Copyright OpenSearch Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 # This script quickly sets up a local Search Relevance Workbench from scratch with:
 # * User Behavior Insights sample data
 # * An "ecommerce" style sample data

--- a/src/test/scripts/demo_hybrid_optimizer.sh
+++ b/src/test/scripts/demo_hybrid_optimizer.sh
@@ -1,5 +1,8 @@
 #!/bin/bash -e
 
+# Copyright OpenSearch Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 # This script quickly sets up a local Search Relevance Workbench from scratch with:
 # * An "ecommerce" style sample data
 # You can now exercise all the capabilities of Hybrid Optimizer!

--- a/src/test/scripts/get_experiment.sh
+++ b/src/test/scripts/get_experiment.sh
@@ -1,1 +1,4 @@
+# Copyright OpenSearch Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 curl -s -X GET "localhost:9200/_plugins/_search_relevance/experiments/{id}"

--- a/src/test/scripts/list_query_set.sh
+++ b/src/test/scripts/list_query_set.sh
@@ -1,3 +1,6 @@
+# Copyright OpenSearch Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 curl -s -X GET "localhost:9200/_plugins/_search_relevance/query_sets" \
 -H "Content-type: application/json" \
 -d'{

--- a/src/test/scripts/list_search_configuration.sh
+++ b/src/test/scripts/list_search_configuration.sh
@@ -1,3 +1,6 @@
+# Copyright OpenSearch Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 curl -s -X GET "http://localhost:9200/_plugins/_search_relevance/search_configurations" \
 -H "Content-type: application/json" \
 -d'{

--- a/src/test/scripts/search_for_experiment.sh
+++ b/src/test/scripts/search_for_experiment.sh
@@ -1,3 +1,6 @@
+# Copyright OpenSearch Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 # Search for experiments by ID
 curl -X POST "localhost:9200/_plugins/_search_relevance/experiments/_search" \
   -H "Content-Type: application/json" \

--- a/src/test/scripts/search_for_judgment.sh
+++ b/src/test/scripts/search_for_judgment.sh
@@ -1,3 +1,6 @@
+# Copyright OpenSearch Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 # Search for judgments by ID
 curl -X POST "localhost:9200/_plugins/_search_relevance/judgments/_search" \
   -H "Content-Type: application/json" \

--- a/src/test/scripts/search_for_query_set.sh
+++ b/src/test/scripts/search_for_query_set.sh
@@ -1,3 +1,6 @@
+# Copyright OpenSearch Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 # Exact match on a name.
 curl -X POST "localhost:9200/_plugins/_search_relevance/query_sets/_search" \
   -H "Content-Type: application/json" \

--- a/src/test/scripts/search_for_search_configuration.sh
+++ b/src/test/scripts/search_for_search_configuration.sh
@@ -1,3 +1,6 @@
+# Copyright OpenSearch Contributors
+# SPDX-License-Identifier: Apache-2.0
+
 # Search for search configurations by ID
 curl -X POST "localhost:9200/_plugins/_search_relevance/search_configurations/_search" \
   -H "Content-Type: application/json" \

--- a/src/yamlRestTest/java/org/opensearch/searchrelevance/plugin/SearchRelevanceClientYamlTestSuiteIT.java
+++ b/src/yamlRestTest/java/org/opensearch/searchrelevance/plugin/SearchRelevanceClientYamlTestSuiteIT.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright OpenSearch Contributors
  * SPDX-License-Identifier: Apache-2.0
  *
  * The OpenSearch Contributors require contributions made to


### PR DESCRIPTION
### Description
Add SPDX license header validation to PR/push workflows using `@kt3k/license-checker`.

**Changes:**
  - Add `.github/workflows/license-header-checker.yml` 
  - Add `.licenserc.json` 
  - Add missing `SPDX-License-Identifier: Apache-2.0` headers to source files
  
### Related Issues
 [#6445](https://github.com/opensearch-project/opensearch-build/issues/6445)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
